### PR TITLE
fix(ci): clean nightly assets in current repository

### DIFF
--- a/docs/plans/2026-03-07-nightly-release-cleanup-design.md
+++ b/docs/plans/2026-03-07-nightly-release-cleanup-design.md
@@ -1,0 +1,39 @@
+# Nightly Release Cleanup Design
+
+## Goal
+
+Make nightly release asset cleanup run against the repository that is actually publishing the release by default, while still allowing an explicit override target when needed.
+
+## Current Problem
+
+- `scripts/ci/cleanup-release-assets.sh` hardcodes `AstrBotDevs/AstrBot-desktop` as the default cleanup target.
+- In forks or test repositories, the cleanup step exits early because `GITHUB_REPOSITORY` does not match that hardcoded target.
+- The workflow still uploads fresh assets afterward, so nightly releases in non-upstream repos accumulate assets over time.
+
+## Decision
+
+Change the default cleanup target repository from a hardcoded upstream name to the current `GITHUB_REPOSITORY`.
+
+Keep both existing escape hatches:
+
+- `ASTRBOT_RELEASE_CLEANUP_TARGET_REPOSITORY` can still force cleanup to target a different repository.
+- `ASTRBOT_RELEASE_CLEANUP_ALLOW_ANY_REPOSITORY` can still bypass the mismatch protection entirely.
+
+## Why
+
+- Default behavior becomes intuitive: clean the same repository that is about to publish assets.
+- Forks, staging repos, and test repos stop accumulating nightly assets.
+- Explicit repository targeting still works for special admin workflows.
+- No dangerous default bypass is introduced.
+
+## Impact
+
+- Upstream behavior stays effectively the same.
+- Fork nightly releases start deleting old assets before publishing new ones.
+- The protection against accidental cross-repository deletion remains in place unless explicitly overridden.
+
+## Verification
+
+- Cleanup script defaults target repository to `GITHUB_REPOSITORY`.
+- Mismatch protection still triggers when `ASTRBOT_RELEASE_CLEANUP_TARGET_REPOSITORY` is explicitly set to another repo.
+- Tests cover default current-repo cleanup behavior and explicit mismatch skip behavior.

--- a/docs/plans/2026-03-07-nightly-release-cleanup.md
+++ b/docs/plans/2026-03-07-nightly-release-cleanup.md
@@ -1,0 +1,75 @@
+# Nightly Release Cleanup Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make nightly asset cleanup default to the repository currently running the workflow so forks and test repositories do not accumulate stale release assets.
+
+**Architecture:** Keep the current cleanup guardrails, but change the script's default cleanup target from a hardcoded upstream repository to `GITHUB_REPOSITORY`. Add regression tests so default current-repo cleanup and explicit mismatch skipping are both locked in.
+
+**Tech Stack:** Bash, GitHub CLI, Node test runner
+
+---
+
+### Task 1: Add failing regression coverage for cleanup target resolution
+
+**Files:**
+- Modify: `scripts/ci/cleanup-release-assets.test.mjs`
+
+**Step 1: Write the failing test**
+
+Add tests for:
+
+- default cleanup targeting current `GITHUB_REPOSITORY`
+- explicit `ASTRBOT_RELEASE_CLEANUP_TARGET_REPOSITORY` mismatch still skipping cleanup
+
+**Step 2: Run test to verify it fails**
+
+Run: `node --test scripts/ci/cleanup-release-assets.test.mjs`
+Expected: new default-current-repo test fails because the script still hardcodes upstream.
+
+**Step 3: Write minimal implementation**
+
+Do not change production code yet; only finish the test fixture needed to expose the current hardcoded default behavior.
+
+**Step 4: Run test to verify it still fails for the expected reason**
+
+Run: `node --test scripts/ci/cleanup-release-assets.test.mjs`
+Expected: failure tied to the current hardcoded cleanup repository behavior.
+
+### Task 2: Change cleanup default to current repository
+
+**Files:**
+- Modify: `scripts/ci/cleanup-release-assets.sh`
+
+**Step 1: Implement minimal production change**
+
+- Replace the hardcoded default cleanup repository with `${GITHUB_REPOSITORY}`.
+- Keep `ASTRBOT_RELEASE_CLEANUP_TARGET_REPOSITORY` override support unchanged.
+- Keep `ASTRBOT_RELEASE_CLEANUP_ALLOW_ANY_REPOSITORY` mismatch bypass unchanged.
+
+**Step 2: Run focused tests**
+
+Run: `node --test scripts/ci/cleanup-release-assets.test.mjs`
+Expected: all cleanup-release-assets tests pass.
+
+### Task 3: Run broader verification
+
+**Files:**
+- Modify: none
+
+**Step 1: Run script suite**
+
+Run: `pnpm run test:prepare-resources`
+Expected: full script test suite passes.
+
+**Step 2: Inspect diff**
+
+Run: `git diff --stat upstream/main...HEAD`
+Expected: diff only contains the cleanup script, its tests, and the new plan docs.
+
+**Step 3: Commit**
+
+```bash
+git add scripts/ci/cleanup-release-assets.sh scripts/ci/cleanup-release-assets.test.mjs docs/plans/2026-03-07-nightly-release-cleanup-design.md docs/plans/2026-03-07-nightly-release-cleanup.md
+git commit -m "fix(ci): clean nightly assets in current repository"
+```

