### PR TITLE
build: disable CI AppImage publishing

### DIFF
--- a/.github/workflows/build-desktop-tauri.yml
+++ b/.github/workflows/build-desktop-tauri.yml
@@ -211,13 +211,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [[ -n "${TAURI_SIGNING_PRIVATE_KEY-}" && -n "${TAURI_SIGNING_PRIVATE_KEY_PASSWORD-}" ]]; then
-            echo "TAURI signing secrets detected; building deb, rpm, and AppImage bundles."
-            cargo tauri build --bundles deb,rpm,appimage
-          else
-            echo "TAURI signing secrets missing; building deb and rpm bundles only."
-            cargo tauri build --bundles deb,rpm
-          fi
+          echo "Building Linux release bundles (deb and rpm only)."
+          cargo tauri build --bundles deb,rpm
 
       - name: Smoke test backend startup (Linux)
         shell: bash
@@ -233,16 +228,6 @@ jobs:
           path: |
             src-tauri/target/release/bundle/**/*.deb
             src-tauri/target/release/bundle/**/*.rpm
-
-      - name: Upload AppImage artifacts (Linux)
-        if: ${{ hashFiles('src-tauri/target/release/bundle/**/*.AppImage', 'src-tauri/target/release/bundle/**/*.AppImage.sig') != '' }}
-        uses: actions/upload-artifact@v6.0.0
-        with:
-          name: astrbot-desktop-tauri-${{ needs.resolve_build_context.outputs.astrbot_version }}-linux-${{ matrix.arch }}-appimage
-          if-no-files-found: ignore
-          path: |
-            src-tauri/target/release/bundle/**/*.AppImage
-            src-tauri/target/release/bundle/**/*.AppImage.sig
 
   build-macos:
     needs:

--- a/docs/plans/2026-03-08-disable-ci-appimage-design.md
+++ b/docs/plans/2026-03-08-disable-ci-appimage-design.md
@@ -1,0 +1,50 @@
+# Disable CI AppImage Publishing Design
+
+**Goal:** Stop publishing Linux AppImage artifacts from CI and remove AppImage entries from the official updater release pipeline, while keeping local AppImage builds available for manual validation.
+
+## Context
+
+The current Linux workflow still builds and uploads AppImage bundles in CI, and the release manifest generator publishes Linux AppImage updater entries. That turns AppImage into an upstream-supported release target.
+
+Recent AppImage platform guidance does not support treating that target as low-risk infrastructure:
+
+- AppImage runtime behavior still depends on host FUSE availability, and AppImage's own troubleshooting guidance documents distro-specific install and recovery steps.
+- AppImage's Wayland notes document display-server integration issues, including cases where bundled Qt stacks miss the required Wayland platform plugin and need XWayland or environment workarounds.
+- AppImage best-practice guidance also expects broad target validation against older Linux bases and bundled dependency compatibility, which our current GitHub Actions packaging path does not prove.
+
+Given that gap, upstream CI should stop producing and advertising AppImage release artifacts until Linux graphics/runtime compatibility is better validated.
+
+## Chosen Approach
+
+Remove AppImage from the official CI and release-manifest pipeline, but keep runtime detection and local build capability untouched.
+
+This means:
+
+1. Linux GitHub Actions builds produce only `deb` and `rpm` bundles.
+2. CI no longer uploads `.AppImage` or `.AppImage.sig` artifacts.
+3. Release manifest generation no longer recognizes or emits Linux AppImage updater platforms.
+4. Tests covering AppImage artifact normalization and manifest inclusion are removed or updated to reflect the new release contract.
+5. The upstream PR body explicitly explains that AppImage release publishing is paused because Linux graphics/runtime compatibility is not stable enough for automated upstream distribution.
+
+## Alternatives Considered
+
+### 1. Only remove AppImage from the Linux workflow
+
+Rejected because the release-manifest tooling and tests would still advertise AppImage as an official updater platform, leaving dead or misleading release logic in place.
+
+### 2. Remove CI, release-manifest handling, and runtime AppImage updater logic
+
+Rejected for now because it broadens the change from release-scope rollback into product-behavior rollback. Local experiments and future re-enablement are easier if runtime support remains isolated.
+
+## Impact
+
+- Official upstream releases stop shipping AppImage updater assets.
+- Official `latest.json` payloads stop containing `linux-*-appimage` entries.
+- Local developers can still build AppImage manually, but that path is no longer an upstream-published release guarantee.
+
+## Verification
+
+- Linux workflow contains no `appimage` bundle target and no AppImage artifact upload step.
+- Updater manifest generation tests pass without Linux AppImage support.
+- Release artifact normalization tests no longer assert AppImage canonicalization for `latest.json` generation.
+- PR description explains the FUSE / Wayland / Linux compatibility rationale for temporarily removing upstream AppImage publishing.

