### PR TITLE
ci: narrow windows release asset glob patterns

### DIFF
--- a/.github/workflows/build-desktop-tauri.yml
+++ b/.github/workflows/build-desktop-tauri.yml
@@ -25,9 +25,6 @@ permissions:
 env:
   ASTRBOT_SOURCE_GIT_URL: ${{ vars.ASTRBOT_SOURCE_GIT_URL || 'https://github.com/AstrBotDevs/AstrBot.git' }}
   ASTRBOT_SOURCE_GIT_REF: ${{ vars.ASTRBOT_SOURCE_GIT_REF || 'master' }}
-  WINDOWS_INSTALLER_EXE_GLOBS: |
-    src-tauri/target/release/bundle/nsis/*.exe
-    src-tauri/target/release/bundle/nsis-web/*.exe
 
 jobs:
   resolve_build_context:
@@ -130,6 +127,10 @@ jobs:
     if: ${{ needs.resolve_build_context.outputs.should_build == 'true' }}
     name: ${{ matrix.os_name }}-${{ matrix.arch }}
     runs-on: ${{ matrix.runner }}
+    env:
+      WINDOWS_INSTALLER_EXE_GLOBS: |
+        src-tauri/target/release/bundle/nsis/*.exe
+        src-tauri/target/release/bundle/nsis-web/*.exe
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- narrow Windows release artifact glob patterns in CI
- upload only installer executables from `bundle/nsis` and `bundle/nsis-web`
- avoid accidentally uploading bundled Python runtime executables (for example `distlib/w64.exe`), which caused release asset conflicts

## Why
- previous pattern `src-tauri/target/release/bundle/**/*.exe` matched unrelated internal files
- repeated filenames triggered release upload failures during `softprops/action-gh-release`

## Changes
- `.github/workflows/build-desktop-tauri.yml`
  - replace broad exe glob with:
    - `src-tauri/target/release/bundle/nsis/*.exe`
    - `src-tauri/target/release/bundle/nsis-web/*.exe`

## Summary by Sourcery

CI:
- 在桌面端 Tauri 的 GitHub Actions 工作流中收紧 Windows `.exe` 的通配符匹配模式，仅包含来自 `nsis` 和 `nsis-web` 打包生成的安装程序二进制文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Tighten Windows .exe glob patterns in the desktop Tauri GitHub Actions workflow to only include installer binaries from nsis and nsis-web bundles.

</details>
- 将 Windows 发布资产的通配符模式收紧为仅包含来自 nsis 和 nsis-web bundle 的安装程序可执行文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- 在桌面端 Tauri 的 GitHub Actions 工作流中收紧 Windows `.exe` 的通配符匹配模式，仅包含来自 `nsis` 和 `nsis-web` 打包生成的安装程序二进制文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Tighten Windows .exe glob patterns in the desktop Tauri GitHub Actions workflow to only include installer binaries from nsis and nsis-web bundles.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- 在桌面端 Tauri 的 GitHub Actions 工作流中收紧 Windows `.exe` 的通配符匹配模式，仅包含来自 `nsis` 和 `nsis-web` 打包生成的安装程序二进制文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Tighten Windows .exe glob patterns in the desktop Tauri GitHub Actions workflow to only include installer binaries from nsis and nsis-web bundles.

</details>
- 将 Windows 发布资产的通配符模式收紧为仅包含来自 nsis 和 nsis-web bundle 的安装程序可执行文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- 在桌面端 Tauri 的 GitHub Actions 工作流中收紧 Windows `.exe` 的通配符匹配模式，仅包含来自 `nsis` 和 `nsis-web` 打包生成的安装程序二进制文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Tighten Windows .exe glob patterns in the desktop Tauri GitHub Actions workflow to only include installer binaries from nsis and nsis-web bundles.

</details>

</details>

</details>