### PR TITLE
ci: macOS actions build app zip only (drop dmg path)

### DIFF
--- a/.github/workflows/build-desktop-tauri.yml
+++ b/.github/workflows/build-desktop-tauri.yml
@@ -246,20 +246,33 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          max_attempts_default=3
+          max_attempts_upper_bound=6
+          retry_sleep_seconds_default=8
+
           max_attempts="${ASTRBOT_MACOS_BUILD_MAX_ATTEMPTS}"
           retry_sleep_seconds="${ASTRBOT_MACOS_BUILD_RETRY_SLEEP_SECONDS}"
           # Retry only for known transient cargo/crates network failures.
+          # Spurious retry hints emitted by cargo.
           transient_retry_spurious='spurious network error|network failure seems to have happened'
+          # HTTP-layer transient fetch failures (rate limits and 5xx responses).
           transient_retry_http='failed to download from|failed to get successful HTTP response|received HTTP code (429|5[0-9][0-9])'
+          # Transport-layer transient failures.
           transient_retry_transport='Operation timed out|Connection reset by peer|Connection refused|Temporary failure in name resolution'
           retry_pattern="${transient_retry_spurious}|${transient_retry_http}|${transient_retry_transport}"
 
           case "${max_attempts}" in
-            ''|*[!0-9]*|0) max_attempts=3 ;;
+            ''|*[!0-9]*|0) max_attempts="${max_attempts_default}" ;;
           esac
+          if [ "${max_attempts}" -gt "${max_attempts_upper_bound}" ]; then
+            echo "::warning::ASTRBOT_MACOS_BUILD_MAX_ATTEMPTS=${max_attempts} exceeds upper bound ${max_attempts_upper_bound}; clamping."
+            max_attempts="${max_attempts_upper_bound}"
+          fi
+
           case "${retry_sleep_seconds}" in
-            ''|*[!0-9]*) retry_sleep_seconds=8 ;;
+            ''|*[!0-9]*|0) retry_sleep_seconds="${retry_sleep_seconds_default}" ;;
           esac
+          echo "macOS build retry config: max_attempts=${max_attempts}, retry_sleep_seconds=${retry_sleep_seconds}, max_attempts_upper_bound=${max_attempts_upper_bound}"
 
           for attempt in $(seq 1 "${max_attempts}"); do
             build_log="$(mktemp -t tauri-macos-build.XXXXXX.log)"

--- a/scripts/ci/resolve-macos-app-name.py
+++ b/scripts/ci/resolve-macos-app-name.py
@@ -94,7 +94,8 @@ def main() -> int:
     if not app_bundle_name:
         raise RuntimeError(
             "Resolved app bundle name is empty after normalization "
-            "(possible value was only '.app')."
+            f"(original value: {raw_name!r} from {source}; "
+            "possible value was only '.app')."
         )
 
     print(f"Resolved app bundle name: {app_bundle_name} (source={source})")


### PR DESCRIPTION
## Summary
- change macOS GitHub Actions packaging to build `app` bundle only
- package `.app` into a zip artifact with `ditto --keepParent`
- remove DMG-specific retry/cleanup/diagnostic/verification steps from CI workflow

## Scope
- CI workflow only (`.github/workflows/build-desktop-tauri.yml`)
- no changes to local packaging behavior or Tauri config

## Why
- avoid flaky DMG detach failures on CI runners while keeping downloadable macOS artifacts

## Sourcery 总结

更新 macOS CI 工作流，仅构建并发布带版本号的 `.app` ZIP 压缩包，而不再使用基于 DMG 的安装程序。

新特性：
- 在 CI 构建中生成按架构区分、带版本号的 macOS `.app` ZIP 工件。

改进：
- 从配置或环境中解析 macOS 应用包名称，并在需要时自动探测作为回退方式。
- 将 CI 中的 macOS Tauri 构建限制为应用包目标，并将生成的 `.app` 打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流，移除 DMG 专用的重试、清理、诊断和验证步骤，并将工件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

新功能：
- 在 CI 的 macOS 构建中，为每种架构生成带版本号的 macOS `.app` ZIP 构件。

增强：
- 从 Tauri 配置或覆盖项中解析 macOS 应用包名称，并进行规范化处理；在需要时通过回退机制自动发现已构建的 `.app` 应用包。
- 将 CI 中的 macOS Tauri 构建限制为仅构建应用包目标，并使用 `ditto` 将其打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流：移除针对 DMG 的重试、清理、诊断和验证步骤，并将构件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

</details>

</details>

新功能：
- 在 CI 构建中，为每种架构生成带版本号的 macOS .app zip 构件。

改进：
- 在打包时，从配置或环境中解析 macOS 应用包名称，如果未配置则回退到自动发现。

CI：
- 在 CI 中将 macOS Tauri 构建限制为应用包目标，仅对生成的 .app 进行打包，输出为 zip 文件而不是 DMG 和应用 tarball。
- 从 macOS GitHub Actions 工作流中移除与 DMG 相关的重试、清理、诊断和完整性验证步骤。
- 更新 macOS 构件上传路径，以发布新的 zip 构件。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

更新 macOS CI 工作流，仅构建并发布带版本号的 `.app` ZIP 压缩包，而不再使用基于 DMG 的安装程序。

新特性：
- 在 CI 构建中生成按架构区分、带版本号的 macOS `.app` ZIP 工件。

改进：
- 从配置或环境中解析 macOS 应用包名称，并在需要时自动探测作为回退方式。
- 将 CI 中的 macOS Tauri 构建限制为应用包目标，并将生成的 `.app` 打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流，移除 DMG 专用的重试、清理、诊断和验证步骤，并将工件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

新功能：
- 在 CI 的 macOS 构建中，为每种架构生成带版本号的 macOS `.app` ZIP 构件。

增强：
- 从 Tauri 配置或覆盖项中解析 macOS 应用包名称，并进行规范化处理；在需要时通过回退机制自动发现已构建的 `.app` 应用包。
- 将 CI 中的 macOS Tauri 构建限制为仅构建应用包目标，并使用 `ditto` 将其打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流：移除针对 DMG 的重试、清理、诊断和验证步骤，并将构件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

</details>

</details>

</details>

新功能：
- 在 CI 中为每种架构生成带版本号的 macOS .app zip 构件。

改进：
- 在打包前从配置或环境中解析 macOS 应用包名，如有必要则回退到自动发现的应用包名。

CI：
- 将 CI 中的 macOS Tauri 构建限制为应用包目标，并将生成的 .app 打包为 zip 文件，而非 DMG 和 app tarball 输出。
- 从 macOS GitHub Actions 工作流中移除与 DMG 相关的重试、清理、诊断和完整性校验步骤。
- 更新 macOS 构件上传路径，以发布新的 zip 构件。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

更新 macOS CI 工作流，仅构建并发布带版本号的 `.app` ZIP 压缩包，而不再使用基于 DMG 的安装程序。

新特性：
- 在 CI 构建中生成按架构区分、带版本号的 macOS `.app` ZIP 工件。

