### PR TITLE
ci: retry flaky macOS dmg bundling on detach timeout

### DIFF
--- a/.github/workflows/build-desktop-tauri.yml
+++ b/.github/workflows/build-desktop-tauri.yml
@@ -208,27 +208,33 @@ jobs:
 
           max_attempts=2
           attempt=1
-          # Match on stable error fragments so minor upstream wording changes do not disable retries.
-          retry_pattern='bundle_dmg|hdiutil: detach:.*timeout|hdiutil: detach:.*not detached|failed to bundle project'
+          # Only retry on known transient DMG detach failures.
+          retry_pattern='hdiutil: detach:.*(timeout|not detached)|DiskArbitration expired'
+          log_file=""
+
+          cleanup_log_file() {
+            if [ -n "${log_file:-}" ]; then
+              rm -f "${log_file}" || true
+              log_file=""
+            fi
+          }
+          trap cleanup_log_file EXIT
 
           while [ "${attempt}" -le "${max_attempts}" ]; do
             log_file="$(mktemp -t tauri-macos-build.XXXXXX.log)"
             echo "macOS build attempt ${attempt}/${max_attempts} (arch=${{ matrix.arch }}, target=${{ matrix.target }})"
 
             if cargo tauri build --verbose --target ${{ matrix.target }} 2>&1 | tee "${log_file}"; then
-              rm -f "${log_file}"
               exit 0
             fi
 
             if [ "${attempt}" -ge "${max_attempts}" ]; then
               echo "macOS build failed after ${max_attempts} attempts."
-              rm -f "${log_file}"
               exit 1
             fi
 
             if ! grep -Eq "${retry_pattern}" "${log_file}"; then
               echo "macOS build failed with a non-retryable error. Skip retry."
-              rm -f "${log_file}"
               exit 1
             fi
 
@@ -256,7 +262,7 @@ jobs:
               fi
             fi
             rm -f src-tauri/target/${{ matrix.target }}/release/bundle/macos/rw.*.dmg || true
-            rm -f "${log_file}"
+            cleanup_log_file
 
             attempt=$((attempt + 1))
             sleep 5


### PR DESCRIPTION
## Summary by Sourcery

CI:
- 在 GitHub Actions 工作流中，将 macOS 的 Tauri 构建步骤包裹在一个 bash 脚本中，以通过一次受控的重试来处理不稳定的 DMG 卸载超时问题，并清理遗留的挂载和构建产物。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Wrap the macOS Tauri build step in a bash script in the GitHub Actions workflow to handle flaky DMG detach timeouts with a single guarded retry and cleanup of stale mounts and artifacts.

</details>
- 将 macOS Tauri 构建步骤封装到一个 bash 脚本中，当出现已知的临时性 DMG 卸载/打包错误时，在清理过期挂载点和构建产物后重试一次。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- 在 GitHub Actions 工作流中，将 macOS 的 Tauri 构建步骤包裹在一个 bash 脚本中，以通过一次受控的重试来处理不稳定的 DMG 卸载超时问题，并清理遗留的挂载和构建产物。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Wrap the macOS Tauri build step in a bash script in the GitHub Actions workflow to handle flaky DMG detach timeouts with a single guarded retry and cleanup of stale mounts and artifacts.

</details>

</details>
- 将 macOS Tauri 构建命令包装到一个 bash 脚本中，当遇到已知的临时性 DMG 卸载/打包错误时会重试一次，并在重试前清理过期的挂载点和构建产物。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- 在 GitHub Actions 工作流中，将 macOS 的 Tauri 构建步骤包裹在一个 bash 脚本中，以通过一次受控的重试来处理不稳定的 DMG 卸载超时问题，并清理遗留的挂载和构建产物。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Wrap the macOS Tauri build step in a bash script in the GitHub Actions workflow to handle flaky DMG detach timeouts with a single guarded retry and cleanup of stale mounts and artifacts.

</details>
- 将 macOS Tauri 构建步骤封装到一个 bash 脚本中，当出现已知的临时性 DMG 卸载/打包错误时，在清理过期挂载点和构建产物后重试一次。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- 在 GitHub Actions 工作流中，将 macOS 的 Tauri 构建步骤包裹在一个 bash 脚本中，以通过一次受控的重试来处理不稳定的 DMG 卸载超时问题，并清理遗留的挂载和构建产物。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Wrap the macOS Tauri build step in a bash script in the GitHub Actions workflow to handle flaky DMG detach timeouts with a single guarded retry and cleanup of stale mounts and artifacts.

</details>

</details>

</details>