### PR TITLE
chore(template): normalize desktop version examples to v-prefix

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -38,8 +38,8 @@ body:
   - type: input
     attributes:
       label: Desktop version / 桌面端版本
-      description: e.g. 4.17.6
-      placeholder: 4.x.x
+      description: e.g. v4.17.6
+      placeholder: v4.x.x
     validations:
       required: true
 
@@ -103,4 +103,3 @@ body:
       options:
         - label: I agree to follow the project's Code of Conduct. / 我同意遵守项目行为准则。
           required: true
-


### PR DESCRIPTION
## Summary
- 将 Bug Report 模板中的桌面端版本示例统一为 `v` 前缀
- `description`: `e.g. v4.17.6`
- `placeholder`: `v4.x.x`

## Why
保持 issue 模板中的版本填写风格一致，减少用户提交时的格式歧义。

## Scope
- `.github/ISSUE_TEMPLATE/bug-report.yml`

## Summary by Sourcery

文档：
- 更新错误报告问题模板中桌面版本的描述和占位符，使其使用带有 `v` 前缀的版本示例。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Update bug report issue template desktop version description and placeholder to use v-prefixed version examples.

</details>