### PR TITLE
  chore: revert GitHub Actions runners to defaults

### DIFF
--- a/.github/workflows/build-desktop-tauri.yml
+++ b/.github/workflows/build-desktop-tauri.yml
@@ -267,28 +267,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          python3 - << 'PY'
-          import os
-          import sys
-          from collections import defaultdict
-
-          root = "release-artifacts"
-          by_name = defaultdict(list)
-          for dirpath, _, filenames in os.walk(root):
-            for filename in filenames:
-              by_name[filename].append(os.path.join(dirpath, filename))
-
-          duplicates = {name: paths for name, paths in by_name.items() if len(paths) > 1}
-          if duplicates:
-            print("Duplicate artifact filenames detected after merge:", file=sys.stderr)
-            for name, paths in sorted(duplicates.items()):
-              print(f"- {name}", file=sys.stderr)
-              for path in sorted(paths):
-                print(f"  - {path}", file=sys.stderr)
-            sys.exit(1)
-
-          print("No duplicate artifact filenames detected.")
-          PY
+          python3 scripts/ci/validate-release-artifacts.py release-artifacts
 
       - name: Create or update release
         uses: softprops/action-gh-release@v2.5.0

--- a/scripts/ci/validate-release-artifacts.py
+++ b/scripts/ci/validate-release-artifacts.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import pathlib
+import sys
+from collections import defaultdict
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("Usage: validate-release-artifacts.py <release-artifacts-dir>", file=sys.stderr)
+        return 2
+
+    root = pathlib.Path(sys.argv[1])
+    if not root.exists():
+        print(f"Artifacts directory not found: {root}", file=sys.stderr)
+        return 1
+    if not root.is_dir():
+        print(f"Artifacts path is not a directory: {root}", file=sys.stderr)
+        return 1
+
+    by_name: dict[str, list[pathlib.Path]] = defaultdict(list)
+    for path in root.rglob("*"):
+        if path.is_file():
+            by_name[path.name].append(path)
+
+    duplicates = {name: paths for name, paths in by_name.items() if len(paths) > 1}
+    if duplicates:
+        print("Duplicate artifact filenames detected after merge:", file=sys.stderr)
+        for name, paths in sorted(duplicates.items()):
+            print(f"- {name}", file=sys.stderr)
+            for path in sorted(paths):
+                print(f"  - {path}", file=sys.stderr)
+        return 1
+
+    print("No duplicate artifact filenames detected.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary by Sourcery

CI：
- 在 GitHub Actions 工作流中新增一个步骤：如果在发布制品目录中检测到重复的制品文件名，则使构建失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Add a GitHub Actions workflow step to fail the build if duplicate artifact filenames are detected in the release artifacts directory.

</details>