--- a/docs/plans/2026-03-08-disable-ci-appimage-plan.md
+++ b/docs/plans/2026-03-08-disable-ci-appimage-plan.md
@@ -1,0 +1,79 @@
+# Disable CI AppImage Publishing Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Remove Linux AppImage from the upstream CI and release manifest pipeline while preserving local AppImage build capability.
+
+**Architecture:** Shrink the Linux GitHub Actions build matrix output to `deb` and `rpm`, then remove AppImage handling from updater-manifest generation and release artifact normalization tests. Keep runtime AppImage detection untouched so local/manual AppImage builds still work outside the upstream release path.
+
+**Tech Stack:** GitHub Actions YAML, Python, Node.js tests, gh CLI
+
+---
+
+### Task 1: Lock the release-pipeline contract in tests
+
+**Files:**
+- Modify: `scripts/ci/test_generate_tauri_latest_json.py`
+- Modify: `scripts/ci/release-updater-artifacts.test.mjs`
+
+**Step 1: Write the failing test changes**
+
+Remove or rewrite AppImage-specific release-manifest expectations so the suite reflects the new contract: no AppImage updater artifacts should be recognized for published releases.
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+
+- `python3 -m unittest scripts.ci.test_generate_tauri_latest_json`
+- `node --test scripts/ci/release-updater-artifacts.test.mjs`
+
+Expected: FAIL because the implementation still recognizes AppImage release artifacts.
+
+### Task 2: Remove AppImage from CI and release-manifest generation
+
+**Files:**
+- Modify: `.github/workflows/build-desktop-tauri.yml`
+- Modify: `scripts/ci/generate_tauri_latest_json.py`
+
+**Step 1: Update Linux CI build output**
+
+Make Linux CI build only `deb,rpm` bundles and remove the AppImage upload step.
+
+**Step 2: Remove AppImage updater manifest handling**
+
+Delete Linux AppImage platform-key, filename, parsing, and collection logic from `generate_tauri_latest_json.py`.
+
+**Step 3: Re-run targeted tests**
+
+Run:
+
+- `python3 -m unittest scripts.ci.test_generate_tauri_latest_json`
+- `node --test scripts/ci/release-updater-artifacts.test.mjs`
+
+Expected: PASS.
+
+### Task 3: Update PR context and verify the change
+
+**Files:**
+- Review/Update PR body via `gh pr edit`
+
+**Step 1: Run final verification**
+
+Run:
+
+- `python3 -m unittest scripts.ci.test_generate_tauri_latest_json`
+- `node --test scripts/ci/release-updater-artifacts.test.mjs`
+
+Expected: PASS.
+
+**Step 2: Commit and push**
+
+```bash
+git add .github/workflows/build-desktop-tauri.yml scripts/ci/generate_tauri_latest_json.py scripts/ci/test_generate_tauri_latest_json.py scripts/ci/release-updater-artifacts.test.mjs
+git commit -m "build: disable CI AppImage publishing"
+git push
+```
+
+**Step 3: Update upstream PR description**
+
+Use `gh pr edit` to explain that Linux AppImage publishing is temporarily disabled in upstream CI because AppImage release compatibility still depends on Linux graphics/runtime details such as FUSE availability, Wayland/XWayland behavior, and broader target-system validation.

