### PR TITLE
[codex] fix(ci): pass Tauri signing key in Linux builds

### DIFF
--- a/.github/workflows/build-desktop-tauri.yml
+++ b/.github/workflows/build-desktop-tauri.yml
@@ -201,6 +201,8 @@ jobs:
           ASTRBOT_SOURCE_GIT_REF: ${{ needs.resolve_build_context.outputs.source_git_ref }}
           ASTRBOT_DESKTOP_VERSION: ${{ steps.desktop_version.outputs.prefixed }}
           ASTRBOT_DESKTOP_UPDATER_PUBLIC_KEY: ${{ env.ASTRBOT_DESKTOP_UPDATER_PUBLIC_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           GITHUB_TOKEN: ${{ github.token }}
           GH_TOKEN: ${{ github.token }}
         run: cargo tauri build --bundles deb,rpm


### PR DESCRIPTION
This pull request fixes a Linux-only regression in the desktop build workflow.

The desktop Tauri configuration now enables updater artifacts and includes an updater public key, which makes release packaging require the matching signing private key during build. macOS and Windows jobs already inject `TAURI_SIGNING_PRIVATE_KEY` and `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`, but the Linux job only received the public key.

As a result, both Linux runners could finish compiling and bundling the `.deb`/`.rpm` packages, then fail during updater artifact signing with the error that a public key was found but no private key was available. This blocked the entire release workflow because the release job requires all platform builds to succeed.

The fix is intentionally minimal: pass the same signing secrets to the Linux `cargo tauri build --bundles deb,rpm` step that are already used on macOS and Windows. This keeps signing behavior consistent across all platforms and unblocks release publication without changing updater configuration or artifact generation behavior.

Validation performed locally:

- parsed `.github/workflows/build-desktop-tauri.yml` successfully as YAML
- verified the Linux build step now exposes the same signing env vars as the macOS and Windows build steps
- ran `git diff --check` to confirm the workflow patch is clean

## Summary by Sourcery

CI：
- 在 Linux 的 cargo Tauri 构建步骤中传入 Tauri 签名私钥和密码机密，以启用更新器制品签名。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Pass Tauri signing private key and password secrets into the Linux cargo Tauri build step to enable updater artifact signing.

</details>
- 将 Tauri 签名私钥和密码的机密变量传递给 Linux 的 cargo Tauri 构建步骤，以在各平台之间统一签名配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI：
- 在 Linux 的 cargo Tauri 构建步骤中传入 Tauri 签名私钥和密码机密，以启用更新器制品签名。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Pass Tauri signing private key and password secrets into the Linux cargo Tauri build step to enable updater artifact signing.

</details>

</details>