### PR TITLE
ci(artifacts): unify cross-platform release asset naming

### DIFF
--- a/scripts/ci/normalize-release-artifact-filenames.py
+++ b/scripts/ci/normalize-release-artifact-filenames.py
@@ -27,7 +27,11 @@ LOCALE_PATTERN = r"[A-Za-z0-9-]+"
 LINUX_ARTIFACT_STEM_PATTERN = re.compile(
     rf"^AstrBot_(?P<version>{VERSION_PATTERN})_(?:linux_)?(?P<arch>{ARCH_PATTERN})$"
 )
-WINDOWS_ARTIFACT_STEM_PATTERN = (
+LINUX_CANONICAL_RULE: tuple[re.Pattern[str], str] = (
+    LINUX_ARTIFACT_STEM_PATTERN,
+    "AstrBot_{version}_linux_{arch}",
+)
+WINDOWS_ARTIFACT_STEM_PATTERN_FRAGMENT = (
     rf"^AstrBot_(?P<version>{VERSION_PATTERN})_(?:windows_)?(?P<arch>{ARCH_PATTERN})"
 )
 
@@ -39,21 +43,15 @@ CANONICALIZE_RULES: dict[str, tuple[tuple[re.Pattern[str], str], ...]] = {
             ),
             "AstrBot_{version}_linux_{arch}",
         ),
