### PR TITLE
fix: restore desktop bridge compatibility and harden installer checks

### DIFF
--- a/.github/workflows/build-desktop-tauri.yml
+++ b/.github/workflows/build-desktop-tauri.yml
@@ -210,6 +210,23 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: pnpm run build
 
+      - name: Verify macOS DMG integrity
+        if: startsWith(matrix.runner, 'macos')
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          dmg_files=(src-tauri/target/release/bundle/dmg/*.dmg)
+          if [ "${#dmg_files[@]}" -eq 0 ]; then
+            echo "No DMG files found under src-tauri/target/release/bundle/dmg"
+            exit 1
+          fi
+
+          for dmg in "${dmg_files[@]}"; do
+            echo "Verifying ${dmg}"
+            hdiutil verify "${dmg}"
+          done
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v6.0.0
         with:

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -955,6 +955,11 @@ fn desktop_bridge_is_desktop_runtime() -> bool {
 }
 
 #[tauri::command]
+fn desktop_bridge_is_electron_runtime() -> bool {
+    desktop_bridge_is_desktop_runtime()
+}
+
+#[tauri::command]
 fn desktop_bridge_get_backend_state(app_handle: AppHandle) -> BackendBridgeState {
     let state = app_handle.state::<BackendState>();
     state.bridge_state(&app_handle)
@@ -1039,6 +1044,7 @@ fn main() {
         .manage(BackendState::default())
         .invoke_handler(tauri::generate_handler![
             desktop_bridge_is_desktop_runtime,
+            desktop_bridge_is_electron_runtime,
             desktop_bridge_get_backend_state,
             desktop_bridge_set_auth_token,
             desktop_bridge_restart_backend,
@@ -1604,6 +1610,9 @@ const DESKTOP_BRIDGE_BOOTSTRAP_SCRIPT: &str = r#"
     __tauriBridge: true,
     isDesktop: true,
     isDesktopRuntime: () => Promise.resolve(true),
+    // Legacy aliases for current dashboard compatibility.
+    isElectron: true,
+    isElectronRuntime: () => Promise.resolve(true),
     getBackendState: () => invokeBridge('desktop_bridge_get_backend_state'),
     restartBackend: async (authToken = null) => {
       const normalizedToken =

--- a/src-tauri/windows/nsis-installer-hooks.nsh
+++ b/src-tauri/windows/nsis-installer-hooks.nsh
@@ -12,6 +12,20 @@
   DetailPrint "Skip backend process cleanup: script not found: $1"
 !macroend
 
+!macro NSIS_HOOK_POSTINSTALL
+  ; Recreate shortcuts to avoid stale links when users migrate from older installers.
+  StrCpy $0 "$INSTDIR\${MAINBINARYNAME}.exe"
+  IfFileExists "$0" +2 0
+    Goto +9
+
+  Delete "$DESKTOP\${PRODUCTNAME}.lnk"
+  CreateShortCut "$DESKTOP\${PRODUCTNAME}.lnk" "$0"
+
+  CreateDirectory "$SMPROGRAMS\${PRODUCTNAME}"
+  Delete "$SMPROGRAMS\${PRODUCTNAME}\${PRODUCTNAME}.lnk"
+  CreateShortCut "$SMPROGRAMS\${PRODUCTNAME}\${PRODUCTNAME}.lnk" "$0"
+!macroend
+
 !macro NSIS_HOOK_POSTUNINSTALL
   ; Keep behavior aligned with NSIS checkbox: only remove user data when user asked for it.
   ${If} $DeleteAppDataCheckboxState = 1


### PR DESCRIPTION
## Summary by Sourcery

在增强 macOS 和 Windows 安装程序行为安全性的同时，恢复对 Desktop Bridge 的兼容性。

新功能：
- 提供一个 desktop bridge 命令以及相应的 bridge 脚本别名，用于为仪表盘报告 Electron 运行时兼容性。

错误修复：
- 在 NSIS 安装后阶段重新创建 Windows 桌面和开始菜单快捷方式，以避免从旧版安装程序迁移时出现失效的快捷链接。

改进：
- 在桌面端 Tauri 构建流程中新增 macOS DMG 完整性校验步骤，以尽早发现无效的安装程序制品。

CI：
- 扩展桌面端 Tauri 的 GitHub Actions 工作流，在上传制品之前使用 `hdiutil` 校验生成的 macOS DMG 文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore desktop bridge compatibility while hardening macOS and Windows installer behavior.

New Features:
- Expose a desktop bridge command and bridge script aliases to report Electron runtime compatibility for the dashboard.

Bug Fixes:
- Recreate Windows desktop and start menu shortcuts during NSIS post-install to avoid stale links when migrating from older installers.

Enhancements:
- Add a macOS DMG integrity verification step to the desktop Tauri build workflow to catch invalid installer artifacts early.

CI:
- Extend the desktop Tauri GitHub Actions workflow to verify generated macOS DMG files with hdiutil before uploading artifacts.

</details>