### PR TITLE
fix(ci): avoid false skip of release job

### DIFF
--- a/.github/workflows/build-desktop-tauri.yml
+++ b/.github/workflows/build-desktop-tauri.yml
@@ -394,7 +394,9 @@ jobs:
 
   release:
     name: Publish GitHub Release
-    if: ${{ needs.resolve_build_context.outputs.should_build == 'true' && needs.resolve_build_context.outputs.publish_release == 'true' }}
+    # Gate on release_tag instead of raw publish_release output so downstream
+    # release decision does not depend on strict string equality edge-cases.
+    if: ${{ needs.resolve_build_context.outputs.should_build == 'true' && needs.resolve_build_context.outputs.release_tag != '' }}
     needs:
       - resolve_build_context
       - build-linux


### PR DESCRIPTION
## 背景
在 run `22249855873`（attempt 1）中，`resolve_build_context` 日志显示：
- `should_build=true`
- `publish_release=true`

且各平台构建全部成功，但 `Publish GitHub Release` 仍被跳过。

## 问题分析
`release` job 的条件使用了严格字符串判断：

```yaml
needs.resolve_build_context.outputs.publish_release == 'true'
```

这类判断对输出格式非常敏感（例如隐藏字符/边界格式差异），会出现日志看似为 `true`，但条件仍未命中的情况。

## 修改内容
将 `release` job 的触发条件从：

```yaml
needs.resolve_build_context.outputs.should_build == 'true' && needs.resolve_build_context.outputs.publish_release == 'true'
```

调整为：

```yaml
needs.resolve_build_context.outputs.should_build == 'true' && needs.resolve_build_context.outputs.release_tag != ''
```

## 变更理由
`release_tag` 是解析阶段的最终发布意图产物，语义更直接、稳定性更高：
- 不应发布时：`release_tag` 为空
- 应发布时：`release_tag` 非空

## 影响范围
仅影响 release job 的触发判定，不影响各平台构建流程本身。

## 验证建议
手动触发一次：
- `build_mode=nightly`
- `publish_release=true`

预期：`release` job 不再被误跳过，并正确创建/更新 nightly release。