-        (
-            LINUX_ARTIFACT_STEM_PATTERN,
-            "AstrBot_{version}_linux_{arch}",
-        ),
+        LINUX_CANONICAL_RULE,
     ),
     ".deb": (
-        (
-            LINUX_ARTIFACT_STEM_PATTERN,
-            "AstrBot_{version}_linux_{arch}",
-        ),
+        LINUX_CANONICAL_RULE,
     ),
     ".exe": (
         (
             re.compile(
-                rf"{WINDOWS_ARTIFACT_STEM_PATTERN}(?:-setup|_setup)$"
+                rf"{WINDOWS_ARTIFACT_STEM_PATTERN_FRAGMENT}(?:-setup|_setup)$"
             ),
             "AstrBot_{version}_windows_{arch}_setup",
         ),
@@ -61,7 +59,7 @@ CANONICALIZE_RULES: dict[str, tuple[tuple[re.Pattern[str], str], ...]] = {
     ".msi": (
         (
             re.compile(
-                rf"{WINDOWS_ARTIFACT_STEM_PATTERN}_(?P<locale>{LOCALE_PATTERN})$"
+                rf"{WINDOWS_ARTIFACT_STEM_PATTERN_FRAGMENT}_(?P<locale>{LOCALE_PATTERN})$"
             ),
             "AstrBot_{version}_windows_{arch}_{locale}",
         ),


### PR DESCRIPTION
## Summary
- unify release/prerelease asset naming across Linux/Windows/macOS
- ensure generated filenames consistently include platform segment (`linux`/`windows`/`macos`)
- keep nightly suffix behavior unchanged (`_nightly_<sha8>`)

## Changes
- `scripts/ci/normalize-release-artifact-filenames.py`
  - `.deb` / `.rpm` now normalize to `AstrBot_<version>_linux_<arch>`
  - `.exe` / `.msi` now normalize to `AstrBot_<version>_windows_<arch>...`
  - `.zip` remains `AstrBot_<version>_macos_<arch>`

## Resulting naming convention
- Linux: `AstrBot_<version>_linux_<arch>.deb/.rpm`
- Windows: `AstrBot_<version>_windows_<arch>_setup.exe`
- macOS: `AstrBot_<version>_macos_<arch>.zip`
- Nightly: append `_nightly_<sha8>` before extension

## Validation
- local dry-run of normalization script on representative artifacts
- verified nightly suffix still applies correctly after normalization

## 由 Sourcery 提供的摘要

统一各平台的发行制品文件名规范化方式，在生成的名称中包含明确的平台段。

构建：
- 标准化 Linux `.deb`/`.rpm` 文件名，在规范名称中包含 `linux` 平台段。
- 标准化 Windows `.exe`/`.msi` 文件名，使用更新的匹配模式，在规范名称中包含 `windows` 平台段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在各平台统一发行构件文件名的规范化方式，确保生成的构件始终包含明确的平台标识段。

Build:
- 标准化 Linux `.deb` / `.rpm` 构件名称，采用 `AstrBot_<version>_linux_<arch>` 命名约定，同时仍然兼容旧有命名模式。
- 标准化 Windows `.exe` / `.msi` 构件名称，采用 `AstrBot_<version>_windows_<arch>...` 命名约定，同时保留对早期命名方案的兼容性。

Chores:
- 为 Linux 和 Windows 构件前缀引入共享的正则表达式模式，以同时支持旧版和规范化的文件名格式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify release artifact filename normalization across platforms so generated assets consistently include an explicit platform segment.

Build:
- Standardize Linux .deb/.rpm artifact names to use the `AstrBot_<version>_linux_<arch>` convention while still accepting legacy patterns.
- Standardize Windows .exe/.msi artifact names to use `AstrBot_<version>_windows_<arch>...` conventions while preserving compatibility with earlier naming schemes.

Chores:
- Introduce shared regex patterns for Linux and Windows artifact stems to handle both legacy and canonical filename formats.

</details>

Build：
- 规范 Linux `.deb`/`.rpm` 制品的命名，使其在文件名中包含显式的 `linux` 段。
- 规范 Windows `.exe`/`.msi` 制品的命名，使其在文件名中包含显式的 `windows` 段，同时仍然匹配旧版命名模式。

Chores：
- 引入共享的正则表达式规则，用于同时处理 Linux 和 Windows 的旧版与规范版制品名称前缀。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在各平台统一发行构件文件名的规范化方式，确保生成的构件始终包含明确的平台标识段。

Build:
- 标准化 Linux `.deb` / `.rpm` 构件名称，采用 `AstrBot_<version>_linux_<arch>` 命名约定，同时仍然兼容旧有命名模式。
- 标准化 Windows `.exe` / `.msi` 构件名称，采用 `AstrBot_<version>_windows_<arch>...` 命名约定，同时保留对早期命名方案的兼容性。

Chores:
- 为 Linux 和 Windows 构件前缀引入共享的正则表达式模式，以同时支持旧版和规范化的文件名格式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify release artifact filename normalization across platforms so generated assets consistently include an explicit platform segment.

Build:
- Standardize Linux .deb/.rpm artifact names to use the `AstrBot_<version>_linux_<arch>` convention while still accepting legacy patterns.
- Standardize Windows .exe/.msi artifact names to use `AstrBot_<version>_windows_<arch>...` conventions while preserving compatibility with earlier naming schemes.

Chores:
- Introduce shared regex patterns for Linux and Windows artifact stems to handle both legacy and canonical filename formats.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

统一各平台的发行制品文件名规范化方式，在生成的名称中包含明确的平台段。

构建：
- 标准化 Linux `.deb`/`.rpm` 文件名，在规范名称中包含 `linux` 平台段。
- 标准化 Windows `.exe`/`.msi` 文件名，使用更新的匹配模式，在规范名称中包含 `windows` 平台段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在各平台统一发行构件文件名的规范化方式，确保生成的构件始终包含明确的平台标识段。

Build:
- 标准化 Linux `.deb` / `.rpm` 构件名称，采用 `AstrBot_<version>_linux_<arch>` 命名约定，同时仍然兼容旧有命名模式。
- 标准化 Windows `.exe` / `.msi` 构件名称，采用 `AstrBot_<version>_windows_<arch>...` 命名约定，同时保留对早期命名方案的兼容性。

Chores:
- 为 Linux 和 Windows 构件前缀引入共享的正则表达式模式，以同时支持旧版和规范化的文件名格式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify release artifact filename normalization across platforms so generated assets consistently include an explicit platform segment.

Build:
- Standardize Linux .deb/.rpm artifact names to use the `AstrBot_<version>_linux_<arch>` convention while still accepting legacy patterns.
- Standardize Windows .exe/.msi artifact names to use `AstrBot_<version>_windows_<arch>...` conventions while preserving compatibility with earlier naming schemes.

Chores:
- Introduce shared regex patterns for Linux and Windows artifact stems to handle both legacy and canonical filename formats.

</details>

Build：
- 规范 Linux `.deb`/`.rpm` 制品的命名，使其在文件名中包含显式的 `linux` 段。
- 规范 Windows `.exe`/`.msi` 制品的命名，使其在文件名中包含显式的 `windows` 段，同时仍然匹配旧版命名模式。

Chores：
- 引入共享的正则表达式规则，用于同时处理 Linux 和 Windows 的旧版与规范版制品名称前缀。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在各平台统一发行构件文件名的规范化方式，确保生成的构件始终包含明确的平台标识段。

Build:
- 标准化 Linux `.deb` / `.rpm` 构件名称，采用 `AstrBot_<version>_linux_<arch>` 命名约定，同时仍然兼容旧有命名模式。
- 标准化 Windows `.exe` / `.msi` 构件名称，采用 `AstrBot_<version>_windows_<arch>...` 命名约定，同时保留对早期命名方案的兼容性。

Chores:
- 为 Linux 和 Windows 构件前缀引入共享的正则表达式模式，以同时支持旧版和规范化的文件名格式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify release artifact filename normalization across platforms so generated assets consistently include an explicit platform segment.

Build:
- Standardize Linux .deb/.rpm artifact names to use the `AstrBot_<version>_linux_<arch>` convention while still accepting legacy patterns.
- Standardize Windows .exe/.msi artifact names to use `AstrBot_<version>_windows_<arch>...` conventions while preserving compatibility with earlier naming schemes.

Chores:
- Introduce shared regex patterns for Linux and Windows artifact stems to handle both legacy and canonical filename formats.

</details>

</details>

</details>

</details>