### PR TITLE
fix(ci+desktop): stabilize tray restart and add nightly release flow

### DIFF
--- a/.github/workflows/build-desktop-tauri.yml
+++ b/.github/workflows/build-desktop-tauri.yml
@@ -17,7 +17,7 @@ on:
         type: boolean
         default: true
       build_mode:
-        description: Build mode (`auto` | `tag-poll` | `nightly`); for workflow_dispatch, `auto` behaves as `manual`
+        description: Build mode (`auto` | `tag-poll` | `nightly`); for workflow_dispatch, `auto` behaves as `manual` and disables publish_release
         required: false
         type: choice
         default: auto


### PR DESCRIPTION
## Summary
- stabilize tray-initiated backend restart signaling between Tauri and WebUI
- harden macOS DMG cleanup/retry flow for CI detach failures (`DiskArbitration expired` / `drive not detached`)
- add daily nightly pipeline while keeping hourly upstream-tag polling build behavior

## Key Changes
- desktop bridge + tray restart event wiring improvements in `src-tauri/src/main.rs`
- loopback capability fix for desktop event APIs in `src-tauri/capabilities/default.json`
- CI DMG cleanup hardening in `scripts/ci/cleanup-dmg.sh`:
  - pre-detach sleep
  - mount-holder process cleanup (gated by env)
  - safer `diskutil unmountDisk` usage with disk identifier resolution
  - bounded/portable lsof timeout handling
- workflow improvements in `.github/workflows/build-desktop-tauri.yml`:
  - keep hourly tag-poll schedule
  - add daily nightly schedule
  - nightly builds from upstream `master` latest commit
  - nightly prerelease tag naming with `-nightly.<date>.<sha>` suffix
  - nightly release publishing without version-file sync

## Validation
- `cargo check --manifest-path src-tauri/Cargo.toml --locked`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --locked --all-targets -- -D warnings`
- `bash -n scripts/ci/cleanup-dmg.sh`
- `node --check scripts/prepare-resources.mjs`
- local packaging flow (`make clean`, `make update`, `make build`)

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

</details>

新功能：
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`）。
- 从可配置的上游分支生成夜间预发布构建，并使用附带日期和 SHA 的版本标签。

增强：
- 在各个任务（job）之间传递已解析的构建模式和发布元数据（`publish` 标志、标签、名称、`prerelease`），以集中化发布决策逻辑。

构建：
- 基于构建模式推导发布元数据，从而对夜间预发布与常规发布进行差异化处理。

CI：
- 将定时运行拆分为夜间执行和 tag-poll 执行，并基于可配置的 UTC 小时进行区分，同时验证输入和环境变量。
- 将仓库版本同步限制为仅在定时 tag-poll 运行时执行，并仅基于解析后的 `publish_release` 标志控制发布行为。
- 更新发布任务，在创建 GitHub Release 时使用预先计算的发布元数据以及 `prerelease` / `latest` 标志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

</details>

</details>

新特性：
- 为桌面构建工作流新增可配置的构建模式输入（`auto`、`tag-poll`、`nightly`）。
- 从可配置的上游分支按日程生成 nightly 预发布构建，版本号使用日期 + SHA 后缀的标签。

增强：
- 在各工作流任务之间传递已解析的构建上下文（构建模式、发布标志、发布标签/名称/预发布标记），以集中管理发布决策逻辑。
- 基于构建模式派生发布元数据，包括对 nightly 预发布与常规发布的分别处理。

CI：
- 根据可配置的 UTC 小时，将计划任务拆分为 nightly 和标签轮询（tag-polling）两种行为，并对输入和环境变量进行校验。
- 将仓库版本同步限制为仅在计划的 tag-poll 运行中执行，并仅由解析后的 `publish_release` 标志驱动发布任务。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

</details>

