### PR TITLE
fix(appimage): sanitize inherited Python env for packaged backend

### DIFF
--- a/src-tauri/src/backend/launch.rs
+++ b/src-tauri/src/backend/launch.rs
@@ -16,6 +16,21 @@ use crate::{
 #[cfg(target_os = "windows")]
 use crate::{CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW};
 
+fn sanitize_packaged_python_environment<F>(command: &mut Command, log: F)
+where
+    F: Fn(&str),
+{
+    for key in ["PYTHONHOME", "PYTHONPATH"] {
+        if env::var_os(key).is_some() {
+            log(&format!(
+                "clearing inherited {} for packaged backend runtime",
+                key
+            ));
+        }
+        command.env_remove(key);
+    }
+}
+
 impl BackendState {
     pub(crate) fn resolve_launch_plan(&self, app: &AppHandle) -> Result<crate::LaunchPlan, String> {
         if let Some(custom_cmd) = env::var("ASTRBOT_BACKEND_CMD")
@@ -96,6 +111,7 @@ impl BackendState {
         }
 
         if plan.packaged_mode {
+            sanitize_packaged_python_environment(&mut command, append_desktop_log);
             command.env("ASTRBOT_DESKTOP_CLIENT", "1");
             if env::var("DASHBOARD_HOST").is_err() && env::var("ASTRBOT_DASHBOARD_HOST").is_err() {
                 command.env("DASHBOARD_HOST", "127.0.0.1");
@@ -178,5 +194,31 @@ impl BackendState {
             self.stop_backend_log_rotation_worker();
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{ffi::OsStr, process::Command};
+
+    use super::sanitize_packaged_python_environment;
+
+    fn get_command_env_value(command: &Command, key: &str) -> Option<Option<String>> {
+        command
+            .get_envs()
+            .find(|(existing_key, _)| *existing_key == OsStr::new(key))
+            .map(|(_, value)| value.map(|v| v.to_string_lossy().into_owned()))
+    }
+
+    #[test]
+    fn sanitize_packaged_python_environment_marks_python_envs_for_removal() {
+        let mut command = Command::new("sh");
+        command.env("PYTHONHOME", "/tmp/fake-python-home");
+        command.env("PYTHONPATH", "/tmp/fake-python-path");
+
+        sanitize_packaged_python_environment(&mut command, |_| {});
+
+        assert_eq!(get_command_env_value(&command, "PYTHONHOME"), Some(None));
+        assert_eq!(get_command_env_value(&command, "PYTHONPATH"), Some(None));
     }
 }


### PR DESCRIPTION
## Summary
- sanitize inherited PYTHONHOME and PYTHONPATH before launching packaged backend python
- apply this only in packaged mode
- add a unit test that verifies both env keys are marked for removal on the backend Command

## Root cause
In AppImage runtime, inherited python env vars can be injected by launcher chain. This can break embedded backend python startup before launch_backend.py executes, with errors like:
- Fatal Python error: init_fs_encoding
- ModuleNotFoundError: No module named encodings

When backend exits immediately, desktop startup reports:
- Backend process exited before becoming reachable: exit status: 1

## Verification
- cargo test --manifest-path src-tauri/Cargo.toml sanitize_packaged_python_environment_marks_python_envs_for_removal passes.

## Summary by Sourcery

为打包后的后端 Python 进程清理环境变量，避免从桌面启动器继承冲突的 Python 配置。

Bug Fixes:
- 在启动打包后的后端时清除继承的 `PYTHONHOME` 和 `PYTHONPATH`，以防止嵌入式 Python 运行时时出现启动失败。

Tests:
- 添加单元测试，验证在打包模式下，后端命令环境中的 `PYTHONHOME` 和 `PYTHONPATH` 会被标记为移除。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Sanitize the environment for packaged backend Python processes to avoid inheriting conflicting Python configuration from the desktop launcher.

Bug Fixes:
- Clear inherited PYTHONHOME and PYTHONPATH when launching the packaged backend to prevent startup failures in embedded Python runtimes.

Tests:
- Add a unit test verifying that PYTHONHOME and PYTHONPATH are marked for removal on the backend command environment in packaged mode.

</details>