改进：
- 从配置或环境中解析 macOS 应用包名称，并在需要时自动探测作为回退方式。
- 将 CI 中的 macOS Tauri 构建限制为应用包目标，并将生成的 `.app` 打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流，移除 DMG 专用的重试、清理、诊断和验证步骤，并将工件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

新功能：
- 在 CI 的 macOS 构建中，为每种架构生成带版本号的 macOS `.app` ZIP 构件。

增强：
- 从 Tauri 配置或覆盖项中解析 macOS 应用包名称，并进行规范化处理；在需要时通过回退机制自动发现已构建的 `.app` 应用包。
- 将 CI 中的 macOS Tauri 构建限制为仅构建应用包目标，并使用 `ditto` 将其打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流：移除针对 DMG 的重试、清理、诊断和验证步骤，并将构件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

</details>

</details>

新功能：
- 在 CI 构建中，为每种架构生成带版本号的 macOS .app zip 构件。

改进：
- 在打包时，从配置或环境中解析 macOS 应用包名称，如果未配置则回退到自动发现。

CI：
- 在 CI 中将 macOS Tauri 构建限制为应用包目标，仅对生成的 .app 进行打包，输出为 zip 文件而不是 DMG 和应用 tarball。
- 从 macOS GitHub Actions 工作流中移除与 DMG 相关的重试、清理、诊断和完整性验证步骤。
- 更新 macOS 构件上传路径，以发布新的 zip 构件。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

更新 macOS CI 工作流，仅构建并发布带版本号的 `.app` ZIP 压缩包，而不再使用基于 DMG 的安装程序。

新特性：
- 在 CI 构建中生成按架构区分、带版本号的 macOS `.app` ZIP 工件。

改进：
- 从配置或环境中解析 macOS 应用包名称，并在需要时自动探测作为回退方式。
- 将 CI 中的 macOS Tauri 构建限制为应用包目标，并将生成的 `.app` 打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流，移除 DMG 专用的重试、清理、诊断和验证步骤，并将工件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

新功能：
- 在 CI 的 macOS 构建中，为每种架构生成带版本号的 macOS `.app` ZIP 构件。

增强：
- 从 Tauri 配置或覆盖项中解析 macOS 应用包名称，并进行规范化处理；在需要时通过回退机制自动发现已构建的 `.app` 应用包。
- 将 CI 中的 macOS Tauri 构建限制为仅构建应用包目标，并使用 `ditto` 将其打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流：移除针对 DMG 的重试、清理、诊断和验证步骤，并将构件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

</details>

</details>

</details>

</details>

新功能：
- 在 CI 中为每种架构生成带版本号的 macOS .app zip 制品。

改进：
- 将 CI 中的 macOS Tauri 构建限制为仅构建应用包目标，并使用 `ditto` 将其打包为 zip 文件。
- 从配置或环境中推断 macOS 应用包名称，以定位并压缩构建好的 .app 应用包。

CI：
- 通过移除与 DMG 相关的重试、清理、诊断和完整性验证步骤，简化 macOS GitHub Actions 工作流程。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

更新 macOS CI 工作流，仅构建并发布带版本号的 `.app` ZIP 压缩包，而不再使用基于 DMG 的安装程序。

新特性：
- 在 CI 构建中生成按架构区分、带版本号的 macOS `.app` ZIP 工件。

改进：
- 从配置或环境中解析 macOS 应用包名称，并在需要时自动探测作为回退方式。
- 将 CI 中的 macOS Tauri 构建限制为应用包目标，并将生成的 `.app` 打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流，移除 DMG 专用的重试、清理、诊断和验证步骤，并将工件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

新功能：
- 在 CI 的 macOS 构建中，为每种架构生成带版本号的 macOS `.app` ZIP 构件。

增强：
- 从 Tauri 配置或覆盖项中解析 macOS 应用包名称，并进行规范化处理；在需要时通过回退机制自动发现已构建的 `.app` 应用包。
- 将 CI 中的 macOS Tauri 构建限制为仅构建应用包目标，并使用 `ditto` 将其打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流：移除针对 DMG 的重试、清理、诊断和验证步骤，并将构件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

</details>

</details>

新功能：
- 在 CI 构建中，为每种架构生成带版本号的 macOS .app zip 构件。

改进：
- 在打包时，从配置或环境中解析 macOS 应用包名称，如果未配置则回退到自动发现。

CI：
- 在 CI 中将 macOS Tauri 构建限制为应用包目标，仅对生成的 .app 进行打包，输出为 zip 文件而不是 DMG 和应用 tarball。
- 从 macOS GitHub Actions 工作流中移除与 DMG 相关的重试、清理、诊断和完整性验证步骤。
- 更新 macOS 构件上传路径，以发布新的 zip 构件。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

更新 macOS CI 工作流，仅构建并发布带版本号的 `.app` ZIP 压缩包，而不再使用基于 DMG 的安装程序。

新特性：
- 在 CI 构建中生成按架构区分、带版本号的 macOS `.app` ZIP 工件。

改进：
- 从配置或环境中解析 macOS 应用包名称，并在需要时自动探测作为回退方式。
- 将 CI 中的 macOS Tauri 构建限制为应用包目标，并将生成的 `.app` 打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流，移除 DMG 专用的重试、清理、诊断和验证步骤，并将工件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

新功能：
- 在 CI 的 macOS 构建中，为每种架构生成带版本号的 macOS `.app` ZIP 构件。

增强：
- 从 Tauri 配置或覆盖项中解析 macOS 应用包名称，并进行规范化处理；在需要时通过回退机制自动发现已构建的 `.app` 应用包。
- 将 CI 中的 macOS Tauri 构建限制为仅构建应用包目标，并使用 `ditto` 将其打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流：移除针对 DMG 的重试、清理、诊断和验证步骤，并将构件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

</details>

</details>

</details>

新功能：
- 在 CI 中为每种架构生成带版本号的 macOS .app zip 构件。

改进：
- 在打包前从配置或环境中解析 macOS 应用包名，如有必要则回退到自动发现的应用包名。

CI：
- 将 CI 中的 macOS Tauri 构建限制为应用包目标，并将生成的 .app 打包为 zip 文件，而非 DMG 和 app tarball 输出。
- 从 macOS GitHub Actions 工作流中移除与 DMG 相关的重试、清理、诊断和完整性校验步骤。
- 更新 macOS 构件上传路径，以发布新的 zip 构件。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

更新 macOS CI 工作流，仅构建并发布带版本号的 `.app` ZIP 压缩包，而不再使用基于 DMG 的安装程序。

新特性：
- 在 CI 构建中生成按架构区分、带版本号的 macOS `.app` ZIP 工件。

改进：
- 从配置或环境中解析 macOS 应用包名称，并在需要时自动探测作为回退方式。
- 将 CI 中的 macOS Tauri 构建限制为应用包目标，并将生成的 `.app` 打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流，移除 DMG 专用的重试、清理、诊断和验证步骤，并将工件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

新功能：
- 在 CI 的 macOS 构建中，为每种架构生成带版本号的 macOS `.app` ZIP 构件。

