### PR TITLE
fix(ci): support linux AppImage updater artifacts

### DIFF
--- a/scripts/ci/generate_tauri_latest_json.py
+++ b/scripts/ci/generate_tauri_latest_json.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from scripts.ci.lib.artifact_arch import normalize_arch_alias
 from scripts.ci.lib.nightly_version import NIGHTLY_CANONICAL_FORMAT, NIGHTLY_VERSION_RE
 from scripts.ci.lib.release_artifacts import (
+    LINUX_APPIMAGE_UPDATER_PATTERNS,
     MACOS_UPDATER_ARCHIVE_PATTERNS,
     WINDOWS_UPDATER_PATTERNS,
     match_any,
@@ -51,6 +52,15 @@ def platform_key_for_macos(arch: str) -> str:
     raise ValueError(f"Unsupported macOS arch: {arch}")
 
 
+def platform_key_for_linux_appimage(arch: str) -> str:
+    arch = normalize_arch(arch)
+    if arch == "amd64":
+        return "linux-x86_64-appimage"
+    if arch == "arm64":
+        return "linux-aarch64-appimage"
+    raise ValueError(f"Unsupported Linux AppImage arch: {arch}")
+
+
 def derive_release_metadata(version: str, channel: str | None) -> tuple[str, str, str]:
     inferred_channel = "nightly" if "nightly" in version.lower() else "stable"
     effective_channel = channel or inferred_channel
@@ -67,7 +77,11 @@ def derive_release_metadata(version: str, channel: str | None) -> tuple[str, str
                     f"Invalid nightly version {version!r}: expected format {NIGHTLY_CANONICAL_FORMAT}"
                 )
             raise ValueError(message)
-        return effective_channel, match.group("base"), f"_nightly_{match.group('sha')[:8]}"
+        return (
+            effective_channel,
+            match.group("base"),
+            f"_nightly_{match.group('sha')[:8]}",
+        )
 
     base_version = match.group("base") if match else version
     return effective_channel, base_version, ""
@@ -89,6 +103,14 @@ def canonical_macos_filename(
     _, base_version, nightly_suffix = derive_release_metadata(version, channel)
     arch = normalize_arch(arch)
     return f"{name}_{base_version}_macos_{arch}{nightly_suffix}{archive_ext}"
+
+
+def canonical_linux_appimage_filename(
+    name: str, arch: str, version: str, channel: str
+) -> str:
+    _, base_version, nightly_suffix = derive_release_metadata(version, channel)
+    arch = normalize_arch(arch)
+    return f"{name}_{base_version}_linux_{arch}{nightly_suffix}.AppImage"
 
 
 def parse_windows_artifact_name(source_name: str) -> re.Match[str]:
@@ -119,6 +141,19 @@ def parse_macos_artifact_name(source_name: str) -> tuple[re.Match[str], str]:
         )
     archive_ext = ".app.tar.gz" if source_name.endswith(".app.tar.gz") else ".zip"
     return match, archive_ext
+
+
+def parse_linux_appimage_artifact_name(source_name: str) -> re.Match[str]:
+    match = match_any(source_name, LINUX_APPIMAGE_UPDATER_PATTERNS)
+    if match:
+        return match
+    raise ValueError(
+        "Unexpected Linux AppImage artifact name: "
+        f"{source_name}. Expected format: "
+        "<name>_<version>_linux_<arch>.AppImage or legacy "
+        "<name>_<version>_<arch>.AppImage "
+        "(nightly builds may append _nightly_<sha> before .AppImage)."
+    )
 
 
 def add_platform(
@@ -196,13 +231,32 @@ def collect_platforms(
             )
             continue
 
+        if sig_name.endswith(".AppImage.sig"):
+            source_name = sig_name[:-4]
+            match = parse_linux_appimage_artifact_name(source_name)
+            artifact_name = canonical_linux_appimage_filename(
+                match.group("name"),
+                match.group("arch"),
+                version,
+                channel,
+            )
+            add_platform(
+                platforms,
+                platform_key_for_linux_appimage(match.group("arch")),
+                "Linux AppImage",
+                artifact_name,
+                sig_path,
+                repo,
+                tag,
+            )
+            continue
+
         unsupported_signature_files.append(sig_name)
 
     if unsupported_signature_files:
         joined = ", ".join(unsupported_signature_files)
         raise ValueError(
-            "Unsupported updater signature files under artifacts root: "
-            f"{joined}"
+            f"Unsupported updater signature files under artifacts root: {joined}"
         )
 
     return platforms

--- a/scripts/ci/lib/release_artifacts.py
+++ b/scripts/ci/lib/release_artifacts.py
@@ -8,9 +8,11 @@ import re
 ARTIFACT_EXTENSIONS: tuple[str, ...] = (
     ".app.tar.gz.sig",
     ".app.tar.gz",
+    ".AppImage.sig",
     ".exe.sig",
     ".msi.sig",
     ".zip.sig",
+    ".AppImage",
     ".rpm",
     ".deb",
     ".exe",
@@ -76,12 +78,28 @@ MACOS_UPDATER_ARCHIVE_PATTERNS: tuple[re.Pattern[str], ...] = (
     ),
 )
 
+LINUX_APPIMAGE_UPDATER_PATTERNS: tuple[re.Pattern[str], ...] = (
+    # Canonical:
+    # <name>_<version>_linux_<arch>_nightly_<shortsha>.AppImage
+    re.compile(
+        rf"(?P<name>.+?)_(?P<version>{CANONICAL_VERSION_PATTERN})_linux_(?P<arch>{CANONICAL_ARCH_PATTERN})"
+        rf"{CANONICAL_NIGHTLY_SUFFIX_PATTERN}\.AppImage$"
+    ),
+    # Legacy:
+    # <name>_<version>_<arch>.AppImage
+    re.compile(
+        rf"(?P<name>.+?)_(?P<version>{LEGACY_VERSION_PATTERN})_(?P<arch>x86_64|x64|amd64|aarch64|arm64)\.AppImage$"
+    ),
+)
+
 
 class ReleaseArtifactError(RuntimeError):
     pass
 
 
-def match_any(filename: str, patterns: tuple[re.Pattern[str], ...]) -> re.Match[str] | None:
+def match_any(
+    filename: str, patterns: tuple[re.Pattern[str], ...]
+) -> re.Match[str] | None:
     for pattern in patterns:
         match = pattern.match(filename)
         if match:

--- a/scripts/ci/normalize_release_artifact_filenames.py
+++ b/scripts/ci/normalize_release_artifact_filenames.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import pathlib
 import re
+import sys
 
 from .lib.artifact_arch import normalize_arch_alias
 from .lib.release_artifacts import (
@@ -30,6 +31,7 @@ LINUX_CANONICAL_RULE: tuple[re.Pattern[str], str] = (
     "AstrBot_{version}_linux_{arch}",
 )
 CANONICALIZE_RULES: dict[str, tuple[tuple[re.Pattern[str], str], ...]] = {
+    ".AppImage": (LINUX_CANONICAL_RULE,),
     ".rpm": (
         (
             re.compile(
@@ -39,14 +41,10 @@ CANONICALIZE_RULES: dict[str, tuple[tuple[re.Pattern[str], str], ...]] = {
         ),
         LINUX_CANONICAL_RULE,
     ),
-    ".deb": (
-        LINUX_CANONICAL_RULE,
-    ),
+    ".deb": (LINUX_CANONICAL_RULE,),
     ".exe": (
         (
-            re.compile(
-                rf"{WINDOWS_ARTIFACT_STEM_PATTERN_FRAGMENT}(?:-setup|_setup)$"
-            ),
+            re.compile(rf"{WINDOWS_ARTIFACT_STEM_PATTERN_FRAGMENT}(?:-setup|_setup)$"),
             "AstrBot_{version}_windows_{arch}_setup",
         ),
     ),
@@ -71,6 +69,7 @@ CANONICALIZE_RULES: dict[str, tuple[tuple[re.Pattern[str], str], ...]] = {
         ),
     ),
 }
+
 
 def normalize_arch(arch: str, warned_unknown_arches: set[str]) -> str:
     normalized = normalize_arch_alias(arch)
@@ -116,7 +115,7 @@ def detect_artifact_extension(path: pathlib.Path) -> str | None:
     best_len = -1
 
     for ext in ARTIFACT_EXTENSIONS:
-        if not lower_name.endswith(ext):
+        if not lower_name.endswith(ext.lower()):
             continue
         ext_len = len(ext)
         if ext_len > best_len:
@@ -168,7 +167,9 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Normalize AstrBot release artifact filenames before publishing."
     )
-    parser.add_argument("--root", required=True, help="Directory containing release artifacts.")
+    parser.add_argument(
+        "--root", required=True, help="Directory containing release artifacts."
+    )
     parser.add_argument(
         "--build-mode",
         default="",
@@ -191,7 +192,9 @@ def main() -> int:
     args = parse_args()
     root = pathlib.Path(args.root)
     if not root.exists():
-        print(f"[normalize-artifacts] artifact directory does not exist, skipping: {root}")
+        print(
+            f"[normalize-artifacts] artifact directory does not exist, skipping: {root}"
+        )
         return 0
     if not root.is_dir():
         raise RuntimeError(f"artifact path is not a directory: {root}")
@@ -248,11 +251,15 @@ def main() -> int:
             rename_plan.append((path, new_path))
 
     collisions = {
-        target: sources for target, sources in target_sources.items() if len(sources) > 1
+        target: sources
+        for target, sources in target_sources.items()
+        if len(sources) > 1
     }
     if collisions:
         collision_details = []
-        for target, sources in sorted(collisions.items(), key=lambda item: str(item[0])):
+        for target, sources in sorted(
+            collisions.items(), key=lambda item: str(item[0])
+        ):
             source_list = ", ".join(str(source.name) for source in sorted(sources))
             collision_details.append(f"{target.name} <= {source_list}")
         raise RuntimeError(

--- a/scripts/ci/release-updater-artifacts.test.mjs
+++ b/scripts/ci/release-updater-artifacts.test.mjs
@@ -250,3 +250,69 @@ test('release artifact normalization keeps updater signatures aligned for latest
     await rm(tempDir, { recursive: true, force: true });
   }
 });
+
+test('release artifact normalization canonicalizes linux AppImage assets for latest.json generation', async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'astrbot-release-artifacts-'));
+
+  try {
+    const artifactsDir = path.join(tempDir, 'release-artifacts');
+    const sourceSha = '7ac169c5e81cee0acc1416d22d7ee4464a507a8d';
+
+    await mkdir(artifactsDir, { recursive: true });
+
+    await writeFile(
+      path.join(artifactsDir, 'AstrBot_4.19.2-nightly.20260306.7ac169c5_aarch64.AppImage'),
+      'appimage',
+      'utf8',
+    );
+    await writeFile(
+      path.join(artifactsDir, 'AstrBot_4.19.2-nightly.20260306.7ac169c5_aarch64.AppImage.sig'),
+      'linux-signature',
+      'utf8',
+    );
+
+    runPython(
+      normalizeModule,
+      ['--root', artifactsDir, '--build-mode', 'nightly', '--source-git-ref', sourceSha],
+      projectRoot,
+    );
+
+    const normalizedLinux = path.join(
+      artifactsDir,
+      'AstrBot_4.19.2_linux_arm64_nightly_7ac169c5.AppImage',
+    );
+    const normalizedLinuxSig = path.join(
+      artifactsDir,
+      'AstrBot_4.19.2_linux_arm64_nightly_7ac169c5.AppImage.sig',
+    );
+
+    await access(normalizedLinux, fsConstants.F_OK);
+    await access(normalizedLinuxSig, fsConstants.F_OK);
+
+    const outputPath = path.join(artifactsDir, 'latest.json');
+    runPython(
+      generateModule,
+      [
+        '--artifacts-root',
+        artifactsDir,
+        '--repo',
+        'AstrBotDevs/AstrBot-desktop',
+        '--tag',
+        'nightly',
+        '--version',
+        '4.19.2-nightly.20260306.7ac169c5',
+        '--output',
+        outputPath,
+      ],
+      projectRoot,
+    );
+
+    const payload = JSON.parse(await readFile(outputPath, 'utf8'));
+    assert.deepEqual(payload.platforms['linux-aarch64-appimage'], {
+      signature: 'linux-signature',
+      url: 'https://github.com/AstrBotDevs/AstrBot-desktop/releases/download/nightly/AstrBot_4.19.2_linux_arm64_nightly_7ac169c5.AppImage',
+    });
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/scripts/ci/test_generate_tauri_latest_json.py
+++ b/scripts/ci/test_generate_tauri_latest_json.py
@@ -9,202 +9,234 @@ from scripts.ci import generate_tauri_latest_json as MODULE
 
 SCRIPT_PATH = Path(MODULE.__file__)
 FORMAT_SPEC = json.loads(
-    (SCRIPT_PATH.parents[1] / '..' / 'src-tauri' / 'nightly-version-format.json').resolve().read_text()
+    (SCRIPT_PATH.parents[1] / ".." / "src-tauri" / "nightly-version-format.json")
+    .resolve()
+    .read_text()
 )
 
 
 class GenerateTauriLatestJsonTests(unittest.TestCase):
     def test_nightly_canonical_format_matches_shared_spec(self):
-        self.assertEqual(MODULE.NIGHTLY_CANONICAL_FORMAT, FORMAT_SPEC['canonicalFormat'])
+        self.assertEqual(
+            MODULE.NIGHTLY_CANONICAL_FORMAT, FORMAT_SPEC["canonicalFormat"]
+        )
 
     def test_nightly_version_regex_matches_shared_examples(self):
-        for raw in FORMAT_SPEC['validExamples']:
+        for raw in FORMAT_SPEC["validExamples"]:
             self.assertIsNotNone(MODULE.NIGHTLY_VERSION_RE.fullmatch(raw), raw)
 
-        for raw in FORMAT_SPEC['invalidExamples']:
+        for raw in FORMAT_SPEC["invalidExamples"]:
             self.assertIsNone(MODULE.NIGHTLY_VERSION_RE.fullmatch(raw), raw)
 
     def test_normalize_arch_aliases(self):
-        self.assertEqual(MODULE.normalize_arch('x86_64'), 'amd64')
-        self.assertEqual(MODULE.normalize_arch('x64'), 'amd64')
-        self.assertEqual(MODULE.normalize_arch('amd64'), 'amd64')
-        self.assertEqual(MODULE.normalize_arch('aarch64'), 'arm64')
-        self.assertEqual(MODULE.normalize_arch('arm64'), 'arm64')
+        self.assertEqual(MODULE.normalize_arch("x86_64"), "amd64")
+        self.assertEqual(MODULE.normalize_arch("x64"), "amd64")
+        self.assertEqual(MODULE.normalize_arch("amd64"), "amd64")
+        self.assertEqual(MODULE.normalize_arch("aarch64"), "arm64")
+        self.assertEqual(MODULE.normalize_arch("arm64"), "arm64")
 
     def test_platform_key_for_windows_unsupported_arch(self):
-        with self.assertRaisesRegex(ValueError, r'Unsupported Windows arch: ppc64le'):
-            MODULE.platform_key_for_windows('ppc64le')
+        with self.assertRaisesRegex(ValueError, r"Unsupported Windows arch: ppc64le"):
+            MODULE.platform_key_for_windows("ppc64le")
 
     def test_platform_key_for_macos_unsupported_arch(self):
-        with self.assertRaisesRegex(ValueError, r'Unsupported macOS arch: ppc64le'):
-            MODULE.platform_key_for_macos('ppc64le')
+        with self.assertRaisesRegex(ValueError, r"Unsupported macOS arch: ppc64le"):
+            MODULE.platform_key_for_macos("ppc64le")
+
+    def test_platform_key_for_linux_appimage_unsupported_arch(self):
+        with self.assertRaisesRegex(
+            ValueError, r"Unsupported Linux AppImage arch: ppc64le"
+        ):
+            MODULE.platform_key_for_linux_appimage("ppc64le")
 
     def test_derive_release_metadata_validates_and_returns_expected_values(self):
         self.assertEqual(
-            MODULE.derive_release_metadata('4.29.0', None),
-            ('stable', '4.29.0', ''),
+            MODULE.derive_release_metadata("4.29.0", None),
+            ("stable", "4.29.0", ""),
         )
         self.assertEqual(
-            MODULE.derive_release_metadata('4.29.0-nightly.20260307.abcd1234', None),
-            ('nightly', '4.29.0', '_nightly_abcd1234'),
+            MODULE.derive_release_metadata("4.29.0-nightly.20260307.abcd1234", None),
+            ("nightly", "4.29.0", "_nightly_abcd1234"),
         )
         self.assertEqual(
             MODULE.derive_release_metadata(
-                '4.29.0-nightly.20260307.abcd1234',
-                'nightly',
+                "4.29.0-nightly.20260307.abcd1234",
+                "nightly",
             ),
-            ('nightly', '4.29.0', '_nightly_abcd1234'),
+            ("nightly", "4.29.0", "_nightly_abcd1234"),
         )
 
         invalid_versions = [
-            '4.29.0-nightly',
-            '4.29.0-nightly.2026-03-07.abcd1234',
-            '4.29.0-nightly.20260307.abc',
-            'not-a-nightly-version',
+            "4.29.0-nightly",
+            "4.29.0-nightly.2026-03-07.abcd1234",
+            "4.29.0-nightly.20260307.abc",
+            "not-a-nightly-version",
         ]
         for raw in invalid_versions:
             with self.subTest(version=raw):
-                with self.assertRaisesRegex(ValueError, 'Nightly manifest version must match'):
-                    MODULE.derive_release_metadata(raw, 'nightly')
+                with self.assertRaisesRegex(
+                    ValueError, "Nightly manifest version must match"
+                ):
+                    MODULE.derive_release_metadata(raw, "nightly")
 
     def test_derive_release_metadata_error_mentions_sha8(self):
-        with self.assertRaisesRegex(ValueError, r'<sha8'):
-            MODULE.derive_release_metadata('4.29.0-nightly', 'nightly')
+        with self.assertRaisesRegex(ValueError, r"<sha8"):
+            MODULE.derive_release_metadata("4.29.0-nightly", "nightly")
 
     def test_derive_release_metadata_rejects_malformed_inferred_nightly(self):
-        with self.assertRaisesRegex(ValueError, 'Invalid nightly version'):
-            MODULE.derive_release_metadata('4.29.0-nightly-beta', None)
+        with self.assertRaisesRegex(ValueError, "Invalid nightly version"):
+            MODULE.derive_release_metadata("4.29.0-nightly-beta", None)
 
     def test_canonical_windows_filename_outputs_expected_names(self):
         self.assertEqual(
-            MODULE.canonical_windows_filename('AstrBot', 'amd64', '4.29.0', 'stable'),
-            'AstrBot_4.29.0_windows_amd64_setup.exe',
+            MODULE.canonical_windows_filename("AstrBot", "amd64", "4.29.0", "stable"),
+            "AstrBot_4.29.0_windows_amd64_setup.exe",
         )
         self.assertEqual(
             MODULE.canonical_windows_filename(
-                'AstrBot',
-                'amd64',
-                '4.29.0-nightly.20260307.abcd1234',
-                'nightly',
+                "AstrBot",
+                "amd64",
+                "4.29.0-nightly.20260307.abcd1234",
+                "nightly",
             ),
-            'AstrBot_4.29.0_windows_amd64_setup_nightly_abcd1234.exe',
+            "AstrBot_4.29.0_windows_amd64_setup_nightly_abcd1234.exe",
         )
 
     def test_canonical_macos_filename_outputs_expected_names(self):
         self.assertEqual(
             MODULE.canonical_macos_filename(
-                'AstrBot',
-                'arm64',
-                '4.29.0',
-                'stable',
-                '.app.tar.gz',
+                "AstrBot",
+                "arm64",
+                "4.29.0",
+                "stable",
+                ".app.tar.gz",
             ),
-            'AstrBot_4.29.0_macos_arm64.app.tar.gz',
+            "AstrBot_4.29.0_macos_arm64.app.tar.gz",
         )
         self.assertEqual(
             MODULE.canonical_macos_filename(
-                'AstrBot',
-                'arm64',
-                '4.29.0-nightly.20260307.abcd1234',
-                'nightly',
-                '.zip',
+                "AstrBot",
+                "arm64",
+                "4.29.0-nightly.20260307.abcd1234",
+                "nightly",
+                ".zip",
             ),
-            'AstrBot_4.29.0_macos_arm64_nightly_abcd1234.zip',
+            "AstrBot_4.29.0_macos_arm64_nightly_abcd1234.zip",
+        )
+
+    def test_canonical_linux_appimage_filename_outputs_expected_names(self):
+        self.assertEqual(
+            MODULE.canonical_linux_appimage_filename(
+                "AstrBot", "arm64", "4.29.0", "stable"
+            ),
+            "AstrBot_4.29.0_linux_arm64.AppImage",
+        )
+        self.assertEqual(
+            MODULE.canonical_linux_appimage_filename(
+                "AstrBot",
+                "aarch64",
+                "4.29.0-nightly.20260307.abcd1234",
+                "nightly",
+            ),
+            "AstrBot_4.29.0_linux_arm64_nightly_abcd1234.AppImage",
         )
 
     def test_main_writes_expected_manifest_json(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
-            output = root / 'latest-nightly.json'
-            (root / 'AstrBot_4.29.0-nightly.20260307.abcd1234_x64-setup.exe.sig').write_text('sig-win')
+            output = root / "latest-nightly.json"
+            (
+                root / "AstrBot_4.29.0-nightly.20260307.abcd1234_x64-setup.exe.sig"
+            ).write_text("sig-win")
 
             argv = [
                 str(SCRIPT_PATH),
-                '--artifacts-root',
+                "--artifacts-root",
                 str(root),
-                '--repo',
-                'AstrBotDevs/AstrBot-desktop',
-                '--tag',
-                'nightly',
-                '--version',
-                '4.29.0-nightly.20260307.abcd1234',
-                '--channel',
-                'nightly',
-                '--output',
+                "--repo",
+                "AstrBotDevs/AstrBot-desktop",
+                "--tag",
+                "nightly",
+                "--version",
+                "4.29.0-nightly.20260307.abcd1234",
+                "--channel",
+                "nightly",
+                "--output",
                 str(output),
-                '--notes',
-                'nightly build',
+                "--notes",
+                "nightly build",
             ]
 
-            with mock.patch('sys.argv', argv):
+            with mock.patch("sys.argv", argv):
                 exit_code = MODULE.main()
 
             payload = json.loads(output.read_text())
 
         self.assertEqual(exit_code, 0)
-        self.assertEqual(payload['version'], '4.29.0-nightly.20260307.abcd1234')
-        self.assertEqual(payload['notes'], 'nightly build')
-        self.assertEqual(payload['channel'], 'nightly')
-        self.assertEqual(payload['baseVersion'], '4.29.0')
-        self.assertEqual(payload['releaseTag'], 'nightly')
-        self.assertIn('platforms', payload)
+        self.assertEqual(payload["version"], "4.29.0-nightly.20260307.abcd1234")
+        self.assertEqual(payload["notes"], "nightly build")
+        self.assertEqual(payload["channel"], "nightly")
+        self.assertEqual(payload["baseVersion"], "4.29.0")
+        self.assertEqual(payload["releaseTag"], "nightly")
+        self.assertIn("platforms", payload)
         self.assertEqual(
-            payload['platforms']['windows-x86_64']['url'],
-            'https://github.com/AstrBotDevs/AstrBot-desktop/releases/download/nightly/'
-            'AstrBot_4.29.0_windows_amd64_setup_nightly_abcd1234.exe',
+            payload["platforms"]["windows-x86_64"]["url"],
+            "https://github.com/AstrBotDevs/AstrBot-desktop/releases/download/nightly/"
+            "AstrBot_4.29.0_windows_amd64_setup_nightly_abcd1234.exe",
         )
         self.assertEqual(
-            payload['platforms']['windows-x86_64']['signature'],
-            'sig-win',
+            payload["platforms"]["windows-x86_64"]["signature"],
+            "sig-win",
         )
 
     def test_main_fails_when_no_signatures_found(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
-            output = root / 'latest-stable.json'
+            output = root / "latest-stable.json"
             argv = [
                 str(SCRIPT_PATH),
-                '--artifacts-root',
+                "--artifacts-root",
                 str(root),
-                '--repo',
-                'AstrBotDevs/AstrBot-desktop',
-                '--tag',
-                'v4.29.0',
-                '--version',
-                '4.29.0',
-                '--channel',
-                'stable',
-                '--output',
+                "--repo",
+                "AstrBotDevs/AstrBot-desktop",
+                "--tag",
+                "v4.29.0",
+                "--version",
+                "4.29.0",
+                "--channel",
+                "stable",
+                "--output",
                 str(output),
             ]
 
-            with mock.patch('sys.argv', argv):
-                with self.assertRaisesRegex(SystemExit, 'No updater signatures found under artifacts root'):
+            with mock.patch("sys.argv", argv):
+                with self.assertRaisesRegex(
+                    SystemExit, "No updater signatures found under artifacts root"
+                ):
                     MODULE.main()
 
             self.assertFalse(output.exists())
 
-
     def test_main_fails_when_inferred_nightly_version_is_malformed(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
-            output = root / 'latest-nightly.json'
+            output = root / "latest-nightly.json"
             argv = [
                 str(SCRIPT_PATH),
-                '--artifacts-root',
+                "--artifacts-root",
                 str(root),
-                '--repo',
-                'AstrBotDevs/AstrBot-desktop',
-                '--tag',
-                'nightly',
-                '--version',
-                '4.29.0-nightly-beta',
-                '--output',
+                "--repo",
+                "AstrBotDevs/AstrBot-desktop",
+                "--tag",
+                "nightly",
+                "--version",
+                "4.29.0-nightly-beta",
+                "--output",
                 str(output),
             ]
 
-            with mock.patch('sys.argv', argv):
-                with self.assertRaisesRegex(SystemExit, 'Invalid nightly version'):
+            with mock.patch("sys.argv", argv):
+                with self.assertRaisesRegex(SystemExit, "Invalid nightly version"):
                     MODULE.main()
 
             self.assertFalse(output.exists())
@@ -212,231 +244,271 @@ class GenerateTauriLatestJsonTests(unittest.TestCase):
     def test_collect_platforms_preserves_canonical_nightly_filenames(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
-            (root / 'AstrBot_4.29.0_windows_amd64_setup_nightly_abcd1234.exe.sig').write_text('sig-win')
-            (root / 'AstrBot_4.29.0_macos_arm64_nightly_abcd1234.zip.sig').write_text('sig-mac')
+            (
+                root / "AstrBot_4.29.0_windows_amd64_setup_nightly_abcd1234.exe.sig"
+            ).write_text("sig-win")
+            (root / "AstrBot_4.29.0_macos_arm64_nightly_abcd1234.zip.sig").write_text(
+                "sig-mac"
+            )
 
             platforms = MODULE.collect_platforms(
                 root,
-                'AstrBotDevs/AstrBot-desktop',
-                'nightly',
-                version='4.29.0-nightly.20260307.abcd1234',
-                channel='nightly',
+                "AstrBotDevs/AstrBot-desktop",
+                "nightly",
+                version="4.29.0-nightly.20260307.abcd1234",
+                channel="nightly",
             )
 
         self.assertEqual(
-            platforms['windows-x86_64']['url'],
-            'https://github.com/AstrBotDevs/AstrBot-desktop/releases/download/nightly/'
-            'AstrBot_4.29.0_windows_amd64_setup_nightly_abcd1234.exe',
+            platforms["windows-x86_64"]["url"],
+            "https://github.com/AstrBotDevs/AstrBot-desktop/releases/download/nightly/"
+            "AstrBot_4.29.0_windows_amd64_setup_nightly_abcd1234.exe",
         )
         self.assertEqual(
-            platforms['darwin-aarch64']['url'],
-            'https://github.com/AstrBotDevs/AstrBot-desktop/releases/download/nightly/'
-            'AstrBot_4.29.0_macos_arm64_nightly_abcd1234.zip',
+            platforms["darwin-aarch64"]["url"],
+            "https://github.com/AstrBotDevs/AstrBot-desktop/releases/download/nightly/"
+            "AstrBot_4.29.0_macos_arm64_nightly_abcd1234.zip",
         )
 
     def test_collect_platforms_normalizes_nightly_release_filenames(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
-            (root / 'AstrBot_4.29.0-nightly.20260307.abcd1234_x64-setup.exe.sig').write_text('sig-win')
-            (root / 'AstrBot_4.29.0-nightly.20260307.abcd1234_macos_aarch64.zip.sig').write_text('sig-mac')
+            (
+                root / "AstrBot_4.29.0-nightly.20260307.abcd1234_x64-setup.exe.sig"
+            ).write_text("sig-win")
+            (
+                root / "AstrBot_4.29.0-nightly.20260307.abcd1234_macos_aarch64.zip.sig"
+            ).write_text("sig-mac")
 
             platforms = MODULE.collect_platforms(
                 root,
-                'AstrBotDevs/AstrBot-desktop',
-                'nightly',
-                version='4.29.0-nightly.20260307.abcd1234',
-                channel='nightly',
+                "AstrBotDevs/AstrBot-desktop",
+                "nightly",
+                version="4.29.0-nightly.20260307.abcd1234",
+                channel="nightly",
             )
 
         self.assertEqual(
-            platforms['windows-x86_64']['url'],
-            'https://github.com/AstrBotDevs/AstrBot-desktop/releases/download/nightly/'
-            'AstrBot_4.29.0_windows_amd64_setup_nightly_abcd1234.exe',
+            platforms["windows-x86_64"]["url"],
+            "https://github.com/AstrBotDevs/AstrBot-desktop/releases/download/nightly/"
+            "AstrBot_4.29.0_windows_amd64_setup_nightly_abcd1234.exe",
         )
         self.assertEqual(
-            platforms['darwin-aarch64']['url'],
-            'https://github.com/AstrBotDevs/AstrBot-desktop/releases/download/nightly/'
-            'AstrBot_4.29.0_macos_arm64_nightly_abcd1234.zip',
+            platforms["darwin-aarch64"]["url"],
+            "https://github.com/AstrBotDevs/AstrBot-desktop/releases/download/nightly/"
+            "AstrBot_4.29.0_macos_arm64_nightly_abcd1234.zip",
         )
 
     def test_collect_platforms_accepts_current_canonical_stable_windows_name(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
-            (root / 'AstrBot_4.29.0_windows_amd64_setup.exe.sig').write_text('sig-win')
+            (root / "AstrBot_4.29.0_windows_amd64_setup.exe.sig").write_text("sig-win")
 
             platforms = MODULE.collect_platforms(
                 root,
-                'AstrBotDevs/AstrBot-desktop',
-                'v4.29.0',
-                version='4.29.0',
-                channel='stable',
+                "AstrBotDevs/AstrBot-desktop",
+                "v4.29.0",
+                version="4.29.0",
+                channel="stable",
             )
 
         self.assertEqual(
-            platforms['windows-x86_64']['url'],
-            'https://github.com/AstrBotDevs/AstrBot-desktop/releases/download/v4.29.0/'
-            'AstrBot_4.29.0_windows_amd64_setup.exe',
+            platforms["windows-x86_64"]["url"],
+            "https://github.com/AstrBotDevs/AstrBot-desktop/releases/download/v4.29.0/"
+            "AstrBot_4.29.0_windows_amd64_setup.exe",
         )
 
     def test_collect_platforms_normalizes_legacy_windows_x86_64_alias(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
-            (root / 'AstrBot_4.29.0_windows_x86_64_setup.exe.sig').write_text('sig-win')
+            (root / "AstrBot_4.29.0_windows_x86_64_setup.exe.sig").write_text("sig-win")
 
             platforms = MODULE.collect_platforms(
                 root,
-                'AstrBotDevs/AstrBot-desktop',
-                'v4.29.0',
-                version='4.29.0',
-                channel='stable',
+                "AstrBotDevs/AstrBot-desktop",
+                "v4.29.0",
+                version="4.29.0",
+                channel="stable",
             )
 
-        self.assertIn('windows-x86_64', platforms)
+        self.assertIn("windows-x86_64", platforms)
         self.assertEqual(
-            platforms['windows-x86_64']['url'],
-            'https://github.com/AstrBotDevs/AstrBot-desktop/releases/download/v4.29.0/'
-            'AstrBot_4.29.0_windows_amd64_setup.exe',
+            platforms["windows-x86_64"]["url"],
+            "https://github.com/AstrBotDevs/AstrBot-desktop/releases/download/v4.29.0/"
+            "AstrBot_4.29.0_windows_amd64_setup.exe",
         )
 
     def test_collect_platforms_accepts_stable_macos_arm64_name(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
-            (root / 'AstrBot_4.29.0_macos_arm64.zip.sig').write_text('sig-mac')
+            (root / "AstrBot_4.29.0_macos_arm64.zip.sig").write_text("sig-mac")
 
             platforms = MODULE.collect_platforms(
                 root,
-                'AstrBotDevs/AstrBot-desktop',
-                'v4.29.0',
-                version='4.29.0',
-                channel='stable',
+                "AstrBotDevs/AstrBot-desktop",
+                "v4.29.0",
+                version="4.29.0",
+                channel="stable",
             )
 
-        self.assertIn('darwin-aarch64', platforms)
+        self.assertIn("darwin-aarch64", platforms)
         self.assertEqual(
-            platforms['darwin-aarch64']['url'],
-            'https://github.com/AstrBotDevs/AstrBot-desktop/releases/download/v4.29.0/'
-            'AstrBot_4.29.0_macos_arm64.zip',
+            platforms["darwin-aarch64"]["url"],
+            "https://github.com/AstrBotDevs/AstrBot-desktop/releases/download/v4.29.0/"
+            "AstrBot_4.29.0_macos_arm64.zip",
         )
-
 
     def test_collect_platforms_accepts_stable_macos_arm64_app_tar_gz(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
-            (root / 'AstrBot_4.29.0_macos_arm64.app.tar.gz.sig').write_text('sig-mac-app')
+            (root / "AstrBot_4.29.0_macos_arm64.app.tar.gz.sig").write_text(
+                "sig-mac-app"
+            )
 
             platforms = MODULE.collect_platforms(
                 root,
-                'AstrBotDevs/AstrBot-desktop',
-                'v4.29.0',
-                version='4.29.0',
-                channel='stable',
+                "AstrBotDevs/AstrBot-desktop",
+                "v4.29.0",
+                version="4.29.0",
+                channel="stable",
             )
 
-        self.assertIn('darwin-aarch64', platforms)
+        self.assertIn("darwin-aarch64", platforms)
         self.assertEqual(
-            platforms['darwin-aarch64']['url'],
-            'https://github.com/AstrBotDevs/AstrBot-desktop/releases/download/v4.29.0/'
-            'AstrBot_4.29.0_macos_arm64.app.tar.gz',
+            platforms["darwin-aarch64"]["url"],
+            "https://github.com/AstrBotDevs/AstrBot-desktop/releases/download/v4.29.0/"
+            "AstrBot_4.29.0_macos_arm64.app.tar.gz",
         )
 
-    def test_collect_platforms_accepts_nightly_macos_arm64_app_tar_gz_canonical_name(self):
+    def test_collect_platforms_accepts_nightly_macos_arm64_app_tar_gz_canonical_name(
+        self,
+    ):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
-            (root / 'AstrBot_4.29.0_macos_arm64_nightly_abcd1234.app.tar.gz.sig').write_text('sig-mac-nightly')
+            (
+                root / "AstrBot_4.29.0_macos_arm64_nightly_abcd1234.app.tar.gz.sig"
+            ).write_text("sig-mac-nightly")
 
             platforms = MODULE.collect_platforms(
                 root,
-                'AstrBotDevs/AstrBot-desktop',
-                'nightly',
-                version='4.29.0-nightly.20260307.abcd1234',
-                channel='nightly',
+                "AstrBotDevs/AstrBot-desktop",
+                "nightly",
+                version="4.29.0-nightly.20260307.abcd1234",
+                channel="nightly",
             )
 
-        self.assertIn('darwin-aarch64', platforms)
+        self.assertIn("darwin-aarch64", platforms)
         self.assertEqual(
-            platforms['darwin-aarch64']['url'],
-            'https://github.com/AstrBotDevs/AstrBot-desktop/releases/download/nightly/'
-            'AstrBot_4.29.0_macos_arm64_nightly_abcd1234.app.tar.gz',
+            platforms["darwin-aarch64"]["url"],
+            "https://github.com/AstrBotDevs/AstrBot-desktop/releases/download/nightly/"
+            "AstrBot_4.29.0_macos_arm64_nightly_abcd1234.app.tar.gz",
+        )
+
+    def test_collect_platforms_accepts_linux_appimage_canonical_name(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (
+                root / "AstrBot_4.29.0_linux_arm64_nightly_abcd1234.AppImage.sig"
+            ).write_text("sig-linux")
+
+            platforms = MODULE.collect_platforms(
+                root,
+                "AstrBotDevs/AstrBot-desktop",
+                "nightly",
+                version="4.29.0-nightly.20260307.abcd1234",
+                channel="nightly",
+            )
+
+        self.assertIn("linux-aarch64-appimage", platforms)
+        self.assertEqual(
+            platforms["linux-aarch64-appimage"]["url"],
+            "https://github.com/AstrBotDevs/AstrBot-desktop/releases/download/nightly/"
+            "AstrBot_4.29.0_linux_arm64_nightly_abcd1234.AppImage",
         )
 
     def test_collect_platforms_invalid_windows_sig_raises(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
-            (root / 'AstrBot_4.29.0_windows_amd64.exe.sig').write_text('sig-win')
+            (root / "AstrBot_4.29.0_windows_amd64.exe.sig").write_text("sig-win")
 
             with self.assertRaisesRegex(
                 ValueError,
-                r'Expected format: <name>_<version>_windows_<arch>_setup\.exe',
+                r"Expected format: <name>_<version>_windows_<arch>_setup\.exe",
             ):
                 MODULE.collect_platforms(
                     root,
-                    'AstrBotDevs/AstrBot-desktop',
-                    'v4.29.0',
-                    version='4.29.0',
-                    channel='stable',
+                    "AstrBotDevs/AstrBot-desktop",
+                    "v4.29.0",
+                    version="4.29.0",
+                    channel="stable",
                 )
 
     def test_collect_platforms_invalid_macos_sig_raises(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
-            (root / 'AstrBot_4.29.0_macos_.zip.sig').write_text('sig-mac')
+            (root / "AstrBot_4.29.0_macos_.zip.sig").write_text("sig-mac")
 
-            with self.assertRaisesRegex(ValueError, 'Unexpected macOS artifact name'):
+            with self.assertRaisesRegex(ValueError, "Unexpected macOS artifact name"):
                 MODULE.collect_platforms(
                     root,
-                    'AstrBotDevs/AstrBot-desktop',
-                    'v4.29.0',
-                    version='4.29.0',
-                    channel='stable',
+                    "AstrBotDevs/AstrBot-desktop",
+                    "v4.29.0",
+                    version="4.29.0",
+                    channel="stable",
                 )
 
     def test_collect_platforms_rejects_macos_name_without_macos_prefix(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
-            (root / 'AstrBot_4.29.0_arm64.zip.sig').write_text('sig-mac')
+            (root / "AstrBot_4.29.0_arm64.zip.sig").write_text("sig-mac")
 
-            with self.assertRaisesRegex(ValueError, 'Unexpected macOS artifact name'):
+            with self.assertRaisesRegex(ValueError, "Unexpected macOS artifact name"):
                 MODULE.collect_platforms(
                     root,
-                    'AstrBotDevs/AstrBot-desktop',
-                    'v4.29.0',
-                    version='4.29.0',
-                    channel='stable',
+                    "AstrBotDevs/AstrBot-desktop",
+                    "v4.29.0",
+                    version="4.29.0",
+                    channel="stable",
                 )
-
 
     def test_collect_platforms_rejects_duplicate_artifacts(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
-            (root / 'AstrBot_4.29.0_windows_amd64_setup.exe.sig').write_text('sig-win-1')
-            (root / 'AstrBot_4.29.0_x64-setup.exe.sig').write_text('sig-win-2')
+            (root / "AstrBot_4.29.0_windows_amd64_setup.exe.sig").write_text(
+                "sig-win-1"
+            )
+            (root / "AstrBot_4.29.0_x64-setup.exe.sig").write_text("sig-win-2")
 
-            with self.assertRaisesRegex(ValueError, r'Duplicate .* artifact for platform'):
+            with self.assertRaisesRegex(
+                ValueError, r"Duplicate .* artifact for platform"
+            ):
                 MODULE.collect_platforms(
                     root,
-                    'AstrBotDevs/AstrBot-desktop',
-                    'v4.29.0',
-                    version='4.29.0',
-                    channel='stable',
+                    "AstrBotDevs/AstrBot-desktop",
+                    "v4.29.0",
+                    version="4.29.0",
+                    channel="stable",
                 )
 
     def test_collect_platforms_rejects_unsupported_signature_files(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
-            (root / 'AstrBot_4.29.0_windows_amd64_setup.msi.sig').write_text('sig-unknown')
+            (root / "AstrBot_4.29.0_windows_amd64_setup.msi.sig").write_text(
+                "sig-unknown"
+            )
 
             with self.assertRaisesRegex(
                 ValueError,
-                'Unsupported updater signature files under artifacts root',
+                "Unsupported updater signature files under artifacts root",
             ):
                 MODULE.collect_platforms(
                     root,
-                    'AstrBotDevs/AstrBot-desktop',
-                    'v4.29.0',
-                    version='4.29.0',
-                    channel='stable',
+                    "AstrBotDevs/AstrBot-desktop",
+                    "v4.29.0",
+                    version="4.29.0",
+                    channel="stable",
                 )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- canonicalize Linux AppImage release artifact names alongside the existing deb/rpm/macOS/Windows release asset flow
- teach `generate_tauri_latest_json` to accept AppImage signatures and emit the `linux-*-appimage` manifest entries Tauri updater expects
- add JS and Python regression coverage for AppImage normalization and updater manifest generation

## Test Plan
- [x] `python3 -m unittest scripts.ci.test_generate_tauri_latest_json`
- [x] `node --test scripts/ci/release-updater-artifacts.test.mjs`
- [x] `pnpm run test:prepare-resources`
- [x] `python3 -m py_compile scripts/ci/generate_tauri_latest_json.py scripts/ci/normalize_release_artifact_filenames.py scripts/ci/lib/release_artifacts.py`

## Summary by Sourcery

在发布制品规范化及 Tauri 的 `latest.json` 清单生成中，新增对 Linux AppImage 更新器制品的支持。

增强功能：
- 将 Linux AppImage 发布制品文件名与现有平台制品一起规范化为统一的标准形式。
- 扩展 `latest.json` 生成逻辑，以解析 Linux AppImage 签名，并输出 Tauri 更新器所需的 `linux-*-appimage` 平台条目。

测试：
- 新增 Python 单元测试，覆盖 Linux AppImage 文件名解析、平台键以及清单生成。
- 新增 JavaScript 测试，用于验证 Linux AppImage 制品规范化及其在生成的 `latest.json` 负载中的包含情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for Linux AppImage updater artifacts in release artifact normalization and Tauri latest.json manifest generation.

Enhancements:
- Normalize Linux AppImage release artifact filenames into a canonical form alongside existing platform artifacts.
- Extend latest.json generation to parse Linux AppImage signatures and emit linux-*-appimage platform entries expected by the Tauri updater.

Tests:
- Add Python unit tests covering Linux AppImage filename parsing, platform keys, and manifest generation.
- Add JavaScript tests verifying Linux AppImage artifact normalization and inclusion in the generated latest.json payload.

</details>