### PR TITLE
ci: fix Windows installer bundle build invocation

### DIFF
--- a/scripts/ci/build-windows-installers.sh
+++ b/scripts/ci/build-windows-installers.sh
@@ -10,6 +10,14 @@ if ! command -v cargo >/dev/null 2>&1; then
   exit 1
 fi
 
+if ! (
+  cd "${root_dir}"
+  cargo tauri -V >/dev/null 2>&1
+); then
+  echo "Tauri CLI is required to build Windows installers (expected: cargo tauri)." >&2
+  exit 1
+fi
+
 bundles="${ASTRBOT_WINDOWS_BUNDLES:-nsis,nsis-web}"
 if [ -z "${bundles}" ]; then
   echo "ASTRBOT_WINDOWS_BUNDLES is empty. Expected a comma-separated bundle list." >&2


### PR DESCRIPTION
## Summary
- fix Windows CI installer build command to pass bundle selection to Tauri correctly
- replace `pnpm run build -- --bundles ...` with `cargo tauri build --bundles ...`
- align tool availability check with actual command usage (`cargo`)

## Root Cause
The previous command path routed `--bundles` through `pnpm run build` (`cargo tauri build` script). The extra `-- --bundles ...` ended up being forwarded incorrectly and finally hit `cargo build`, causing:

```
error: unexpected argument '--bundles' found
```

## Validation
- `bash -n scripts/ci/build-windows-installers.sh`

## Notes
- this PR is recreated from latest `upstream/main` to avoid the large unrelated diff seen in the previous branch/PR.

## 由 Sourcery 提供的摘要

CI：
- 更新 Windows 安装程序构建脚本，将依赖从 pnpm 改为 cargo，并使用所选的 bundle 调用 `cargo tauri build`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI：
- 更新 Windows 安装程序的 CI 脚本，使其依赖基于 Cargo 的 Tauri CLI，而不是 pnpm，并将打包选项直接传递给 `cargo tauri build`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Update Windows installer CI script to depend on the Cargo-based Tauri CLI instead of pnpm and to pass bundle options directly to `cargo tauri build`.

</details>

</details>