增强：
- 从 Tauri 配置或覆盖项中解析 macOS 应用包名称，并进行规范化处理；在需要时通过回退机制自动发现已构建的 `.app` 应用包。
- 将 CI 中的 macOS Tauri 构建限制为仅构建应用包目标，并使用 `ditto` 将其打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流：移除针对 DMG 的重试、清理、诊断和验证步骤，并将构件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

</details>

</details>

新功能：
- 在 CI 构建中，为每种架构生成带版本号的 macOS .app zip 构件。

改进：
- 在打包时，从配置或环境中解析 macOS 应用包名称，如果未配置则回退到自动发现。

CI：
- 在 CI 中将 macOS Tauri 构建限制为应用包目标，仅对生成的 .app 进行打包，输出为 zip 文件而不是 DMG 和应用 tarball。
- 从 macOS GitHub Actions 工作流中移除与 DMG 相关的重试、清理、诊断和完整性验证步骤。
- 更新 macOS 构件上传路径，以发布新的 zip 构件。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

更新 macOS CI 工作流，仅构建并发布带版本号的 `.app` ZIP 压缩包，而不再使用基于 DMG 的安装程序。

新特性：
- 在 CI 构建中生成按架构区分、带版本号的 macOS `.app` ZIP 工件。

改进：
- 从配置或环境中解析 macOS 应用包名称，并在需要时自动探测作为回退方式。
- 将 CI 中的 macOS Tauri 构建限制为应用包目标，并将生成的 `.app` 打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流，移除 DMG 专用的重试、清理、诊断和验证步骤，并将工件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

新功能：
- 在 CI 的 macOS 构建中，为每种架构生成带版本号的 macOS `.app` ZIP 构件。

增强：
- 从 Tauri 配置或覆盖项中解析 macOS 应用包名称，并进行规范化处理；在需要时通过回退机制自动发现已构建的 `.app` 应用包。
- 将 CI 中的 macOS Tauri 构建限制为仅构建应用包目标，并使用 `ditto` 将其打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流：移除针对 DMG 的重试、清理、诊断和验证步骤，并将构件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

</details>

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

更新 macOS CI 工作流，仅构建并发布带版本号的 `.app` ZIP 压缩包，而不再使用基于 DMG 的安装程序。

新特性：
- 在 CI 构建中生成按架构区分、带版本号的 macOS `.app` ZIP 工件。

改进：
- 从配置或环境中解析 macOS 应用包名称，并在需要时自动探测作为回退方式。
- 将 CI 中的 macOS Tauri 构建限制为应用包目标，并将生成的 `.app` 打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流，移除 DMG 专用的重试、清理、诊断和验证步骤，并将工件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

新功能：
- 在 CI 的 macOS 构建中，为每种架构生成带版本号的 macOS `.app` ZIP 构件。

增强：
- 从 Tauri 配置或覆盖项中解析 macOS 应用包名称，并进行规范化处理；在需要时通过回退机制自动发现已构建的 `.app` 应用包。
- 将 CI 中的 macOS Tauri 构建限制为仅构建应用包目标，并使用 `ditto` 将其打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流：移除针对 DMG 的重试、清理、诊断和验证步骤，并将构件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

</details>

</details>

新功能：
- 在 CI 构建中，为每种架构生成带版本号的 macOS .app zip 构件。

改进：
- 在打包时，从配置或环境中解析 macOS 应用包名称，如果未配置则回退到自动发现。

CI：
- 在 CI 中将 macOS Tauri 构建限制为应用包目标，仅对生成的 .app 进行打包，输出为 zip 文件而不是 DMG 和应用 tarball。
- 从 macOS GitHub Actions 工作流中移除与 DMG 相关的重试、清理、诊断和完整性验证步骤。
- 更新 macOS 构件上传路径，以发布新的 zip 构件。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

更新 macOS CI 工作流，仅构建并发布带版本号的 `.app` ZIP 压缩包，而不再使用基于 DMG 的安装程序。

新特性：
- 在 CI 构建中生成按架构区分、带版本号的 macOS `.app` ZIP 工件。

改进：
- 从配置或环境中解析 macOS 应用包名称，并在需要时自动探测作为回退方式。
- 将 CI 中的 macOS Tauri 构建限制为应用包目标，并将生成的 `.app` 打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流，移除 DMG 专用的重试、清理、诊断和验证步骤，并将工件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

新功能：
- 在 CI 的 macOS 构建中，为每种架构生成带版本号的 macOS `.app` ZIP 构件。

增强：
- 从 Tauri 配置或覆盖项中解析 macOS 应用包名称，并进行规范化处理；在需要时通过回退机制自动发现已构建的 `.app` 应用包。
- 将 CI 中的 macOS Tauri 构建限制为仅构建应用包目标，并使用 `ditto` 将其打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流：移除针对 DMG 的重试、清理、诊断和验证步骤，并将构件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

</details>

</details>

</details>

新功能：
- 在 CI 中为每种架构生成带版本号的 macOS .app zip 构件。

改进：
- 在打包前从配置或环境中解析 macOS 应用包名，如有必要则回退到自动发现的应用包名。

CI：
- 将 CI 中的 macOS Tauri 构建限制为应用包目标，并将生成的 .app 打包为 zip 文件，而非 DMG 和 app tarball 输出。
- 从 macOS GitHub Actions 工作流中移除与 DMG 相关的重试、清理、诊断和完整性校验步骤。
- 更新 macOS 构件上传路径，以发布新的 zip 构件。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

更新 macOS CI 工作流，仅构建并发布带版本号的 `.app` ZIP 压缩包，而不再使用基于 DMG 的安装程序。

新特性：
- 在 CI 构建中生成按架构区分、带版本号的 macOS `.app` ZIP 工件。

改进：
- 从配置或环境中解析 macOS 应用包名称，并在需要时自动探测作为回退方式。
- 将 CI 中的 macOS Tauri 构建限制为应用包目标，并将生成的 `.app` 打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流，移除 DMG 专用的重试、清理、诊断和验证步骤，并将工件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

新功能：
- 在 CI 的 macOS 构建中，为每种架构生成带版本号的 macOS `.app` ZIP 构件。

增强：
- 从 Tauri 配置或覆盖项中解析 macOS 应用包名称，并进行规范化处理；在需要时通过回退机制自动发现已构建的 `.app` 应用包。
- 将 CI 中的 macOS Tauri 构建限制为仅构建应用包目标，并使用 `ditto` 将其打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流：移除针对 DMG 的重试、清理、诊断和验证步骤，并将构件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

</details>

</details>

新功能：
- 在 CI 构建中，为每种架构生成带版本号的 macOS .app zip 构件。

改进：
- 在打包时，从配置或环境中解析 macOS 应用包名称，如果未配置则回退到自动发现。

CI：
- 在 CI 中将 macOS Tauri 构建限制为应用包目标，仅对生成的 .app 进行打包，输出为 zip 文件而不是 DMG 和应用 tarball。
- 从 macOS GitHub Actions 工作流中移除与 DMG 相关的重试、清理、诊断和完整性验证步骤。
- 更新 macOS 构件上传路径，以发布新的 zip 构件。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

