### PR TITLE
[codex] force manual tag-poll builds and overwrite release assets

### DIFF
--- a/.github/workflows/build-desktop-tauri.yml
+++ b/.github/workflows/build-desktop-tauri.yml
@@ -514,6 +514,7 @@ jobs:
           generate_release_notes: true
           prerelease: ${{ needs.resolve_build_context.outputs.release_prerelease == 'true' }}
           make_latest: ${{ needs.resolve_build_context.outputs.release_prerelease != 'true' }}
+          overwrite_files: true
           files: release-artifacts/**/*
           fail_on_unmatched_files: true
 


### PR DESCRIPTION
## Summary
This PR contains three follow-up changes on top of the latest `upstream/main`:

1. Fixes the single-instance callback callsite to pass `AppHandle` by reference.
2. Removes a needless borrow in the callback path to satisfy clippy.
3. Updates desktop build workflow behavior so manual `tag-poll` runs always execute the build and can overwrite existing release assets.

## User Impact
When maintainers manually trigger the desktop build workflow in `tag-poll` mode, the workflow can now reliably rebuild artifacts even if a release tag already exists. This makes manual rebuild/recover operations predictable and avoids silently skipped runs.

## Root Cause
`resolve-build-context.sh` unconditionally checked whether the target release tag already existed and set `should_build=false` for `tag-poll`, which is correct for scheduled polling but not for manual dispatch. In manual scenarios, maintainers may intentionally rebuild and republish under the same tag.

## Fix
- In `scripts/ci/resolve-build-context.sh`, keep the existing skip logic for scheduled `tag-poll` runs, but force manual `workflow_dispatch` + `tag-poll` to continue building.
- In `.github/workflows/build-desktop-tauri.yml`, set `overwrite_files: true` for `softprops/action-gh-release` and keep the existing cleanup step so replacement assets are uploaded cleanly.
- Includes the two `#59` follow-up commits (`fix(tauri)` and `fix(clippy)`) rebased on current upstream main.

## Validation
- Local shell syntax check passed: `bash -n scripts/ci/resolve-build-context.sh`.
- Manual reasoning verification of workflow conditions and release step behavior.

## Summary by Sourcery

调整桌面端 tag-poll 构建行为，使其在手动触发的工作流程中始终运行，并允许在手动触发的工作流程中覆盖发布资源（release assets）。

Build:
- 更改 tag-poll 构建的上下文解析逻辑，即使发布标签已存在，在 `workflow_dispatch` 事件触发时也始终执行构建。
- 配置桌面构建工作流程的发布步骤，在上传构建产物（artifacts）时允许覆盖现有的发布资源。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust desktop tag-poll build behavior to always run and allow release asset overwrites on manually triggered workflows.

Build:
- Change tag-poll build context resolution to always build on workflow_dispatch events even when the release tag already exists.
- Configure the desktop build workflow release step to overwrite existing release assets when uploading artifacts.

</details>