新功能：
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`）。
- 从可配置的上游分支生成夜间预发布构建，并使用附带日期和 SHA 的版本标签。

增强：
- 在各个任务（job）之间传递已解析的构建模式和发布元数据（`publish` 标志、标签、名称、`prerelease`），以集中化发布决策逻辑。

构建：
- 基于构建模式推导发布元数据，从而对夜间预发布与常规发布进行差异化处理。

CI：
- 将定时运行拆分为夜间执行和 tag-poll 执行，并基于可配置的 UTC 小时进行区分，同时验证输入和环境变量。
- 将仓库版本同步限制为仅在定时 tag-poll 运行时执行，并仅基于解析后的 `publish_release` 标志控制发布行为。
- 更新发布任务，在创建 GitHub Release 时使用预先计算的发布元数据以及 `prerelease` / `latest` 标志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

</details>

</details>

</details>

新功能：
- 引入构建模式概念（manual、tag-poll、nightly），并提供相应的工作流输入和环境配置。
- 新增夜间构建功能：从可配置的上游分支在特定 UTC 时间触发构建，并自动生成夜间预发布标签和名称。

改进：
- 将已解析的构建和发布上下文（mode、publish 标志、tag、name、prerelease）从解析任务传播到下游任务。
- 将仓库版本同步限制为仅在计划的 tag-poll 运行中执行，而非所有计划任务执行。
- 仅根据解析得到的 `publish_release` 标志驱动发布任务，在创建 GitHub Releases 时使用预先计算好的发布元数据，包括预发布和最新版本设置。

CI：
- 扩展桌面构建工作流，以区分 manual、tag-poll 和 nightly 三种执行方式，并包含输入校验和调度行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

</details>

新功能：
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`）。
- 从可配置的上游分支生成夜间预发布构建，并使用附带日期和 SHA 的版本标签。

增强：
- 在各个任务（job）之间传递已解析的构建模式和发布元数据（`publish` 标志、标签、名称、`prerelease`），以集中化发布决策逻辑。

构建：
- 基于构建模式推导发布元数据，从而对夜间预发布与常规发布进行差异化处理。

CI：
- 将定时运行拆分为夜间执行和 tag-poll 执行，并基于可配置的 UTC 小时进行区分，同时验证输入和环境变量。
- 将仓库版本同步限制为仅在定时 tag-poll 运行时执行，并仅基于解析后的 `publish_release` 标志控制发布行为。
- 更新发布任务，在创建 GitHub Release 时使用预先计算的发布元数据以及 `prerelease` / `latest` 标志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

</details>

</details>

新特性：
- 为桌面构建工作流新增可配置的构建模式输入（`auto`、`tag-poll`、`nightly`）。
- 从可配置的上游分支按日程生成 nightly 预发布构建，版本号使用日期 + SHA 后缀的标签。

增强：
- 在各工作流任务之间传递已解析的构建上下文（构建模式、发布标志、发布标签/名称/预发布标记），以集中管理发布决策逻辑。
- 基于构建模式派生发布元数据，包括对 nightly 预发布与常规发布的分别处理。

CI：
- 根据可配置的 UTC 小时，将计划任务拆分为 nightly 和标签轮询（tag-polling）两种行为，并对输入和环境变量进行校验。
- 将仓库版本同步限制为仅在计划的 tag-poll 运行中执行，并仅由解析后的 `publish_release` 标志驱动发布任务。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

</details>

新功能：
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`）。
- 从可配置的上游分支生成夜间预发布构建，并使用附带日期和 SHA 的版本标签。

增强：
- 在各个任务（job）之间传递已解析的构建模式和发布元数据（`publish` 标志、标签、名称、`prerelease`），以集中化发布决策逻辑。

构建：
- 基于构建模式推导发布元数据，从而对夜间预发布与常规发布进行差异化处理。

CI：
- 将定时运行拆分为夜间执行和 tag-poll 执行，并基于可配置的 UTC 小时进行区分，同时验证输入和环境变量。
- 将仓库版本同步限制为仅在定时 tag-poll 运行时执行，并仅基于解析后的 `publish_release` 标志控制发布行为。
- 更新发布任务，在创建 GitHub Release 时使用预先计算的发布元数据以及 `prerelease` / `latest` 标志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

</details>

</details>

</details>

</details>

Build：
- 通过工作流 job 的输出传播解析后的构建模式和发布元数据，以便下游 job 能据此决定构建与发布行为。

CI：
- 在现有的每小时定时任务基础上新增每日定时运行，以支持从上游 master 分支触发的夜间构建。
- 根据运行是手动触发、夜间构建还是 tag-poll 驱动，推导构建上下文输出，包括构建模式、发布标记（是否发布）以及发布元数据（tag、名称、是否为预发行版）。
- 将仓库版本同步限制为仅在定时的 tag-poll 构建中执行，而不是在所有定时任务中执行。
- 修改发布 job，使其依赖解析出的 `publish_release` 标志，并在创建 GitHub Release 时使用计算好的发布元数据，包括预发行版状态和 “latest” 标记。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

</details>

新功能：
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`）。
- 从可配置的上游分支生成夜间预发布构建，并使用附带日期和 SHA 的版本标签。