更新 macOS CI 工作流，仅构建并发布带版本号的 `.app` ZIP 压缩包，而不再使用基于 DMG 的安装程序。

新特性：
- 在 CI 构建中生成按架构区分、带版本号的 macOS `.app` ZIP 工件。

改进：
- 从配置或环境中解析 macOS 应用包名称，并在需要时自动探测作为回退方式。
- 将 CI 中的 macOS Tauri 构建限制为应用包目标，并将生成的 `.app` 打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流，移除 DMG 专用的重试、清理、诊断和验证步骤，并将工件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

新功能：
- 在 CI 的 macOS 构建中，为每种架构生成带版本号的 macOS `.app` ZIP 构件。

增强：
- 从 Tauri 配置或覆盖项中解析 macOS 应用包名称，并进行规范化处理；在需要时通过回退机制自动发现已构建的 `.app` 应用包。
- 将 CI 中的 macOS Tauri 构建限制为仅构建应用包目标，并使用 `ditto` 将其打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流：移除针对 DMG 的重试、清理、诊断和验证步骤，并将构件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

</details>

</details>

</details>

</details>

新功能：
- 在 CI 中为每种架构生成带版本号的 macOS .app zip 制品。

改进：
- 将 CI 中的 macOS Tauri 构建限制为仅构建应用包目标，并使用 `ditto` 将其打包为 zip 文件。
- 从配置或环境中推断 macOS 应用包名称，以定位并压缩构建好的 .app 应用包。

CI：
- 通过移除与 DMG 相关的重试、清理、诊断和完整性验证步骤，简化 macOS GitHub Actions 工作流程。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

更新 macOS CI 工作流，仅构建并发布带版本号的 `.app` ZIP 压缩包，而不再使用基于 DMG 的安装程序。

新特性：
- 在 CI 构建中生成按架构区分、带版本号的 macOS `.app` ZIP 工件。

改进：
- 从配置或环境中解析 macOS 应用包名称，并在需要时自动探测作为回退方式。
- 将 CI 中的 macOS Tauri 构建限制为应用包目标，并将生成的 `.app` 打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流，移除 DMG 专用的重试、清理、诊断和验证步骤，并将工件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

新功能：
- 在 CI 的 macOS 构建中，为每种架构生成带版本号的 macOS `.app` ZIP 构件。

增强：
- 从 Tauri 配置或覆盖项中解析 macOS 应用包名称，并进行规范化处理；在需要时通过回退机制自动发现已构建的 `.app` 应用包。
- 将 CI 中的 macOS Tauri 构建限制为仅构建应用包目标，并使用 `ditto` 将其打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流：移除针对 DMG 的重试、清理、诊断和验证步骤，并将构件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

</details>

</details>

新功能：
- 在 CI 构建中，为每种架构生成带版本号的 macOS .app zip 构件。

改进：
- 在打包时，从配置或环境中解析 macOS 应用包名称，如果未配置则回退到自动发现。

CI：
- 在 CI 中将 macOS Tauri 构建限制为应用包目标，仅对生成的 .app 进行打包，输出为 zip 文件而不是 DMG 和应用 tarball。
- 从 macOS GitHub Actions 工作流中移除与 DMG 相关的重试、清理、诊断和完整性验证步骤。
- 更新 macOS 构件上传路径，以发布新的 zip 构件。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

更新 macOS CI 工作流，仅构建并发布带版本号的 `.app` ZIP 压缩包，而不再使用基于 DMG 的安装程序。

新特性：
- 在 CI 构建中生成按架构区分、带版本号的 macOS `.app` ZIP 工件。

改进：
- 从配置或环境中解析 macOS 应用包名称，并在需要时自动探测作为回退方式。
- 将 CI 中的 macOS Tauri 构建限制为应用包目标，并将生成的 `.app` 打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流，移除 DMG 专用的重试、清理、诊断和验证步骤，并将工件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

新功能：
- 在 CI 的 macOS 构建中，为每种架构生成带版本号的 macOS `.app` ZIP 构件。

增强：
- 从 Tauri 配置或覆盖项中解析 macOS 应用包名称，并进行规范化处理；在需要时通过回退机制自动发现已构建的 `.app` 应用包。
- 将 CI 中的 macOS Tauri 构建限制为仅构建应用包目标，并使用 `ditto` 将其打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流：移除针对 DMG 的重试、清理、诊断和验证步骤，并将构件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

</details>

</details>

</details>

新功能：
- 在 CI 中为每种架构生成带版本号的 macOS .app zip 构件。

改进：
- 在打包前从配置或环境中解析 macOS 应用包名，如有必要则回退到自动发现的应用包名。

CI：
- 将 CI 中的 macOS Tauri 构建限制为应用包目标，并将生成的 .app 打包为 zip 文件，而非 DMG 和 app tarball 输出。
- 从 macOS GitHub Actions 工作流中移除与 DMG 相关的重试、清理、诊断和完整性校验步骤。
- 更新 macOS 构件上传路径，以发布新的 zip 构件。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

更新 macOS CI 工作流，仅构建并发布带版本号的 `.app` ZIP 压缩包，而不再使用基于 DMG 的安装程序。

新特性：
- 在 CI 构建中生成按架构区分、带版本号的 macOS `.app` ZIP 工件。

改进：
- 从配置或环境中解析 macOS 应用包名称，并在需要时自动探测作为回退方式。
- 将 CI 中的 macOS Tauri 构建限制为应用包目标，并将生成的 `.app` 打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流，移除 DMG 专用的重试、清理、诊断和验证步骤，并将工件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

新功能：
- 在 CI 的 macOS 构建中，为每种架构生成带版本号的 macOS `.app` ZIP 构件。

增强：
- 从 Tauri 配置或覆盖项中解析 macOS 应用包名称，并进行规范化处理；在需要时通过回退机制自动发现已构建的 `.app` 应用包。
- 将 CI 中的 macOS Tauri 构建限制为仅构建应用包目标，并使用 `ditto` 将其打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流：移除针对 DMG 的重试、清理、诊断和验证步骤，并将构件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

</details>

</details>

新功能：
- 在 CI 构建中，为每种架构生成带版本号的 macOS .app zip 构件。

改进：
- 在打包时，从配置或环境中解析 macOS 应用包名称，如果未配置则回退到自动发现。

CI：
- 在 CI 中将 macOS Tauri 构建限制为应用包目标，仅对生成的 .app 进行打包，输出为 zip 文件而不是 DMG 和应用 tarball。
- 从 macOS GitHub Actions 工作流中移除与 DMG 相关的重试、清理、诊断和完整性验证步骤。
- 更新 macOS 构件上传路径，以发布新的 zip 构件。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

更新 macOS CI 工作流，仅构建并发布带版本号的 `.app` ZIP 压缩包，而不再使用基于 DMG 的安装程序。

新特性：
- 在 CI 构建中生成按架构区分、带版本号的 macOS `.app` ZIP 工件。

