### PR TITLE
ci: fix Windows installer bundle build in CI

### DIFF
--- a/.github/workflows/build-desktop-tauri.yml
+++ b/.github/workflows/build-desktop-tauri.yml
@@ -378,9 +378,8 @@ jobs:
     name: windows-${{ matrix.arch }}
     runs-on: ${{ matrix.runner }}
     env:
-      ASTRBOT_WINDOWS_BUNDLES: nsis,nsis-web
+      ASTRBOT_WINDOWS_BUNDLES: nsis
       WINDOWS_INSTALLER_EXE_GLOBS: |
-        src-tauri/target/release/bundle/nsis-web/*.exe
         src-tauri/target/release/bundle/nsis/*.exe
     strategy:
       fail-fast: false
@@ -505,7 +504,7 @@ jobs:
             - Source: `${{ needs.resolve_build_context.outputs.source_git_url }}`
             - Ref: `${{ needs.resolve_build_context.outputs.source_git_ref }}`
             - Mode: `${{ needs.resolve_build_context.outputs.build_mode }}`
-            - Windows tip: prefer `nsis-web` installer for smaller downloads and faster install startup.
+            - Windows installer format: `nsis`.
           generate_release_notes: true
           prerelease: ${{ needs.resolve_build_context.outputs.release_prerelease == 'true' }}
           make_latest: ${{ needs.resolve_build_context.outputs.release_prerelease != 'true' }}

--- a/scripts/ci/build-windows-installers.sh
+++ b/scripts/ci/build-windows-installers.sh
@@ -18,7 +18,7 @@ if ! (
   exit 1
 fi
 
-bundles="${ASTRBOT_WINDOWS_BUNDLES:-nsis,nsis-web}"
+bundles="${ASTRBOT_WINDOWS_BUNDLES:-nsis}"
 if [ -z "${bundles}" ]; then
   echo "ASTRBOT_WINDOWS_BUNDLES is empty. Expected a comma-separated bundle list." >&2
   exit 1


### PR DESCRIPTION
## Summary
- fix Windows CI installer build invocation to pass bundle selection directly to Tauri CLI
- add explicit preflight check for Tauri CLI availability (`cargo tauri -V`)
- align Windows bundle config with current Tauri support by using `nsis` only
- update Windows installer artifact glob and release note line accordingly

## Why
Recent Windows CI runs failed with:

```
error: invalid value 'nsis-web' for '--bundles [<BUNDLES>...]'
[possible values: msi, nsis]
```

and earlier with forwarded args hitting `cargo build` unexpectedly.

This PR keeps the workflow on supported bundle values and makes failures clearer when Tauri CLI is missing.

## Validation
- `bash -n scripts/ci/build-windows-installers.sh`

## Summary by Sourcery

通过统一打包配置并直接使用 Tauri CLI，修复 CI 中的 Windows Tauri 安装程序打包构建问题。

Bug 修复：
- 更正 Windows 安装程序构建调用方式，使用带有显式打包选项的 `cargo tauri build`。
- 在 Windows CI 中禁止使用不受支持的 `nsis-web` 打包方式，将默认值限制为受支持的 `nsis` 打包方式，并更新构建产物的匹配规则（globs）。
- 当 Windows 安装程序构建所需工具（`cargo` 和 Tauri CLI）不可用时，快速失败并给出清晰的错误信息。

CI：
- 更新 Windows CI 工作流环境与构建产物模式，使其与受支持的 `nsis` 打包方式保持一致，并在发行说明中反映这些更改。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix Windows Tauri installer bundle builds in CI by aligning bundle configuration and using the Tauri CLI directly.

Bug Fixes:
- Correct Windows installer build invocation to call `cargo tauri build` with explicit bundle selection.
- Prevent unsupported `nsis-web` bundle usage in Windows CI by restricting defaults to the supported `nsis` bundle and updating artifact globs.
- Fail fast with clear messaging when required tools (`cargo` and Tauri CLI) are not available for Windows installer builds.

CI:
- Update Windows CI workflow environment and artifact patterns to match the supported `nsis` bundle and reflect this in release notes.

</details>