增强：
- 在各个任务（job）之间传递已解析的构建模式和发布元数据（`publish` 标志、标签、名称、`prerelease`），以集中化发布决策逻辑。

构建：
- 基于构建模式推导发布元数据，从而对夜间预发布与常规发布进行差异化处理。

CI：
- 将定时运行拆分为夜间执行和 tag-poll 执行，并基于可配置的 UTC 小时进行区分，同时验证输入和环境变量。
- 将仓库版本同步限制为仅在定时 tag-poll 运行时执行，并仅基于解析后的 `publish_release` 标志控制发布行为。
- 更新发布任务，在创建 GitHub Release 时使用预先计算的发布元数据以及 `prerelease` / `latest` 标志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

</details>

</details>

新特性：
- 为桌面构建工作流新增可配置的构建模式输入（`auto`、`tag-poll`、`nightly`）。
- 从可配置的上游分支按日程生成 nightly 预发布构建，版本号使用日期 + SHA 后缀的标签。

增强：
- 在各工作流任务之间传递已解析的构建上下文（构建模式、发布标志、发布标签/名称/预发布标记），以集中管理发布决策逻辑。
- 基于构建模式派生发布元数据，包括对 nightly 预发布与常规发布的分别处理。

CI：
- 根据可配置的 UTC 小时，将计划任务拆分为 nightly 和标签轮询（tag-polling）两种行为，并对输入和环境变量进行校验。
- 将仓库版本同步限制为仅在计划的 tag-poll 运行中执行，并仅由解析后的 `publish_release` 标志驱动发布任务。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

</details>

新功能：
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`）。
- 从可配置的上游分支生成夜间预发布构建，并使用附带日期和 SHA 的版本标签。

增强：
- 在各个任务（job）之间传递已解析的构建模式和发布元数据（`publish` 标志、标签、名称、`prerelease`），以集中化发布决策逻辑。

构建：
- 基于构建模式推导发布元数据，从而对夜间预发布与常规发布进行差异化处理。

CI：
- 将定时运行拆分为夜间执行和 tag-poll 执行，并基于可配置的 UTC 小时进行区分，同时验证输入和环境变量。
- 将仓库版本同步限制为仅在定时 tag-poll 运行时执行，并仅基于解析后的 `publish_release` 标志控制发布行为。
- 更新发布任务，在创建 GitHub Release 时使用预先计算的发布元数据以及 `prerelease` / `latest` 标志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

</details>

</details>

</details>

新功能：
- 引入构建模式概念（manual、tag-poll、nightly），并提供相应的工作流输入和环境配置。
- 新增夜间构建功能：从可配置的上游分支在特定 UTC 时间触发构建，并自动生成夜间预发布标签和名称。

改进：
- 将已解析的构建和发布上下文（mode、publish 标志、tag、name、prerelease）从解析任务传播到下游任务。
- 将仓库版本同步限制为仅在计划的 tag-poll 运行中执行，而非所有计划任务执行。
- 仅根据解析得到的 `publish_release` 标志驱动发布任务，在创建 GitHub Releases 时使用预先计算好的发布元数据，包括预发布和最新版本设置。

CI：
- 扩展桌面构建工作流，以区分 manual、tag-poll 和 nightly 三种执行方式，并包含输入校验和调度行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

</details>

新功能：
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`）。
- 从可配置的上游分支生成夜间预发布构建，并使用附带日期和 SHA 的版本标签。

增强：
- 在各个任务（job）之间传递已解析的构建模式和发布元数据（`publish` 标志、标签、名称、`prerelease`），以集中化发布决策逻辑。

构建：
- 基于构建模式推导发布元数据，从而对夜间预发布与常规发布进行差异化处理。