改进：
- 从配置或环境中解析 macOS 应用包名称，并在需要时自动探测作为回退方式。
- 将 CI 中的 macOS Tauri 构建限制为应用包目标，并将生成的 `.app` 打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流，移除 DMG 专用的重试、清理、诊断和验证步骤，并将工件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

新功能：
- 在 CI 的 macOS 构建中，为每种架构生成带版本号的 macOS `.app` ZIP 构件。

增强：
- 从 Tauri 配置或覆盖项中解析 macOS 应用包名称，并进行规范化处理；在需要时通过回退机制自动发现已构建的 `.app` 应用包。
- 将 CI 中的 macOS Tauri 构建限制为仅构建应用包目标，并使用 `ditto` 将其打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流：移除针对 DMG 的重试、清理、诊断和验证步骤，并将构件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

</details>

</details>

</details>

</details>

</details>

</details>

CI：
- 将 macOS 安装程序构建替换为仅针对应用的 Tauri 构建，将打包目标限制为 app。
- 从 macOS 工作流中移除特定于 DMG 的重试、清理、诊断和完整性校验步骤。
- 将构建好的 macOS `.app` 包打成带版本号的 zip 文件，并作为 CI 构件上传，用它替代原来的 DMG 和 app tarball。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

更新 macOS CI 工作流，仅构建并发布带版本号的 `.app` ZIP 压缩包，而不再使用基于 DMG 的安装程序。

新特性：
- 在 CI 构建中生成按架构区分、带版本号的 macOS `.app` ZIP 工件。

改进：
- 从配置或环境中解析 macOS 应用包名称，并在需要时自动探测作为回退方式。
- 将 CI 中的 macOS Tauri 构建限制为应用包目标，并将生成的 `.app` 打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流，移除 DMG 专用的重试、清理、诊断和验证步骤，并将工件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

新功能：
- 在 CI 的 macOS 构建中，为每种架构生成带版本号的 macOS `.app` ZIP 构件。

增强：
- 从 Tauri 配置或覆盖项中解析 macOS 应用包名称，并进行规范化处理；在需要时通过回退机制自动发现已构建的 `.app` 应用包。
- 将 CI 中的 macOS Tauri 构建限制为仅构建应用包目标，并使用 `ditto` 将其打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流：移除针对 DMG 的重试、清理、诊断和验证步骤，并将构件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

</details>

</details>

新功能：
- 在 CI 构建中，为每种架构生成带版本号的 macOS .app zip 构件。

改进：
- 在打包时，从配置或环境中解析 macOS 应用包名称，如果未配置则回退到自动发现。

CI：
- 在 CI 中将 macOS Tauri 构建限制为应用包目标，仅对生成的 .app 进行打包，输出为 zip 文件而不是 DMG 和应用 tarball。
- 从 macOS GitHub Actions 工作流中移除与 DMG 相关的重试、清理、诊断和完整性验证步骤。
- 更新 macOS 构件上传路径，以发布新的 zip 构件。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

更新 macOS CI 工作流，仅构建并发布带版本号的 `.app` ZIP 压缩包，而不再使用基于 DMG 的安装程序。

新特性：
- 在 CI 构建中生成按架构区分、带版本号的 macOS `.app` ZIP 工件。

改进：
- 从配置或环境中解析 macOS 应用包名称，并在需要时自动探测作为回退方式。
- 将 CI 中的 macOS Tauri 构建限制为应用包目标，并将生成的 `.app` 打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流，移除 DMG 专用的重试、清理、诊断和验证步骤，并将工件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

新功能：
- 在 CI 的 macOS 构建中，为每种架构生成带版本号的 macOS `.app` ZIP 构件。

增强：
- 从 Tauri 配置或覆盖项中解析 macOS 应用包名称，并进行规范化处理；在需要时通过回退机制自动发现已构建的 `.app` 应用包。
- 将 CI 中的 macOS Tauri 构建限制为仅构建应用包目标，并使用 `ditto` 将其打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流：移除针对 DMG 的重试、清理、诊断和验证步骤，并将构件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

</details>

</details>

</details>

新功能：
- 在 CI 中为每种架构生成带版本号的 macOS .app zip 构件。

改进：
- 在打包前从配置或环境中解析 macOS 应用包名，如有必要则回退到自动发现的应用包名。

CI：
- 将 CI 中的 macOS Tauri 构建限制为应用包目标，并将生成的 .app 打包为 zip 文件，而非 DMG 和 app tarball 输出。
- 从 macOS GitHub Actions 工作流中移除与 DMG 相关的重试、清理、诊断和完整性校验步骤。
- 更新 macOS 构件上传路径，以发布新的 zip 构件。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

更新 macOS CI 工作流，仅构建并发布带版本号的 `.app` ZIP 压缩包，而不再使用基于 DMG 的安装程序。

新特性：
- 在 CI 构建中生成按架构区分、带版本号的 macOS `.app` ZIP 工件。

改进：
- 从配置或环境中解析 macOS 应用包名称，并在需要时自动探测作为回退方式。
- 将 CI 中的 macOS Tauri 构建限制为应用包目标，并将生成的 `.app` 打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流，移除 DMG 专用的重试、清理、诊断和验证步骤，并将工件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

新功能：
- 在 CI 的 macOS 构建中，为每种架构生成带版本号的 macOS `.app` ZIP 构件。

增强：
- 从 Tauri 配置或覆盖项中解析 macOS 应用包名称，并进行规范化处理；在需要时通过回退机制自动发现已构建的 `.app` 应用包。
- 将 CI 中的 macOS Tauri 构建限制为仅构建应用包目标，并使用 `ditto` 将其打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流：移除针对 DMG 的重试、清理、诊断和验证步骤，并将构件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

</details>

</details>

新功能：
- 在 CI 构建中，为每种架构生成带版本号的 macOS .app zip 构件。

改进：
- 在打包时，从配置或环境中解析 macOS 应用包名称，如果未配置则回退到自动发现。

CI：
- 在 CI 中将 macOS Tauri 构建限制为应用包目标，仅对生成的 .app 进行打包，输出为 zip 文件而不是 DMG 和应用 tarball。
- 从 macOS GitHub Actions 工作流中移除与 DMG 相关的重试、清理、诊断和完整性验证步骤。
- 更新 macOS 构件上传路径，以发布新的 zip 构件。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

更新 macOS CI 工作流，仅构建并发布带版本号的 `.app` ZIP 压缩包，而不再使用基于 DMG 的安装程序。

新特性：
- 在 CI 构建中生成按架构区分、带版本号的 macOS `.app` ZIP 工件。

改进：
- 从配置或环境中解析 macOS 应用包名称，并在需要时自动探测作为回退方式。
- 将 CI 中的 macOS Tauri 构建限制为应用包目标，并将生成的 `.app` 打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流，移除 DMG 专用的重试、清理、诊断和验证步骤，并将工件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

新功能：
- 在 CI 的 macOS 构建中，为每种架构生成带版本号的 macOS `.app` ZIP 构件。

