### PR TITLE
ci(release): auto-demote previous prerelease marker

### DIFF
--- a/.github/workflows/build-desktop-tauri.yml
+++ b/.github/workflows/build-desktop-tauri.yml
@@ -475,10 +475,12 @@ jobs:
           set -euo pipefail
 
           previous_prerelease_id="$(
-            gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
-              | jq -r --arg current_tag "${CURRENT_RELEASE_TAG}" '
-                  [.[] | select(.prerelease == true and .draft == false and .tag_name != $current_tag)]
-                  | sort_by(.created_at)
+            gh api --paginate "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
+              | jq -s -r --arg current_tag "${CURRENT_RELEASE_TAG}" '
+                  map(if type == "array" then . else [] end)
+                  | add
+                  | map(select(.prerelease == true and .draft == false and .tag_name != $current_tag))
+                  | sort_by(.published_at // .created_at)
                   | reverse
                   | .[0].id // empty
                 '


### PR DESCRIPTION
## Summary
- add a release post-step for prerelease runs to automatically demote the previous prerelease marker
- keep current release behavior unchanged; only prior prerelease entries are updated
- no-op safely when there is no prior prerelease

## Details
- step runs only when release_prerelease == true
- queries releases via gh api and finds the latest prerelease excluding the current tag
- patches that previous release with prerelease=false and make_latest=false

## Validation
- local YAML parse check passed

## 由 Sourcery 提供的摘要

CI：
- 在桌面端 Tauri 工作流中添加一个发布后步骤：当新的预发布版本发布时，查找并降级之前最新的预发布版本；如果不存在则安全地不执行任何操作。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Add a post-release step in the desktop Tauri workflow to find and demote the latest prior prerelease release when a new prerelease is published, safely no-oping if none exist.

</details>