CI：
- 将定时运行拆分为夜间执行和 tag-poll 执行，并基于可配置的 UTC 小时进行区分，同时验证输入和环境变量。
- 将仓库版本同步限制为仅在定时 tag-poll 运行时执行，并仅基于解析后的 `publish_release` 标志控制发布行为。
- 更新发布任务，在创建 GitHub Release 时使用预先计算的发布元数据以及 `prerelease` / `latest` 标志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

</details>

</details>

新特性：
- 为桌面构建工作流新增可配置的构建模式输入（`auto`、`tag-poll`、`nightly`）。
- 从可配置的上游分支按日程生成 nightly 预发布构建，版本号使用日期 + SHA 后缀的标签。

增强：
- 在各工作流任务之间传递已解析的构建上下文（构建模式、发布标志、发布标签/名称/预发布标记），以集中管理发布决策逻辑。
- 基于构建模式派生发布元数据，包括对 nightly 预发布与常规发布的分别处理。

CI：
- 根据可配置的 UTC 小时，将计划任务拆分为 nightly 和标签轮询（tag-polling）两种行为，并对输入和环境变量进行校验。
- 将仓库版本同步限制为仅在计划的 tag-poll 运行中执行，并仅由解析后的 `publish_release` 标志驱动发布任务。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

</details>

新功能：
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`）。
- 从可配置的上游分支生成夜间预发布构建，并使用附带日期和 SHA 的版本标签。

增强：
- 在各个任务（job）之间传递已解析的构建模式和发布元数据（`publish` 标志、标签、名称、`prerelease`），以集中化发布决策逻辑。

构建：
- 基于构建模式推导发布元数据，从而对夜间预发布与常规发布进行差异化处理。

CI：
- 将定时运行拆分为夜间执行和 tag-poll 执行，并基于可配置的 UTC 小时进行区分，同时验证输入和环境变量。
- 将仓库版本同步限制为仅在定时 tag-poll 运行时执行，并仅基于解析后的 `publish_release` 标志控制发布行为。
- 更新发布任务，在创建 GitHub Release 时使用预先计算的发布元数据以及 `prerelease` / `latest` 标志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

</details>

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

</details>

新功能：
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`）。
- 从可配置的上游分支生成夜间预发布构建，并使用附带日期和 SHA 的版本标签。

增强：
- 在各个任务（job）之间传递已解析的构建模式和发布元数据（`publish` 标志、标签、名称、`prerelease`），以集中化发布决策逻辑。

构建：
- 基于构建模式推导发布元数据，从而对夜间预发布与常规发布进行差异化处理。

CI：
- 将定时运行拆分为夜间执行和 tag-poll 执行，并基于可配置的 UTC 小时进行区分，同时验证输入和环境变量。
- 将仓库版本同步限制为仅在定时 tag-poll 运行时执行，并仅基于解析后的 `publish_release` 标志控制发布行为。
- 更新发布任务，在创建 GitHub Release 时使用预先计算的发布元数据以及 `prerelease` / `latest` 标志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

</details>

</details>

新特性：
- 为桌面构建工作流新增可配置的构建模式输入（`auto`、`tag-poll`、`nightly`）。
- 从可配置的上游分支按日程生成 nightly 预发布构建，版本号使用日期 + SHA 后缀的标签。

增强：
- 在各工作流任务之间传递已解析的构建上下文（构建模式、发布标志、发布标签/名称/预发布标记），以集中管理发布决策逻辑。
- 基于构建模式派生发布元数据，包括对 nightly 预发布与常规发布的分别处理。

CI：
- 根据可配置的 UTC 小时，将计划任务拆分为 nightly 和标签轮询（tag-polling）两种行为，并对输入和环境变量进行校验。
- 将仓库版本同步限制为仅在计划的 tag-poll 运行中执行，并仅由解析后的 `publish_release` 标志驱动发布任务。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

</details>