增强：
- 从 Tauri 配置或覆盖项中解析 macOS 应用包名称，并进行规范化处理；在需要时通过回退机制自动发现已构建的 `.app` 应用包。
- 将 CI 中的 macOS Tauri 构建限制为仅构建应用包目标，并使用 `ditto` 将其打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流：移除针对 DMG 的重试、清理、诊断和验证步骤，并将构件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

</details>

</details>

</details>

</details>

新功能：
- 在 CI 中为每种架构生成带版本号的 macOS .app zip 制品。

改进：
- 将 CI 中的 macOS Tauri 构建限制为仅构建应用包目标，并使用 `ditto` 将其打包为 zip 文件。
- 从配置或环境中推断 macOS 应用包名称，以定位并压缩构建好的 .app 应用包。

CI：
- 通过移除与 DMG 相关的重试、清理、诊断和完整性验证步骤，简化 macOS GitHub Actions 工作流程。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

更新 macOS CI 工作流，仅构建并发布带版本号的 `.app` ZIP 压缩包，而不再使用基于 DMG 的安装程序。

新特性：
- 在 CI 构建中生成按架构区分、带版本号的 macOS `.app` ZIP 工件。

改进：
- 从配置或环境中解析 macOS 应用包名称，并在需要时自动探测作为回退方式。
- 将 CI 中的 macOS Tauri 构建限制为应用包目标，并将生成的 `.app` 打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流，移除 DMG 专用的重试、清理、诊断和验证步骤，并将工件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

新功能：
- 在 CI 的 macOS 构建中，为每种架构生成带版本号的 macOS `.app` ZIP 构件。

增强：
- 从 Tauri 配置或覆盖项中解析 macOS 应用包名称，并进行规范化处理；在需要时通过回退机制自动发现已构建的 `.app` 应用包。
- 将 CI 中的 macOS Tauri 构建限制为仅构建应用包目标，并使用 `ditto` 将其打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流：移除针对 DMG 的重试、清理、诊断和验证步骤，并将构件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

</details>

</details>

新功能：
- 在 CI 构建中，为每种架构生成带版本号的 macOS .app zip 构件。

改进：
- 在打包时，从配置或环境中解析 macOS 应用包名称，如果未配置则回退到自动发现。

CI：
- 在 CI 中将 macOS Tauri 构建限制为应用包目标，仅对生成的 .app 进行打包，输出为 zip 文件而不是 DMG 和应用 tarball。
- 从 macOS GitHub Actions 工作流中移除与 DMG 相关的重试、清理、诊断和完整性验证步骤。
- 更新 macOS 构件上传路径，以发布新的 zip 构件。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

更新 macOS CI 工作流，仅构建并发布带版本号的 `.app` ZIP 压缩包，而不再使用基于 DMG 的安装程序。

新特性：
- 在 CI 构建中生成按架构区分、带版本号的 macOS `.app` ZIP 工件。

改进：
- 从配置或环境中解析 macOS 应用包名称，并在需要时自动探测作为回退方式。
- 将 CI 中的 macOS Tauri 构建限制为应用包目标，并将生成的 `.app` 打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流，移除 DMG 专用的重试、清理、诊断和验证步骤，并将工件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

新功能：
- 在 CI 的 macOS 构建中，为每种架构生成带版本号的 macOS `.app` ZIP 构件。

增强：
- 从 Tauri 配置或覆盖项中解析 macOS 应用包名称，并进行规范化处理；在需要时通过回退机制自动发现已构建的 `.app` 应用包。
- 将 CI 中的 macOS Tauri 构建限制为仅构建应用包目标，并使用 `ditto` 将其打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流：移除针对 DMG 的重试、清理、诊断和验证步骤，并将构件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

</details>

</details>

</details>

新功能：
- 在 CI 中为每种架构生成带版本号的 macOS .app zip 构件。

改进：
- 在打包前从配置或环境中解析 macOS 应用包名，如有必要则回退到自动发现的应用包名。

CI：
- 将 CI 中的 macOS Tauri 构建限制为应用包目标，并将生成的 .app 打包为 zip 文件，而非 DMG 和 app tarball 输出。
- 从 macOS GitHub Actions 工作流中移除与 DMG 相关的重试、清理、诊断和完整性校验步骤。
- 更新 macOS 构件上传路径，以发布新的 zip 构件。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

更新 macOS CI 工作流，仅构建并发布带版本号的 `.app` ZIP 压缩包，而不再使用基于 DMG 的安装程序。

新特性：
- 在 CI 构建中生成按架构区分、带版本号的 macOS `.app` ZIP 工件。

改进：
- 从配置或环境中解析 macOS 应用包名称，并在需要时自动探测作为回退方式。
- 将 CI 中的 macOS Tauri 构建限制为应用包目标，并将生成的 `.app` 打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流，移除 DMG 专用的重试、清理、诊断和验证步骤，并将工件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

新功能：
- 在 CI 的 macOS 构建中，为每种架构生成带版本号的 macOS `.app` ZIP 构件。

增强：
- 从 Tauri 配置或覆盖项中解析 macOS 应用包名称，并进行规范化处理；在需要时通过回退机制自动发现已构建的 `.app` 应用包。
- 将 CI 中的 macOS Tauri 构建限制为仅构建应用包目标，并使用 `ditto` 将其打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流：移除针对 DMG 的重试、清理、诊断和验证步骤，并将构件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

</details>

</details>

新功能：
- 在 CI 构建中，为每种架构生成带版本号的 macOS .app zip 构件。

改进：
- 在打包时，从配置或环境中解析 macOS 应用包名称，如果未配置则回退到自动发现。

CI：
- 在 CI 中将 macOS Tauri 构建限制为应用包目标，仅对生成的 .app 进行打包，输出为 zip 文件而不是 DMG 和应用 tarball。
- 从 macOS GitHub Actions 工作流中移除与 DMG 相关的重试、清理、诊断和完整性验证步骤。
- 更新 macOS 构件上传路径，以发布新的 zip 构件。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

更新 macOS CI 工作流，仅构建并发布带版本号的 `.app` ZIP 压缩包，而不再使用基于 DMG 的安装程序。

新特性：
- 在 CI 构建中生成按架构区分、带版本号的 macOS `.app` ZIP 工件。

改进：
- 从配置或环境中解析 macOS 应用包名称，并在需要时自动探测作为回退方式。
- 将 CI 中的 macOS Tauri 构建限制为应用包目标，并将生成的 `.app` 打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流，移除 DMG 专用的重试、清理、诊断和验证步骤，并将工件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

新功能：
- 在 CI 的 macOS 构建中，为每种架构生成带版本号的 macOS `.app` ZIP 构件。

增强：
- 从 Tauri 配置或覆盖项中解析 macOS 应用包名称，并进行规范化处理；在需要时通过回退机制自动发现已构建的 `.app` 应用包。
- 将 CI 中的 macOS Tauri 构建限制为仅构建应用包目标，并使用 `ditto` 将其打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流：移除针对 DMG 的重试、清理、诊断和验证步骤，并将构件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

</details>

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

更新 macOS CI 工作流，仅构建并发布带版本号的 `.app` ZIP 压缩包，而不再使用基于 DMG 的安装程序。

