### PR TITLE
fix: stop false manual-download update prompts

### DIFF
--- a/src-tauri/src/bridge/commands.rs
+++ b/src-tauri/src/bridge/commands.rs
@@ -8,9 +8,9 @@ use crate::bridge::updater_messages::{
 };
 use crate::bridge::updater_mode::{resolve_desktop_update_mode, DesktopUpdateMode};
 use crate::bridge::updater_types::{
-    map_manual_download_result, map_manual_download_update_available_result, map_no_update_result,
-    map_update_available_result, map_update_channel_error, map_update_channel_ok,
-    map_update_check_error, map_update_install_error, map_update_install_ok,
+    map_manual_download_no_update_result, map_manual_download_update_available_result,
+    map_no_update_result, map_update_available_result, map_update_channel_error,
+    map_update_channel_ok, map_update_check_error, map_update_install_error, map_update_install_ok,
     DesktopAppUpdateChannelResult, DesktopAppUpdateCheckResult, DesktopAppUpdateResult,
 };
 use crate::{
@@ -61,7 +61,7 @@ fn build_channel_aware_updater(
         .map_err(|error| format!("Failed to initialize updater: {error}"))
 }
 
-fn short_circuit_update_check(
+fn update_check_short_circuit_result(
     mode: DesktopUpdateMode,
     current_version: &str,
 ) -> Option<(&'static str, DesktopAppUpdateCheckResult)> {
@@ -300,7 +300,9 @@ pub(crate) async fn desktop_bridge_check_app_update(
 ) -> DesktopAppUpdateCheckResult {
     let current_version = app_handle.package_info().version.to_string();
     let update_mode = resolve_desktop_update_mode();
-    if let Some((log_message, result)) = short_circuit_update_check(update_mode, &current_version) {
+    if let Some((log_message, result)) =
+        update_check_short_circuit_result(update_mode, &current_version)
+    {
         append_desktop_log(log_message);
         return result;
     }
@@ -320,9 +322,10 @@ pub(crate) async fn desktop_bridge_check_app_update(
             _ => map_update_available_result(&current_version, &update.version),
         },
         Ok(None) => match update_mode {
-            DesktopUpdateMode::ManualDownload => {
-                map_manual_download_result(&current_version, desktop_manual_download_reason())
-            }
+            DesktopUpdateMode::ManualDownload => map_manual_download_no_update_result(
+                &current_version,
+                desktop_manual_download_reason(),
+            ),
             _ => map_no_update_result(&current_version),
         },
         Err(error) => map_update_check_error(
@@ -367,16 +370,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn updater_check_manual_download_mode_does_not_short_circuit() {
+    fn update_check_short_circuit_only_applies_to_unsupported_mode() {
         assert!(
-            short_circuit_update_check(DesktopUpdateMode::ManualDownload, "4.19.2").is_none(),
-            "manual-download mode should still compare remote versions during update checks"
+            update_check_short_circuit_result(DesktopUpdateMode::ManualDownload, "4.19.2")
+                .is_none(),
+            "manual-download mode should keep running the update check"
         );
     }
 
     #[test]
     fn updater_check_manual_download_mode_only_reports_reason_without_forced_update_flag() {
-        let result = crate::bridge::updater_types::map_manual_download_result(
+        let result = crate::bridge::updater_types::map_manual_download_no_update_result(
             "4.19.2",
             crate::bridge::updater_messages::desktop_manual_download_reason(),
         );
@@ -397,7 +401,7 @@ mod tests {
     #[test]
     fn updater_check_mode_returns_unsupported_result() {
         let (log_message, result) =
-            short_circuit_update_check(DesktopUpdateMode::Unsupported, "4.19.2")
+            update_check_short_circuit_result(DesktopUpdateMode::Unsupported, "4.19.2")
                 .expect("unsupported mode should short-circuit update checks");
 
         assert_eq!(

--- a/src-tauri/src/bridge/updater_types.rs
+++ b/src-tauri/src/bridge/updater_types.rs
@@ -56,6 +56,7 @@ pub(crate) fn map_update_available_result(
     map_update_result(current_version, latest_version, None, true, false)
 }
 
+/// Maps a manual-download install that did find a newer remote release.
 pub(crate) fn map_manual_download_update_available_result(
     current_version: &str,
     latest_version: &str,
@@ -70,7 +71,8 @@ pub(crate) fn map_manual_download_update_available_result(
     )
 }
 
-pub(crate) fn map_manual_download_result(
+/// Maps a manual-download install that checked successfully but found no newer release.
+pub(crate) fn map_manual_download_no_update_result(
     current_version: &str,
     reason: impl Into<String>,
 ) -> DesktopAppUpdateCheckResult {
@@ -191,8 +193,8 @@ mod tests {
     }
 
     #[test]
-    fn map_manual_download_result_keeps_current_version_and_reason() {
-        let result = map_manual_download_result(
+    fn map_manual_download_no_update_result_keeps_current_version_and_reason() {
+        let result = map_manual_download_no_update_result(
             "4.19.2",
             crate::bridge::updater_messages::DESKTOP_UPDATER_MANUAL_DOWNLOAD_REASON,
         );
@@ -208,8 +210,8 @@ mod tests {
     }
 
     #[test]
-    fn map_manual_download_result_keeps_manual_download_message_without_update_flag() {
-        let result = map_manual_download_result(
+    fn map_manual_download_no_update_result_keeps_manual_download_message_without_update_flag() {
+        let result = map_manual_download_no_update_result(
             "4.19.2",
             crate::bridge::updater_messages::desktop_manual_download_reason(),
         );


### PR DESCRIPTION
## Summary
- let Linux manual-download installs keep running update checks so rpm/deb builds only report an update when the remote version is actually newer
- keep manual-download install behavior unchanged while returning manual-download messaging for both no-update and update-available results
- disable upstream CI AppImage publishing for now by removing AppImage Linux bundles and AppImage updater-manifest entries from the release pipeline

## Why AppImage publishing is paused
- AppImage still depends on host-specific Linux runtime details that are not stable enough for our upstream CI release contract, especially FUSE availability and distro-specific setup
- AppImage's own Wayland guidance also documents display-server/plugin compatibility issues, including cases that still require XWayland or Qt platform-plugin workarounds
- until we have a better compatibility matrix and validation story for Linux graphics/runtime behavior, upstream releases should not advertise AppImage as an official CI-produced updater target

## Test Plan
- [x] cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check
- [x] cargo test --manifest-path src-tauri/Cargo.toml --locked
- [x] python3 -m unittest scripts.ci.test_generate_tauri_latest_json
- [x] node --test scripts/ci/release-updater-artifacts.test.mjs