新功能：
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`）。
- 从可配置的上游分支生成夜间预发布构建，并使用附带日期和 SHA 的版本标签。

增强：
- 在各个任务（job）之间传递已解析的构建模式和发布元数据（`publish` 标志、标签、名称、`prerelease`），以集中化发布决策逻辑。

构建：
- 基于构建模式推导发布元数据，从而对夜间预发布与常规发布进行差异化处理。

CI：
- 将定时运行拆分为夜间执行和 tag-poll 执行，并基于可配置的 UTC 小时进行区分，同时验证输入和环境变量。
- 将仓库版本同步限制为仅在定时 tag-poll 运行时执行，并仅基于解析后的 `publish_release` 标志控制发布行为。
- 更新发布任务，在创建 GitHub Release 时使用预先计算的发布元数据以及 `prerelease` / `latest` 标志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

</details>

</details>

</details>

新功能：
- 引入构建模式概念（manual、tag-poll、nightly），并提供相应的工作流输入和环境配置。
- 新增夜间构建功能：从可配置的上游分支在特定 UTC 时间触发构建，并自动生成夜间预发布标签和名称。

改进：
- 将已解析的构建和发布上下文（mode、publish 标志、tag、name、prerelease）从解析任务传播到下游任务。
- 将仓库版本同步限制为仅在计划的 tag-poll 运行中执行，而非所有计划任务执行。
- 仅根据解析得到的 `publish_release` 标志驱动发布任务，在创建 GitHub Releases 时使用预先计算好的发布元数据，包括预发布和最新版本设置。

CI：
- 扩展桌面构建工作流，以区分 manual、tag-poll 和 nightly 三种执行方式，并包含输入校验和调度行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

</details>

新功能：
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`）。
- 从可配置的上游分支生成夜间预发布构建，并使用附带日期和 SHA 的版本标签。

增强：
- 在各个任务（job）之间传递已解析的构建模式和发布元数据（`publish` 标志、标签、名称、`prerelease`），以集中化发布决策逻辑。

构建：
- 基于构建模式推导发布元数据，从而对夜间预发布与常规发布进行差异化处理。

CI：
- 将定时运行拆分为夜间执行和 tag-poll 执行，并基于可配置的 UTC 小时进行区分，同时验证输入和环境变量。
- 将仓库版本同步限制为仅在定时 tag-poll 运行时执行，并仅基于解析后的 `publish_release` 标志控制发布行为。
- 更新发布任务，在创建 GitHub Release 时使用预先计算的发布元数据以及 `prerelease` / `latest` 标志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

</details>

</details>

新特性：
- 为桌面构建工作流新增可配置的构建模式输入（`auto`、`tag-poll`、`nightly`）。
- 从可配置的上游分支按日程生成 nightly 预发布构建，版本号使用日期 + SHA 后缀的标签。

增强：
- 在各工作流任务之间传递已解析的构建上下文（构建模式、发布标志、发布标签/名称/预发布标记），以集中管理发布决策逻辑。
- 基于构建模式派生发布元数据，包括对 nightly 预发布与常规发布的分别处理。

CI：
- 根据可配置的 UTC 小时，将计划任务拆分为 nightly 和标签轮询（tag-polling）两种行为，并对输入和环境变量进行校验。
- 将仓库版本同步限制为仅在计划的 tag-poll 运行中执行，并仅由解析后的 `publish_release` 标志驱动发布任务。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

</details>

新功能：
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`）。
- 从可配置的上游分支生成夜间预发布构建，并使用附带日期和 SHA 的版本标签。

增强：
- 在各个任务（job）之间传递已解析的构建模式和发布元数据（`publish` 标志、标签、名称、`prerelease`），以集中化发布决策逻辑。

构建：
- 基于构建模式推导发布元数据，从而对夜间预发布与常规发布进行差异化处理。

CI：
- 将定时运行拆分为夜间执行和 tag-poll 执行，并基于可配置的 UTC 小时进行区分，同时验证输入和环境变量。
- 将仓库版本同步限制为仅在定时 tag-poll 运行时执行，并仅基于解析后的 `publish_release` 标志控制发布行为。
- 更新发布任务，在创建 GitHub Release 时使用预先计算的发布元数据以及 `prerelease` / `latest` 标志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

</details>

</details>

</details>

</details>

Build：
- 通过工作流 job 的输出传播解析后的构建模式和发布元数据，以便下游 job 能据此决定构建与发布行为。

CI：
- 在现有的每小时定时任务基础上新增每日定时运行，以支持从上游 master 分支触发的夜间构建。
- 根据运行是手动触发、夜间构建还是 tag-poll 驱动，推导构建上下文输出，包括构建模式、发布标记（是否发布）以及发布元数据（tag、名称、是否为预发行版）。
- 将仓库版本同步限制为仅在定时的 tag-poll 构建中执行，而不是在所有定时任务中执行。
- 修改发布 job，使其依赖解析出的 `publish_release` 标志，并在创建 GitHub Release 时使用计算好的发布元数据，包括预发行版状态和 “latest” 标记。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

</details>

新功能：
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`）。
- 从可配置的上游分支生成夜间预发布构建，并使用附带日期和 SHA 的版本标签。