新特性：
- 在 CI 构建中生成按架构区分、带版本号的 macOS `.app` ZIP 工件。

改进：
- 从配置或环境中解析 macOS 应用包名称，并在需要时自动探测作为回退方式。
- 将 CI 中的 macOS Tauri 构建限制为应用包目标，并将生成的 `.app` 打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流，移除 DMG 专用的重试、清理、诊断和验证步骤，并将工件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

新功能：
- 在 CI 的 macOS 构建中，为每种架构生成带版本号的 macOS `.app` ZIP 构件。

增强：
- 从 Tauri 配置或覆盖项中解析 macOS 应用包名称，并进行规范化处理；在需要时通过回退机制自动发现已构建的 `.app` 应用包。
- 将 CI 中的 macOS Tauri 构建限制为仅构建应用包目标，并使用 `ditto` 将其打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流：移除针对 DMG 的重试、清理、诊断和验证步骤，并将构件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

</details>

</details>

新功能：
- 在 CI 构建中，为每种架构生成带版本号的 macOS .app zip 构件。

改进：
- 在打包时，从配置或环境中解析 macOS 应用包名称，如果未配置则回退到自动发现。

CI：
- 在 CI 中将 macOS Tauri 构建限制为应用包目标，仅对生成的 .app 进行打包，输出为 zip 文件而不是 DMG 和应用 tarball。
- 从 macOS GitHub Actions 工作流中移除与 DMG 相关的重试、清理、诊断和完整性验证步骤。
- 更新 macOS 构件上传路径，以发布新的 zip 构件。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

更新 macOS CI 工作流，仅构建并发布带版本号的 `.app` ZIP 压缩包，而不再使用基于 DMG 的安装程序。

新特性：
- 在 CI 构建中生成按架构区分、带版本号的 macOS `.app` ZIP 工件。

改进：
- 从配置或环境中解析 macOS 应用包名称，并在需要时自动探测作为回退方式。
- 将 CI 中的 macOS Tauri 构建限制为应用包目标，并将生成的 `.app` 打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流，移除 DMG 专用的重试、清理、诊断和验证步骤，并将工件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

新功能：
- 在 CI 的 macOS 构建中，为每种架构生成带版本号的 macOS `.app` ZIP 构件。

增强：
- 从 Tauri 配置或覆盖项中解析 macOS 应用包名称，并进行规范化处理；在需要时通过回退机制自动发现已构建的 `.app` 应用包。
- 将 CI 中的 macOS Tauri 构建限制为仅构建应用包目标，并使用 `ditto` 将其打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流：移除针对 DMG 的重试、清理、诊断和验证步骤，并将构件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

</details>

</details>

</details>

新功能：
- 在 CI 中为每种架构生成带版本号的 macOS .app zip 构件。

改进：
- 在打包前从配置或环境中解析 macOS 应用包名，如有必要则回退到自动发现的应用包名。

CI：
- 将 CI 中的 macOS Tauri 构建限制为应用包目标，并将生成的 .app 打包为 zip 文件，而非 DMG 和 app tarball 输出。
- 从 macOS GitHub Actions 工作流中移除与 DMG 相关的重试、清理、诊断和完整性校验步骤。
- 更新 macOS 构件上传路径，以发布新的 zip 构件。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

更新 macOS CI 工作流，仅构建并发布带版本号的 `.app` ZIP 压缩包，而不再使用基于 DMG 的安装程序。

新特性：
- 在 CI 构建中生成按架构区分、带版本号的 macOS `.app` ZIP 工件。

改进：
- 从配置或环境中解析 macOS 应用包名称，并在需要时自动探测作为回退方式。
- 将 CI 中的 macOS Tauri 构建限制为应用包目标，并将生成的 `.app` 打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流，移除 DMG 专用的重试、清理、诊断和验证步骤，并将工件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

新功能：
- 在 CI 的 macOS 构建中，为每种架构生成带版本号的 macOS `.app` ZIP 构件。

增强：
- 从 Tauri 配置或覆盖项中解析 macOS 应用包名称，并进行规范化处理；在需要时通过回退机制自动发现已构建的 `.app` 应用包。
- 将 CI 中的 macOS Tauri 构建限制为仅构建应用包目标，并使用 `ditto` 将其打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流：移除针对 DMG 的重试、清理、诊断和验证步骤，并将构件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

</details>

</details>

新功能：
- 在 CI 构建中，为每种架构生成带版本号的 macOS .app zip 构件。

改进：
- 在打包时，从配置或环境中解析 macOS 应用包名称，如果未配置则回退到自动发现。

CI：
- 在 CI 中将 macOS Tauri 构建限制为应用包目标，仅对生成的 .app 进行打包，输出为 zip 文件而不是 DMG 和应用 tarball。
- 从 macOS GitHub Actions 工作流中移除与 DMG 相关的重试、清理、诊断和完整性验证步骤。
- 更新 macOS 构件上传路径，以发布新的 zip 构件。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

更新 macOS CI 工作流，仅构建并发布带版本号的 `.app` ZIP 压缩包，而不再使用基于 DMG 的安装程序。

新特性：
- 在 CI 构建中生成按架构区分、带版本号的 macOS `.app` ZIP 工件。

改进：
- 从配置或环境中解析 macOS 应用包名称，并在需要时自动探测作为回退方式。
- 将 CI 中的 macOS Tauri 构建限制为应用包目标，并将生成的 `.app` 打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流，移除 DMG 专用的重试、清理、诊断和验证步骤，并将工件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

新功能：
- 在 CI 的 macOS 构建中，为每种架构生成带版本号的 macOS `.app` ZIP 构件。

增强：
- 从 Tauri 配置或覆盖项中解析 macOS 应用包名称，并进行规范化处理；在需要时通过回退机制自动发现已构建的 `.app` 应用包。
- 将 CI 中的 macOS Tauri 构建限制为仅构建应用包目标，并使用 `ditto` 将其打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流：移除针对 DMG 的重试、清理、诊断和验证步骤，并将构件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

</details>

</details>

</details>

</details>

新功能：
- 在 CI 中为每种架构生成带版本号的 macOS .app zip 制品。

改进：
- 将 CI 中的 macOS Tauri 构建限制为仅构建应用包目标，并使用 `ditto` 将其打包为 zip 文件。
- 从配置或环境中推断 macOS 应用包名称，以定位并压缩构建好的 .app 应用包。

CI：
- 通过移除与 DMG 相关的重试、清理、诊断和完整性验证步骤，简化 macOS GitHub Actions 工作流程。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

更新 macOS CI 工作流，仅构建并发布带版本号的 `.app` ZIP 压缩包，而不再使用基于 DMG 的安装程序。

新特性：
- 在 CI 构建中生成按架构区分、带版本号的 macOS `.app` ZIP 工件。

改进：
- 从配置或环境中解析 macOS 应用包名称，并在需要时自动探测作为回退方式。
- 将 CI 中的 macOS Tauri 构建限制为应用包目标，并将生成的 `.app` 打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流，移除 DMG 专用的重试、清理、诊断和验证步骤，并将工件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

