### PR TITLE
refactor: switch desktop bridge naming and runtime env

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -386,7 +386,7 @@ impl BackendState {
         }
 
         if plan.packaged_mode {
-            command.env("ASTRBOT_ELECTRON_CLIENT", "1");
+            command.env("ASTRBOT_DESKTOP_CLIENT", "1");
             if env::var("DASHBOARD_HOST").is_err() && env::var("ASTRBOT_DASHBOARD_HOST").is_err() {
                 command.env("DASHBOARD_HOST", "127.0.0.1");
             }
@@ -950,7 +950,7 @@ Content-Length: {}\r\n\
 }
 
 #[tauri::command]
-fn desktop_bridge_is_electron_runtime() -> bool {
+fn desktop_bridge_is_desktop_runtime() -> bool {
     true
 }
 
@@ -1038,7 +1038,7 @@ fn main() {
     tauri::Builder::default()
         .manage(BackendState::default())
         .invoke_handler(tauri::generate_handler![
-            desktop_bridge_is_electron_runtime,
+            desktop_bridge_is_desktop_runtime,
             desktop_bridge_get_backend_state,
             desktop_bridge_set_auth_token,
             desktop_bridge_restart_backend,
@@ -1602,8 +1602,8 @@ const DESKTOP_BRIDGE_BOOTSTRAP_SCRIPT: &str = r#"
 
   window.astrbotDesktop = {
     __tauriBridge: true,
-    isElectron: true,
-    isElectronRuntime: () => Promise.resolve(true),
+    isDesktop: true,
+    isDesktopRuntime: () => Promise.resolve(true),
     getBackendState: () => invokeBridge('desktop_bridge_get_backend_state'),
     restartBackend: async (authToken = null) => {
       const normalizedToken =


### PR DESCRIPTION
## Summary
  - switch packaged runtime marker to `ASTRBOT_DESKTOP_CLIENT=1`
  - rename runtime bridge command to `desktop_bridge_is_desktop_runtime`
  - expose `isDesktop` and `isDesktopRuntime` in injected desktop bridge
  - remove electron wording from the desktop-side runtime bridge surface

## Testing
  - cargo fmt --manifest-path src-tauri/Cargo.toml --all
  - cargo clippy --manifest-path src-tauri/Cargo.toml --locked --all-targets
  -- -D warnings

## Summary by Sourcery

在 Tauri 桌面应用中标准化桌面运行时的识别方式以及 bridge API 的命名。

增强内容：
- 重命名桌面运行时的环境变量标记，使其使用与具体桌面技术无关的名称。
- 重命名桌面 bridge 运行时检查命令，使其使用与具体桌面技术无关的名称，并将其接入 Tauri 的命令处理器。
- 调整注入的桌面 bridge 对象，使其暴露的是通用的桌面运行时标志，而不是特定于 Electron 的标志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize desktop runtime identification and bridge API naming across the Tauri desktop app.

Enhancements:
- Rename the desktop runtime environment variable marker to use a desktop-agnostic name.
- Rename the desktop bridge runtime check command to a desktop-agnostic name and wire it into the Tauri command handler.
- Adjust the injected desktop bridge object to expose generic desktop runtime flags instead of Electron-specific ones.

</details>