增强：
- 在各个任务（job）之间传递已解析的构建模式和发布元数据（`publish` 标志、标签、名称、`prerelease`），以集中化发布决策逻辑。

构建：
- 基于构建模式推导发布元数据，从而对夜间预发布与常规发布进行差异化处理。

CI：
- 将定时运行拆分为夜间执行和 tag-poll 执行，并基于可配置的 UTC 小时进行区分，同时验证输入和环境变量。
- 将仓库版本同步限制为仅在定时 tag-poll 运行时执行，并仅基于解析后的 `publish_release` 标志控制发布行为。
- 更新发布任务，在创建 GitHub Release 时使用预先计算的发布元数据以及 `prerelease` / `latest` 标志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

</details>

</details>

新特性：
- 为桌面构建工作流新增可配置的构建模式输入（`auto`、`tag-poll`、`nightly`）。
- 从可配置的上游分支按日程生成 nightly 预发布构建，版本号使用日期 + SHA 后缀的标签。

增强：
- 在各工作流任务之间传递已解析的构建上下文（构建模式、发布标志、发布标签/名称/预发布标记），以集中管理发布决策逻辑。
- 基于构建模式派生发布元数据，包括对 nightly 预发布与常规发布的分别处理。

CI：
- 根据可配置的 UTC 小时，将计划任务拆分为 nightly 和标签轮询（tag-polling）两种行为，并对输入和环境变量进行校验。
- 将仓库版本同步限制为仅在计划的 tag-poll 运行中执行，并仅由解析后的 `publish_release` 标志驱动发布任务。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

</details>

新功能：
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`）。
- 从可配置的上游分支生成夜间预发布构建，并使用附带日期和 SHA 的版本标签。

增强：
- 在各个任务（job）之间传递已解析的构建模式和发布元数据（`publish` 标志、标签、名称、`prerelease`），以集中化发布决策逻辑。

构建：
- 基于构建模式推导发布元数据，从而对夜间预发布与常规发布进行差异化处理。

CI：
- 将定时运行拆分为夜间执行和 tag-poll 执行，并基于可配置的 UTC 小时进行区分，同时验证输入和环境变量。
- 将仓库版本同步限制为仅在定时 tag-poll 运行时执行，并仅基于解析后的 `publish_release` 标志控制发布行为。
- 更新发布任务，在创建 GitHub Release 时使用预先计算的发布元数据以及 `prerelease` / `latest` 标志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

</details>

</details>

</details>

新功能：
- 引入构建模式概念（manual、tag-poll、nightly），并提供相应的工作流输入和环境配置。
- 新增夜间构建功能：从可配置的上游分支在特定 UTC 时间触发构建，并自动生成夜间预发布标签和名称。

改进：
- 将已解析的构建和发布上下文（mode、publish 标志、tag、name、prerelease）从解析任务传播到下游任务。
- 将仓库版本同步限制为仅在计划的 tag-poll 运行中执行，而非所有计划任务执行。
- 仅根据解析得到的 `publish_release` 标志驱动发布任务，在创建 GitHub Releases 时使用预先计算好的发布元数据，包括预发布和最新版本设置。

CI：
- 扩展桌面构建工作流，以区分 manual、tag-poll 和 nightly 三种执行方式，并包含输入校验和调度行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

</details>

新功能：
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`）。
- 从可配置的上游分支生成夜间预发布构建，并使用附带日期和 SHA 的版本标签。

增强：
- 在各个任务（job）之间传递已解析的构建模式和发布元数据（`publish` 标志、标签、名称、`prerelease`），以集中化发布决策逻辑。

构建：
- 基于构建模式推导发布元数据，从而对夜间预发布与常规发布进行差异化处理。

