### PR TITLE
ci: restore nightly prerelease demotion step

### DIFF
--- a/.github/workflows/build-desktop-tauri.yml
+++ b/.github/workflows/build-desktop-tauri.yml
@@ -523,8 +523,9 @@ jobs:
           previous_prerelease_id="$(
             gh api --paginate "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
               | jq -s -r --arg current_tag "${CURRENT_RELEASE_TAG}" '
-                  map(if type == "array" then . else [] end)
-                  | add
+                  # gh --paginate emits one JSON value per page; keep array pages and flatten.
+                  map(select(type == "array"))
+                  | flatten
                   | map(select(.prerelease == true and .draft == false and .tag_name != $current_tag))
                   | sort_by(.published_at // .created_at)
                   | reverse


### PR DESCRIPTION
## Summary\n- restore the nightly-only step that demotes the previous prerelease after publishing the new nightly release\n- keep release behavior unchanged for non-prerelease builds\n\n## Why\n- without this step, older nightly releases can remain marked as prerelease unexpectedly\n

## Summary by Sourcery

CI：
- 添加一个仅在 nightly 构建中运行的工作流步骤：在发布新的 nightly 版本后，找到最近的上一个预发布版本，并将其从预发布/最新状态中移除（降级）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Add a nightly-only workflow step that finds the most recent prior prerelease and demotes it from prerelease/latest status after a new nightly is published.

</details>