### PR TITLE
fix: include desktop plugin site-packages in launcher sys.path

### DIFF
--- a/scripts/backend/templates/launch_backend.py
+++ b/scripts/backend/templates/launch_backend.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ctypes
 import os
 import runpy
+import site
 import sys
 from pathlib import Path
 
@@ -113,9 +114,30 @@ def preload_windows_runtime_dlls() -> None:
                     continue
 
 
+def configure_python_import_paths() -> None:
+    candidates: list[Path] = []
+    root = os.environ.get("ASTRBOT_ROOT")
+    if root:
+        candidates.append(Path(root).expanduser() / "data" / "site-packages")
+
+    try:
+        user_site = site.getusersitepackages()
+    except Exception:
+        user_site = ""
+    if user_site:
+        candidates.append(Path(user_site))
+
+    for candidate in candidates:
+        candidate_str = str(candidate)
+        if candidate_str in sys.path:
+            continue
+        sys.path.insert(0, candidate_str)
+
+
 configure_stdio_utf8()
 configure_windows_dll_search_path()
 preload_windows_runtime_dlls()
+configure_python_import_paths()
 
 sys.path.insert(0, str(APP_DIR))
 


### PR DESCRIPTION
## Summary
- add a minimal import-path bootstrap in launch_backend.py template
- prepend ASTRBOT_ROOT/data/site-packages for desktop plugin deps
- prepend Python user site-packages to avoid immediate import failures after pip user installs

## Why
On Linux RPM desktop installs, plugin dependency installation can fall back to user site-packages (log shows 'Defaulting to user installation'). Some plugins then fail to import newly installed modules during the same runtime startup (for example, yt_dlp).

This keeps the fix minimal and scoped to backend launcher path setup only.

## Summary by Sourcery

在应用启动之前更新后端启动器，以为插件依赖配置 Python 导入路径。

增强内容：
- 添加一个启动器辅助工具，将位于 `ASTRBOT_ROOT` 下的桌面插件 `site-packages` 目录预先插入到 Python 的 `sys.path` 中。
- 在启动器的导入路径配置中加入 Python 用户级 `site-packages` 目录，以支持在用户级安装的插件依赖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the backend launcher to configure Python import paths for plugin dependencies before application startup.

Enhancements:
- Add a launcher helper to prepend desktop plugin site-packages under ASTRBOT_ROOT to Python sys.path.
- Include the Python user site-packages directory in the launcher import path setup to support user-level plugin dependency installs.

</details>