CI：
- 将定时运行拆分为夜间执行和 tag-poll 执行，并基于可配置的 UTC 小时进行区分，同时验证输入和环境变量。
- 将仓库版本同步限制为仅在定时 tag-poll 运行时执行，并仅基于解析后的 `publish_release` 标志控制发布行为。
- 更新发布任务，在创建 GitHub Release 时使用预先计算的发布元数据以及 `prerelease` / `latest` 标志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

</details>

</details>

新特性：
- 为桌面构建工作流新增可配置的构建模式输入（`auto`、`tag-poll`、`nightly`）。
- 从可配置的上游分支按日程生成 nightly 预发布构建，版本号使用日期 + SHA 后缀的标签。

增强：
- 在各工作流任务之间传递已解析的构建上下文（构建模式、发布标志、发布标签/名称/预发布标记），以集中管理发布决策逻辑。
- 基于构建模式派生发布元数据，包括对 nightly 预发布与常规发布的分别处理。

CI：
- 根据可配置的 UTC 小时，将计划任务拆分为 nightly 和标签轮询（tag-polling）两种行为，并对输入和环境变量进行校验。
- 将仓库版本同步限制为仅在计划的 tag-poll 运行中执行，并仅由解析后的 `publish_release` 标志驱动发布任务。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

</details>

新功能：
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`）。
- 从可配置的上游分支生成夜间预发布构建，并使用附带日期和 SHA 的版本标签。

增强：
- 在各个任务（job）之间传递已解析的构建模式和发布元数据（`publish` 标志、标签、名称、`prerelease`），以集中化发布决策逻辑。

构建：
- 基于构建模式推导发布元数据，从而对夜间预发布与常规发布进行差异化处理。

CI：
- 将定时运行拆分为夜间执行和 tag-poll 执行，并基于可配置的 UTC 小时进行区分，同时验证输入和环境变量。
- 将仓库版本同步限制为仅在定时 tag-poll 运行时执行，并仅基于解析后的 `publish_release` 标志控制发布行为。
- 更新发布任务，在创建 GitHub Release 时使用预先计算的发布元数据以及 `prerelease` / `latest` 标志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为桌面端 CI 引入可配置的构建模式和统一的构建上下文解析机制，在支持每夜预发行构建的同时，优化正式发布和版本同步的触发时机。

New Features:
- 为桌面构建工作流新增可配置的 `build_mode` 输入参数（`auto`、`tag-poll`、`nightly`），用于控制构建行为。
- 从可配置的上游 ref 生成每夜预发行构建，并使用包含日期和 SHA 后缀的版本标签与名称。

Enhancements:
- 将构建上下文和发布元数据的解析集中到一个可复用脚本中，该脚本会把构建模式、发布标志以及发布标识符传播到下游任务。

Build:
- 根据解析得到的构建模式和源 ref 推导发布标签、名称和是否为预发行，而不是在工作流中硬编码这些信息。

CI:
- 按可配置的 UTC 小时将定时运行拆分为 nightly 和 tag-poll 模式，同时校验输入和环境变量。
- 将仓库版本同步限制为仅在定时的 tag-poll 运行中执行，并由解析出的 `build_mode` 输出驱动。
- 仅根据解析后的 `publish_release` 标志和预先计算好的发布元数据（包括是否为预发行以及是否为最新）来驱动发布流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable build mode and centralized build-context resolution for desktop CI, enabling nightly prerelease builds while refining when releases and version syncs occur.

New Features:
- Add a configurable build_mode input (auto, tag-poll, nightly) for the desktop build workflow to control build behavior.
- Generate nightly prerelease builds from a configurable upstream ref with date+SHA-suffixed version tags and names.

Enhancements:
- Centralize build context and release metadata resolution into a reusable script that propagates build mode, publish flags, and release identifiers to downstream jobs.

Build:
- Derive release tags, names, and prerelease status from the resolved build mode and source ref instead of hardcoding them in the workflow.

CI:
- Split scheduled runs into nightly and tag-poll modes based on a configurable UTC hour while validating inputs and environment variables.
- Restrict repository version synchronization to scheduled tag-poll runs only, driven by the resolved build_mode output.
- Drive release publishing solely from the parsed publish_release flag and precomputed release metadata, including prerelease and latest settings.

</details>

</details>

</details>

</details>

</details>

</details>

</details>