--- a/scripts/ci/cleanup-release-assets.sh
+++ b/scripts/ci/cleanup-release-assets.sh
@@ -17,7 +17,7 @@ if [ -z "${GITHUB_REPOSITORY:-}" ]; then
   exit 1
 fi
 
-default_cleanup_repository="AstrBotDevs/AstrBot-desktop"
+default_cleanup_repository="${GITHUB_REPOSITORY}"
 cleanup_repository="${ASTRBOT_RELEASE_CLEANUP_TARGET_REPOSITORY:-${default_cleanup_repository}}"
 allow_any_repository_flag="$(printf '%s' "${ASTRBOT_RELEASE_CLEANUP_ALLOW_ANY_REPOSITORY:-0}" | tr '[:upper:]' '[:lower:]')"
 case "${allow_any_repository_flag}" in

--- a/scripts/ci/cleanup-release-assets.test.mjs
+++ b/scripts/ci/cleanup-release-assets.test.mjs
@@ -1,0 +1,98 @@
+import os from 'node:os';
+import path from 'node:path';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { chmodSync } from 'node:fs';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(scriptDir, '..', '..');
+const cleanupScript = path.join(projectRoot, 'scripts/ci/cleanup-release-assets.sh');
+
+const createFakeGh = async (root, logFile) => {
+  const binDir = path.join(root, 'bin');
+  const ghPath = path.join(binDir, 'gh');
+  await mkdir(binDir, { recursive: true });
+  await writeFile(
+    ghPath,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${logFile}"
+if [ "$1" = "api" ] && [ "$2" = "repos/test-owner/test-repo/releases/tags/nightly" ]; then
+  printf '123\n'
+  exit 0
+fi
+if [ "$1" = "api" ] && [ "$2" = "--paginate" ] && [ "$3" = "repos/test-owner/test-repo/releases/123/assets?per_page=100" ]; then
+  printf '1\told-asset.zip\n'
+  exit 0
+fi
+if [ "$1" = "api" ] && [ "$2" = "-X" ] && [ "$3" = "DELETE" ] && [ "$4" = "repos/test-owner/test-repo/releases/assets/1" ]; then
+  exit 0
+fi
+printf 'unexpected gh args: %s\n' "$*" >&2
+exit 1
+`,
+    'utf8',
+  );
+  chmodSync(ghPath, 0o755);
+  return binDir;
+};
+
+const runCleanup = (envOverrides, cwd = projectRoot) =>
+  spawnSync('bash', [cleanupScript], {
+    cwd,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      ...envOverrides,
+    },
+  });
+
+test('cleanup-release-assets defaults to cleaning the current repository', async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'astrbot-cleanup-release-assets-'));
+
+  try {
+    const logFile = path.join(tempDir, 'gh.log');
+    const binDir = await createFakeGh(tempDir, logFile);
+
+    const result = runCleanup({
+      GITHUB_REPOSITORY: 'test-owner/test-repo',
+      RELEASE_TAG: 'nightly',
+      PATH: `${binDir}:${process.env.PATH}`,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /Deleted existing release asset/);
+
+    const ghLog = await readFile(logFile, 'utf8');
+    assert.match(ghLog, /repos\/test-owner\/test-repo\/releases\/tags\/nightly/);
+    assert.match(ghLog, /repos\/test-owner\/test-repo\/releases\/assets\/1/);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('cleanup-release-assets still skips when explicit target repository mismatches', async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'astrbot-cleanup-release-assets-'));
+
+  try {
+    const logFile = path.join(tempDir, 'gh.log');
+    const binDir = await createFakeGh(tempDir, logFile);
+
+    const result = runCleanup({
+      GITHUB_REPOSITORY: 'test-owner/test-repo',
+      RELEASE_TAG: 'nightly',
+      ASTRBOT_RELEASE_CLEANUP_TARGET_REPOSITORY: 'AstrBotDevs/AstrBot-desktop',
+      PATH: `${binDir}:${process.env.PATH}`,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /Skipping release asset cleanup for non-target repository/);
+
+    await assert.rejects(readFile(logFile, 'utf8'));
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- default release asset cleanup to the repository currently running the workflow instead of a hardcoded upstream repo
- keep explicit cleanup target override and allow-any-repository bypass behavior intact
- add regression tests covering current-repo cleanup and explicit mismatch skipping

## Test Plan
- [x] `node --test scripts/ci/cleanup-release-assets.test.mjs`
- [x] `pnpm run test:prepare-resources`

## 由 Sourcery 提供的总结

将默认的 nightly 版本资产清理行为改为作用在运行该工作流的仓库上，并为此行为变更补充回归测试和文档。

Bug 修复：
- 将发布资产清理的默认目标从硬编码的上游仓库改为当前的 `GITHUB_REPOSITORY`，以避免在 fork 仓库和测试仓库中留下过期资产。

文档：
- 记录更新后的 nightly 版本资产清理行为的设计与实现方案。

测试：
- 添加回归测试，覆盖默认清理当前仓库以及在显式指定目标仓库不匹配时跳过清理的情形。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Default nightly release asset cleanup to the repository running the workflow and add regression coverage and docs for the behavior change.

Bug Fixes:
- Default release asset cleanup to the current GITHUB_REPOSITORY instead of a hardcoded upstream repository to avoid stale assets in forks and test repos.

Documentation:
- Document the design and implementation plan for the updated nightly release asset cleanup behavior.

Tests:
- Add regression tests covering default current-repository cleanup and explicit target-repository mismatch skipping.

</details>