新功能：
- 在 CI 的 macOS 构建中，为每种架构生成带版本号的 macOS `.app` ZIP 构件。

增强：
- 从 Tauri 配置或覆盖项中解析 macOS 应用包名称，并进行规范化处理；在需要时通过回退机制自动发现已构建的 `.app` 应用包。
- 将 CI 中的 macOS Tauri 构建限制为仅构建应用包目标，并使用 `ditto` 将其打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流：移除针对 DMG 的重试、清理、诊断和验证步骤，并将构件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

</details>

</details>

新功能：
- 在 CI 构建中，为每种架构生成带版本号的 macOS .app zip 构件。

改进：
- 在打包时，从配置或环境中解析 macOS 应用包名称，如果未配置则回退到自动发现。

CI：
- 在 CI 中将 macOS Tauri 构建限制为应用包目标，仅对生成的 .app 进行打包，输出为 zip 文件而不是 DMG 和应用 tarball。
- 从 macOS GitHub Actions 工作流中移除与 DMG 相关的重试、清理、诊断和完整性验证步骤。
- 更新 macOS 构件上传路径，以发布新的 zip 构件。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

更新 macOS CI 工作流，仅构建并发布带版本号的 `.app` ZIP 压缩包，而不再使用基于 DMG 的安装程序。

新特性：
- 在 CI 构建中生成按架构区分、带版本号的 macOS `.app` ZIP 工件。

改进：
- 从配置或环境中解析 macOS 应用包名称，并在需要时自动探测作为回退方式。
- 将 CI 中的 macOS Tauri 构建限制为应用包目标，并将生成的 `.app` 打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流，移除 DMG 专用的重试、清理、诊断和验证步骤，并将工件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

新功能：
- 在 CI 的 macOS 构建中，为每种架构生成带版本号的 macOS `.app` ZIP 构件。

增强：
- 从 Tauri 配置或覆盖项中解析 macOS 应用包名称，并进行规范化处理；在需要时通过回退机制自动发现已构建的 `.app` 应用包。
- 将 CI 中的 macOS Tauri 构建限制为仅构建应用包目标，并使用 `ditto` 将其打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流：移除针对 DMG 的重试、清理、诊断和验证步骤，并将构件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

</details>

</details>

</details>

新功能：
- 在 CI 中为每种架构生成带版本号的 macOS .app zip 构件。

改进：
- 在打包前从配置或环境中解析 macOS 应用包名，如有必要则回退到自动发现的应用包名。

CI：
- 将 CI 中的 macOS Tauri 构建限制为应用包目标，并将生成的 .app 打包为 zip 文件，而非 DMG 和 app tarball 输出。
- 从 macOS GitHub Actions 工作流中移除与 DMG 相关的重试、清理、诊断和完整性校验步骤。
- 更新 macOS 构件上传路径，以发布新的 zip 构件。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

更新 macOS CI 工作流，仅构建并发布带版本号的 `.app` ZIP 压缩包，而不再使用基于 DMG 的安装程序。

新特性：
- 在 CI 构建中生成按架构区分、带版本号的 macOS `.app` ZIP 工件。

改进：
- 从配置或环境中解析 macOS 应用包名称，并在需要时自动探测作为回退方式。
- 将 CI 中的 macOS Tauri 构建限制为应用包目标，并将生成的 `.app` 打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流，移除 DMG 专用的重试、清理、诊断和验证步骤，并将工件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

新功能：
- 在 CI 的 macOS 构建中，为每种架构生成带版本号的 macOS `.app` ZIP 构件。

增强：
- 从 Tauri 配置或覆盖项中解析 macOS 应用包名称，并进行规范化处理；在需要时通过回退机制自动发现已构建的 `.app` 应用包。
- 将 CI 中的 macOS Tauri 构建限制为仅构建应用包目标，并使用 `ditto` 将其打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流：移除针对 DMG 的重试、清理、诊断和验证步骤，并将构件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

</details>

</details>

新功能：
- 在 CI 构建中，为每种架构生成带版本号的 macOS .app zip 构件。

改进：
- 在打包时，从配置或环境中解析 macOS 应用包名称，如果未配置则回退到自动发现。

CI：
- 在 CI 中将 macOS Tauri 构建限制为应用包目标，仅对生成的 .app 进行打包，输出为 zip 文件而不是 DMG 和应用 tarball。
- 从 macOS GitHub Actions 工作流中移除与 DMG 相关的重试、清理、诊断和完整性验证步骤。
- 更新 macOS 构件上传路径，以发布新的 zip 构件。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

更新 macOS CI 工作流，仅构建并发布带版本号的 `.app` ZIP 压缩包，而不再使用基于 DMG 的安装程序。

新特性：
- 在 CI 构建中生成按架构区分、带版本号的 macOS `.app` ZIP 工件。

改进：
- 从配置或环境中解析 macOS 应用包名称，并在需要时自动探测作为回退方式。
- 将 CI 中的 macOS Tauri 构建限制为应用包目标，并将生成的 `.app` 打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流，移除 DMG 专用的重试、清理、诊断和验证步骤，并将工件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

新功能：
- 在 CI 的 macOS 构建中，为每种架构生成带版本号的 macOS `.app` ZIP 构件。

增强：
- 从 Tauri 配置或覆盖项中解析 macOS 应用包名称，并进行规范化处理；在需要时通过回退机制自动发现已构建的 `.app` 应用包。
- 将 CI 中的 macOS Tauri 构建限制为仅构建应用包目标，并使用 `ditto` 将其打包为 ZIP 文件。

CI：
- 简化 macOS GitHub Actions 工作流：移除针对 DMG 的重试、清理、诊断和验证步骤，并将构件上传路径更新为新的 ZIP 输出。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

更新 macOS 桌面端 CI 工作流程，只构建 .app 包，将其打包为 zip 构件，并移除基于 DMG 的打包及相关步骤。

新功能：
- 在 CI 构建中生成带版本号、按架构划分的 macOS .app zip 构件。

增强内容：
- 引入一个 Python 辅助脚本，从配置或环境中解析并规范化 macOS 应用包名称，并提供回退机制。
- 调整 macOS 构建的重试逻辑，以针对短暂的 cargo/网络故障，并支持配置重试次数和退避(backoff)设置。

CI：
- 简化 macOS GitHub Actions 工作流程，移除与 DMG 相关的清理、诊断、验证和安装程序上传路径，改为使用 .app zip 打包和上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update macOS desktop CI workflow to build only the .app bundle, package it as a zip artifact, and drop DMG-based packaging and related steps.

New Features:
- Produce versioned, per-architecture macOS .app zip artifacts from CI builds.

Enhancements:
- Introduce a Python helper script to resolve and normalize the macOS app bundle name from configuration or environment with a fallback mechanism.
- Adjust macOS build retry logic to target transient cargo/network failures with configurable attempt and backoff settings.

CI:
- Simplify the macOS GitHub Actions workflow by removing DMG-specific cleanup, diagnostics, verification, and installer upload paths, replacing them with .app zip packaging and upload.

</details>

</details>

</details>

</details>

</details>

</details>

</details>

</details>