--- a/scripts/ci/generate_tauri_latest_json.py
+++ b/scripts/ci/generate_tauri_latest_json.py
@@ -11,7 +11,6 @@ from scripts.ci.lib.artifact_arch import normalize_arch_alias
 from scripts.ci.lib.nightly_version import NIGHTLY_CANONICAL_FORMAT, NIGHTLY_VERSION_RE
 from scripts.ci.lib.release_artifacts import (
     ARTIFACT_EXTENSIONS,
-    LINUX_APPIMAGE_UPDATER_PATTERNS,
     MACOS_UPDATER_ARCHIVE_EXTENSION,
     MACOS_UPDATER_ARCHIVE_PATTERNS,
     MACOS_UPDATER_SIGNATURE_EXTENSION,
@@ -59,15 +58,6 @@ def platform_key_for_macos(arch: str) -> str:
     raise ValueError(f"Unsupported macOS arch: {arch}")
 
 
-def platform_key_for_linux_appimage(arch: str) -> str:
-    arch = normalize_arch(arch)
-    if arch == "amd64":
-        return "linux-x86_64-appimage"
-    if arch == "arm64":
-        return "linux-aarch64-appimage"
-    raise ValueError(f"Unsupported Linux AppImage arch: {arch}")
-
-
 def derive_release_metadata(version: str, channel: str | None) -> tuple[str, str, str]:
     inferred_channel = "nightly" if "nightly" in version.lower() else "stable"
     effective_channel = channel or inferred_channel
@@ -111,14 +101,6 @@ def canonical_macos_filename(
     return f"{name}_{base_version}_macos_{arch}{nightly_suffix}{MACOS_UPDATER_ARCHIVE_EXTENSION}"
 
 
-def canonical_linux_appimage_filename(
-    name: str, arch: str, version: str, channel: str
-) -> str:
-    _, base_version, nightly_suffix = derive_release_metadata(version, channel)
-    arch = normalize_arch(arch)
-    return f"{name}_{base_version}_linux_{arch}{nightly_suffix}.AppImage"
-
-
 def parse_windows_artifact_name(source_name: str) -> re.Match[str]:
     match = match_any(source_name, WINDOWS_UPDATER_PATTERNS)
     if match:
@@ -145,19 +127,6 @@ def parse_macos_artifact_name(source_name: str) -> re.Match[str]:
             "(nightly builds may append _nightly_<sha> before the extension)."
         )
     return match
-
-
-def parse_linux_appimage_artifact_name(source_name: str) -> re.Match[str]:
-    match = match_any(source_name, LINUX_APPIMAGE_UPDATER_PATTERNS)
-    if match:
-        return match
-    raise ValueError(
-        "Unexpected Linux AppImage artifact name: "
-        f"{source_name}. Expected format: "
-        "<name>_<version>_linux_<arch>.AppImage or legacy "
-        "<name>_<version>_<arch>.AppImage "
-        "(nightly builds may append _nightly_<sha> before .AppImage)."
-    )
 
 
 def add_platform(
@@ -234,26 +203,6 @@ def collect_platforms(
                 platforms,
                 platform_key_for_macos(match.group("arch")),
                 "macOS",
-                artifact_name,
-                sig_path,
-                repo,
-                tag,
-            )
-            continue
-
-        if sig_name.endswith(".AppImage.sig"):
-            source_name = sig_name[:-4]
-            match = parse_linux_appimage_artifact_name(source_name)
-            artifact_name = canonical_linux_appimage_filename(
-                match.group("name"),
-                match.group("arch"),
-                version,
-                channel,
-            )
-            add_platform(
-                platforms,
-                platform_key_for_linux_appimage(match.group("arch")),
-                "Linux AppImage",
                 artifact_name,
                 sig_path,
                 repo,

--- a/scripts/ci/release-updater-artifacts.test.mjs
+++ b/scripts/ci/release-updater-artifacts.test.mjs
@@ -305,7 +305,7 @@ test('release artifact normalization keeps updater signatures aligned for latest
   }
 });
 
-test('release artifact normalization canonicalizes linux AppImage assets for latest.json generation', async () => {
+test('release artifact normalization leaves linux AppImage assets unsupported for latest.json generation', async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), 'astrbot-release-artifacts-'));
 
   try {
@@ -343,29 +343,26 @@ test('release artifact normalization canonicalizes linux AppImage assets for lat
     await access(normalizedLinux, fsConstants.F_OK);
     await access(normalizedLinuxSig, fsConstants.F_OK);
 
-    const outputPath = path.join(artifactsDir, 'latest.json');
-    runPython(
-      generateModule,
-      [
-        '--artifacts-root',
-        artifactsDir,
-        '--repo',
-        'AstrBotDevs/AstrBot-desktop',
-        '--tag',
-        'nightly',
-        '--version',
-        '4.19.2-nightly.20260306.7ac169c5',
-        '--output',
-        outputPath,
-      ],
-      projectRoot,
+    assert.throws(
+      () =>
+        runPython(
+          generateModule,
+          [
+            '--artifacts-root',
+            artifactsDir,
+            '--repo',
+            'AstrBotDevs/AstrBot-desktop',
+            '--tag',
+            'nightly',
+            '--version',
+            '4.19.2-nightly.20260306.7ac169c5',
+            '--output',
+            path.join(artifactsDir, 'latest.json'),
+          ],
+          projectRoot,
+        ),
+      /Unsupported updater signature files under artifacts root/,
     );
-
-    const payload = JSON.parse(await readFile(outputPath, 'utf8'));
-    assert.deepEqual(payload.platforms['linux-aarch64-appimage'], {
-      signature: 'linux-signature',
-      url: 'https://github.com/AstrBotDevs/AstrBot-desktop/releases/download/nightly/AstrBot_4.19.2_linux_arm64_nightly_7ac169c5.AppImage',
-    });
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/scripts/ci/test_generate_tauri_latest_json.py
+++ b/scripts/ci/test_generate_tauri_latest_json.py
@@ -43,12 +43,6 @@ class GenerateTauriLatestJsonTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, r"Unsupported macOS arch: ppc64le"):
             MODULE.platform_key_for_macos("ppc64le")
 
-    def test_platform_key_for_linux_appimage_unsupported_arch(self):
-        with self.assertRaisesRegex(
-            ValueError, r"Unsupported Linux AppImage arch: ppc64le"
-        ):
-            MODULE.platform_key_for_linux_appimage("ppc64le")
-
     def test_derive_release_metadata_validates_and_returns_expected_values(self):
         self.assertEqual(
             MODULE.derive_release_metadata("4.29.0", None),
@@ -120,23 +114,6 @@ class GenerateTauriLatestJsonTests(unittest.TestCase):
                 "nightly",
             ),
             "AstrBot_4.29.0_macos_arm64_nightly_abcd1234.app.tar.gz",
-        )
-
-    def test_canonical_linux_appimage_filename_outputs_expected_names(self):
-        self.assertEqual(
-            MODULE.canonical_linux_appimage_filename(
-                "AstrBot", "arm64", "4.29.0", "stable"
-            ),
-            "AstrBot_4.29.0_linux_arm64.AppImage",
-        )
-        self.assertEqual(
-            MODULE.canonical_linux_appimage_filename(
-                "AstrBot",
-                "aarch64",
-                "4.29.0-nightly.20260307.abcd1234",
-                "nightly",
-            ),
-            "AstrBot_4.29.0_linux_arm64_nightly_abcd1234.AppImage",
         )
 
     def test_main_writes_expected_manifest_json(self):
@@ -483,27 +460,24 @@ class GenerateTauriLatestJsonTests(unittest.TestCase):
 
         self.assertIn("darwin-aarch64", platforms)
 
-    def test_collect_platforms_accepts_linux_appimage_canonical_name(self):
+    def test_collect_platforms_rejects_linux_appimage_signature_files(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             (
                 root / "AstrBot_4.29.0_linux_arm64_nightly_abcd1234.AppImage.sig"
             ).write_text("sig-linux")
 
-            platforms = MODULE.collect_platforms(
-                root,
-                "AstrBotDevs/AstrBot-desktop",
-                "nightly",
-                version="4.29.0-nightly.20260307.abcd1234",
-                channel="nightly",
-            )
-
-        self.assertIn("linux-aarch64-appimage", platforms)
-        self.assertEqual(
-            platforms["linux-aarch64-appimage"]["url"],
-            "https://github.com/AstrBotDevs/AstrBot-desktop/releases/download/nightly/"
-            "AstrBot_4.29.0_linux_arm64_nightly_abcd1234.AppImage",
-        )
+            with self.assertRaisesRegex(
+                ValueError,
+                "Unsupported updater signature files under artifacts root",
+            ):
+                MODULE.collect_platforms(
+                    root,
+                    "AstrBotDevs/AstrBot-desktop",
+                    "nightly",
+                    version="4.29.0-nightly.20260307.abcd1234",
+                    channel="nightly",
+                )
 
     def test_collect_platforms_invalid_windows_sig_raises(self):
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary
- stop GitHub Actions from building and uploading Linux AppImage artifacts, leaving Linux CI releases on deb/rpm only
- remove Linux AppImage updater-manifest handling from the official release pipeline so upstream latest.json no longer advertises AppImage targets
- keep local AppImage builds available for manual validation while pausing upstream AppImage publishing

## Why AppImage publishing is paused
- AppImage still depends on host-specific Linux runtime details that are not stable enough for our upstream CI release contract, especially FUSE availability and distro-specific setup
- AppImage's own Wayland guidance also documents display-server/plugin compatibility issues, including cases that still require XWayland or Qt platform-plugin workarounds
- until we have a better compatibility matrix and validation story for Linux graphics/runtime behavior, upstream releases should not advertise AppImage as an official CI-produced updater target

## Test Plan
- [x] python3 -m unittest scripts.ci.test_generate_tauri_latest_json
- [x] node --test scripts/ci/release-updater-artifacts.test.mjs

## Summary by Sourcery

在保留本地构建 AppImage 能力的前提下，禁用 Linux AppImage 作为官方 CI 构建和更新器目标。

Enhancements:
- 从更新器 manifest 生成器中移除对 Linux AppImage 平台的处理，使 `latest.json` 不再包含 AppImage 平台信息。
- 更新发布构件规范化测试，以断言 AppImage 资源不再受 manifest 生成支持。
- 在新的 Markdown 文件中记录暂停 CI 发布 AppImage 的实施方案和设计理由。

Build:
- 修改桌面端 Tauri 的 GitHub Actions 工作流，使其在 Linux 上只构建并上传 deb 和 rpm 包，CI 中不再构建和上传 AppImage 包。

Tests:
- 调整 Python 和 Node.js 测试，以反映发布 manifest 流水线不再识别或输出 Linux AppImage 构件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Disable Linux AppImage as an official CI build and updater target while preserving local AppImage build capability.

Enhancements:
- Remove Linux AppImage platform handling from the updater manifest generator so latest.json no longer includes AppImage platforms.
- Update release artifact normalization tests to assert that AppImage assets are unsupported for manifest generation.
- Document the implementation plan and design rationale for pausing CI AppImage publishing in new markdown files.

Build:
- Change the desktop Tauri GitHub Actions workflow to build and upload only deb and rpm bundles on Linux, dropping AppImage bundles from CI.

Tests:
- Adjust Python and Node.js tests to reflect that Linux AppImage artifacts are no longer recognized or emitted by the release manifest pipeline.

</details>