### PR TITLE
[codex] refine startup loading copy

### DIFF
--- a/scripts/prepare-resources/startup-shell-copy.test.mjs
+++ b/scripts/prepare-resources/startup-shell-copy.test.mjs
@@ -49,8 +49,13 @@ test('startup shell loads shared copy config, reuses applyStartupMode, and expos
   );
   assert.match(
     source,
-    /const\s+\{\s*STARTUP_MODES,\s*STARTUP_COPY\s*\}\s*=\s*window\.__astrbotStartupShell;/,
-    'expected startup shell to read startup copy from the shared config',
+    /const\s+startupShell\s*=\s*window\.astrbot\.startupShell;/,
+    'expected startup shell to read its shared config from a named astrbot namespace',
+  );
+  assert.match(
+    source,
+    /const\s+\{\s*STARTUP_MODES,\s*STARTUP_COPY\s*\}\s*=\s*startupShell;/,
+    'expected startup shell to destructure startup config from the namespaced object',
   );
   assert.doesNotMatch(
     source,
@@ -62,20 +67,45 @@ test('startup shell loads shared copy config, reuses applyStartupMode, and expos
     /applyStartupMode\(STARTUP_MODES\.LOADING\);/,
     'expected startup shell to initialize through applyStartupMode',
   );
+  assert.match(
+    source,
+    /if\s*\(status\.textContent\s*===\s*next\.status\)\s*return;/,
+    'expected startup shell to skip duplicate status announcements',
+  );
 
   assert.match(
     configSource,
-    /const\s+STARTUP_MODES\s*=\s*Object\.freeze\(/,
+    /const\s+deepFreeze\s*=\s*\(obj\)\s*=>/,
+    'expected shared startup copy config to use a deepFreeze helper',
+  );
+  assert.match(
+    configSource,
+    /const\s+STARTUP_MODES\s*=\s*\{/,
     'expected shared startup copy config to define startup modes',
   );
   assert.match(
     configSource,
-    /const\s+STARTUP_COPY\s*=\s*Object\.freeze\(/,
+    /window\.astrbot\s*=\s*window\.astrbot\s*\|\|\s*\{\};/,
+    'expected shared startup copy config to allocate the astrbot namespace',
+  );
+  assert.match(
+    configSource,
+    /window\.astrbot\.startupShell\s*=\s*deepFreeze\(/,
+    'expected shared startup copy config to expose startup shell under the astrbot namespace',
+  );
+  assert.match(
+    configSource,
+    /STARTUP_COPY:\s*\{/,
     'expected shared startup copy config to define localized startup copy',
   );
   assert.match(
     configSource,
-    /window\.__astrbotStartupShell\s*=\s*Object\.freeze\(/,
-    'expected shared startup copy config to expose startup shell data on window',
+    /en:\s*\{/,
+    'expected shared startup copy config to include English startup copy',
+  );
+  assert.match(
+    configSource,
+    /zh:\s*\{/,
+    'expected shared startup copy config to include Chinese startup copy',
   );
 });

--- a/ui/index.html
+++ b/ui/index.html
@@ -151,9 +151,10 @@
         const desc = document.getElementById("startup-desc");
         const status = document.getElementById("startup-status");
         if (!title || !desc || !status) return;
-        if (!window.__astrbotStartupShell) return;
+        if (!window.astrbot || !window.astrbot.startupShell) return;
 
-        const { STARTUP_MODES, STARTUP_COPY } = window.__astrbotStartupShell;
+        const startupShell = window.astrbot.startupShell;
+        const { STARTUP_MODES, STARTUP_COPY } = startupShell;
 
         const resolveLocaleKey = () => {
           const locale =
@@ -173,6 +174,7 @@
           const next = resolveStartupCopy(mode);
           title.textContent = next.title;
           desc.textContent = next.desc;
+          if (status.textContent === next.status) return;
           status.textContent = next.status;
         };
 

--- a/ui/startup-copy.js
+++ b/ui/startup-copy.js
@@ -1,38 +1,46 @@
-(() => {
-  const STARTUP_MODES = Object.freeze({
-    LOADING: 'loading',
-    PANEL_UPDATE: 'panel-update',
-  });
+const deepFreeze = (obj) => {
+  for (const key of Object.getOwnPropertyNames(obj)) {
+    const value = obj[key];
+    if (value && typeof value === 'object' && !Object.isFrozen(value)) {
+      deepFreeze(value);
+    }
+  }
 
-  const STARTUP_COPY = Object.freeze({
-    en: Object.freeze({
-      [STARTUP_MODES.LOADING]: Object.freeze({
+  return Object.freeze(obj);
+};
+
+const STARTUP_MODES = {
+  LOADING: 'loading',
+  PANEL_UPDATE: 'panel-update',
+};
+
+window.astrbot = window.astrbot || {};
+window.astrbot.startupShell = deepFreeze({
+  STARTUP_MODES,
+  STARTUP_COPY: {
+    en: {
+      [STARTUP_MODES.LOADING]: {
         title: 'AstrBot Desktop',
         desc: 'Preparing the runtime, please wait.',
         status: 'Starting core services...',
-      }),
-      [STARTUP_MODES.PANEL_UPDATE]: Object.freeze({
+      },
+      [STARTUP_MODES.PANEL_UPDATE]: {
         title: 'AstrBot Desktop',
         desc: 'A new panel version is available and is being downloaded and applied.',
         status: 'Syncing panel assets...',
-      }),
-    }),
-    zh: Object.freeze({
-      [STARTUP_MODES.LOADING]: Object.freeze({
+      },
+    },
+    zh: {
+      [STARTUP_MODES.LOADING]: {
         title: 'AstrBot Desktop',
         desc: '正在准备运行环境，请稍候。',
         status: '正在启动核心服务...',
-      }),
-      [STARTUP_MODES.PANEL_UPDATE]: Object.freeze({
+      },
+      [STARTUP_MODES.PANEL_UPDATE]: {
         title: 'AstrBot Desktop',
         desc: '检测到新面板版本，正在下载并应用。',
         status: '正在同步面板资源...',
-      }),
-    }),
-  });
-
-  window.__astrbotStartupShell = Object.freeze({
-    STARTUP_MODES,
-    STARTUP_COPY,
-  });
-})();
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary
This update reduces repeated startup messaging on the desktop loading screen by separating the product title from the state and progress text. The previous copy repeated the same startup idea in the title, subtitle, and status row, which made the loading shell feel noisy and less intentional.

The root cause was that `ui/index.html` used nearly identical loading phrases for all three text slots in both the normal loading mode and the panel update mode. That weakened the hierarchy because each line communicated the same thing instead of letting the title identify the product, the description explain the phase, and the status line reflect the current action.

The fix updates the startup copy to use `AstrBot Desktop` as the consistent title and rewrites the localized description and status text for both `loading` and `panel-update` modes. The result is a clearer information hierarchy with less repetition and more specific progress language for both Chinese and English users.

## Validation
- Ran `pnpm run test:prepare-resources`
- Ran `git diff --check`

## Summary by Sourcery

将桌面启动屏幕的文案统一并外部化到共享配置中，同时提升其可访问性和本地化消息质量。

Enhancements:
- 从共享的、带命名空间的 `startup-copy` 配置中加载启动标题、描述和状态文本，而不是将它们硬编码在 HTML shell 中。
- 将启动标题统一为 “AstrBot Desktop”，并优化英文和中文的描述及状态消息，涵盖加载模式和面板更新模式。
- 调整启动状态元素，使其作为一个“礼貌”的实时区域（polite live region），并在状态文本未变化时避免重复朗读。
- 对共享的启动 shell 配置进行深度冻结（deep-freeze），以防止运行时被修改。

Tests:
- 添加基于 Node 的测试，用于验证启动 shell 是否使用共享文案配置、是否正确暴露可访问性属性，以及是否在 HTML 中避免重复文案或配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify and externalize the desktop startup screen copy into a shared config while improving its accessibility and localized messaging.

Enhancements:
- Load startup title, description, and status text from a shared namespaced startup-copy config instead of hardcoding them in the HTML shell.
- Standardize the startup title to "AstrBot Desktop" and refine English and Chinese descriptions and status messages for loading and panel-update modes.
- Adjust the startup status element to act as a polite live region and avoid duplicate announcements when the status text does not change.
- Deep-freeze the shared startup shell configuration to prevent runtime mutation.

Tests:
- Add a node-based test to verify the startup shell uses the shared copy config, exposes the accessibility attributes, and skips duplicated copy or configuration in the HTML.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将桌面启动屏幕的文案统一并外部化到共享配置中，同时提升其可访问性和本地化消息质量。

Enhancements:
- 从共享的、带命名空间的 `startup-copy` 配置中加载启动标题、描述和状态文本，而不是将它们硬编码在 HTML shell 中。
- 将启动标题统一为 “AstrBot Desktop”，并优化英文和中文的描述及状态消息，涵盖加载模式和面板更新模式。
- 调整启动状态元素，使其作为一个“礼貌”的实时区域（polite live region），并在状态文本未变化时避免重复朗读。
- 对共享的启动 shell 配置进行深度冻结（deep-freeze），以防止运行时被修改。

Tests:
- 添加基于 Node 的测试，用于验证启动 shell 是否使用共享文案配置、是否正确暴露可访问性属性，以及是否在 HTML 中避免重复文案或配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify and externalize the desktop startup screen copy into a shared config while improving its accessibility and localized messaging.

Enhancements:
- Load startup title, description, and status text from a shared namespaced startup-copy config instead of hardcoding them in the HTML shell.
- Standardize the startup title to "AstrBot Desktop" and refine English and Chinese descriptions and status messages for loading and panel-update modes.
- Adjust the startup status element to act as a polite live region and avoid duplicate announcements when the status text does not change.
- Deep-freeze the shared startup shell configuration to prevent runtime mutation.

Tests:
- Add a node-based test to verify the startup shell uses the shared copy config, exposes the accessibility attributes, and skips duplicated copy or configuration in the HTML.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将桌面启动屏幕的文案统一并外部化到共享配置中，同时提升其可访问性和本地化消息质量。

Enhancements:
- 从共享的、带命名空间的 `startup-copy` 配置中加载启动标题、描述和状态文本，而不是将它们硬编码在 HTML shell 中。
- 将启动标题统一为 “AstrBot Desktop”，并优化英文和中文的描述及状态消息，涵盖加载模式和面板更新模式。
- 调整启动状态元素，使其作为一个“礼貌”的实时区域（polite live region），并在状态文本未变化时避免重复朗读。
- 对共享的启动 shell 配置进行深度冻结（deep-freeze），以防止运行时被修改。

Tests:
- 添加基于 Node 的测试，用于验证启动 shell 是否使用共享文案配置、是否正确暴露可访问性属性，以及是否在 HTML 中避免重复文案或配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify and externalize the desktop startup screen copy into a shared config while improving its accessibility and localized messaging.

Enhancements:
- Load startup title, description, and status text from a shared namespaced startup-copy config instead of hardcoding them in the HTML shell.
- Standardize the startup title to "AstrBot Desktop" and refine English and Chinese descriptions and status messages for loading and panel-update modes.
- Adjust the startup status element to act as a polite live region and avoid duplicate announcements when the status text does not change.
- Deep-freeze the shared startup shell configuration to prevent runtime mutation.

Tests:
- Add a node-based test to verify the startup shell uses the shared copy config, exposes the accessibility attributes, and skips duplicated copy or configuration in the HTML.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将桌面启动屏幕的文案统一并外部化到共享配置中，同时提升其可访问性和本地化消息质量。

Enhancements:
- 从共享的、带命名空间的 `startup-copy` 配置中加载启动标题、描述和状态文本，而不是将它们硬编码在 HTML shell 中。
- 将启动标题统一为 “AstrBot Desktop”，并优化英文和中文的描述及状态消息，涵盖加载模式和面板更新模式。
- 调整启动状态元素，使其作为一个“礼貌”的实时区域（polite live region），并在状态文本未变化时避免重复朗读。
- 对共享的启动 shell 配置进行深度冻结（deep-freeze），以防止运行时被修改。

Tests:
- 添加基于 Node 的测试，用于验证启动 shell 是否使用共享文案配置、是否正确暴露可访问性属性，以及是否在 HTML 中避免重复文案或配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify and externalize the desktop startup screen copy into a shared config while improving its accessibility and localized messaging.

Enhancements:
- Load startup title, description, and status text from a shared namespaced startup-copy config instead of hardcoding them in the HTML shell.
- Standardize the startup title to "AstrBot Desktop" and refine English and Chinese descriptions and status messages for loading and panel-update modes.
- Adjust the startup status element to act as a polite live region and avoid duplicate announcements when the status text does not change.
- Deep-freeze the shared startup shell configuration to prevent runtime mutation.

Tests:
- Add a node-based test to verify the startup shell uses the shared copy config, exposes the accessibility attributes, and skips duplicated copy or configuration in the HTML.

</details>

</details>

</details>

改进内容：
- 在加载和面板更新模式下统一启动标题为“AstrBot Desktop”。
- 改进中英文的加载描述和状态文本，更好地区分产品身份、加载阶段和当前操作。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将桌面启动屏幕的文案统一并外部化到共享配置中，同时提升其可访问性和本地化消息质量。

Enhancements:
- 从共享的、带命名空间的 `startup-copy` 配置中加载启动标题、描述和状态文本，而不是将它们硬编码在 HTML shell 中。
- 将启动标题统一为 “AstrBot Desktop”，并优化英文和中文的描述及状态消息，涵盖加载模式和面板更新模式。
- 调整启动状态元素，使其作为一个“礼貌”的实时区域（polite live region），并在状态文本未变化时避免重复朗读。
- 对共享的启动 shell 配置进行深度冻结（deep-freeze），以防止运行时被修改。

Tests:
- 添加基于 Node 的测试，用于验证启动 shell 是否使用共享文案配置、是否正确暴露可访问性属性，以及是否在 HTML 中避免重复文案或配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify and externalize the desktop startup screen copy into a shared config while improving its accessibility and localized messaging.

Enhancements:
- Load startup title, description, and status text from a shared namespaced startup-copy config instead of hardcoding them in the HTML shell.
- Standardize the startup title to "AstrBot Desktop" and refine English and Chinese descriptions and status messages for loading and panel-update modes.
- Adjust the startup status element to act as a polite live region and avoid duplicate announcements when the status text does not change.
- Deep-freeze the shared startup shell configuration to prevent runtime mutation.

Tests:
- Add a node-based test to verify the startup shell uses the shared copy config, exposes the accessibility attributes, and skips duplicated copy or configuration in the HTML.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将桌面启动屏幕的文案统一并外部化到共享配置中，同时提升其可访问性和本地化消息质量。

Enhancements:
- 从共享的、带命名空间的 `startup-copy` 配置中加载启动标题、描述和状态文本，而不是将它们硬编码在 HTML shell 中。
- 将启动标题统一为 “AstrBot Desktop”，并优化英文和中文的描述及状态消息，涵盖加载模式和面板更新模式。
- 调整启动状态元素，使其作为一个“礼貌”的实时区域（polite live region），并在状态文本未变化时避免重复朗读。
- 对共享的启动 shell 配置进行深度冻结（deep-freeze），以防止运行时被修改。

Tests:
- 添加基于 Node 的测试，用于验证启动 shell 是否使用共享文案配置、是否正确暴露可访问性属性，以及是否在 HTML 中避免重复文案或配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify and externalize the desktop startup screen copy into a shared config while improving its accessibility and localized messaging.

Enhancements:
- Load startup title, description, and status text from a shared namespaced startup-copy config instead of hardcoding them in the HTML shell.
- Standardize the startup title to "AstrBot Desktop" and refine English and Chinese descriptions and status messages for loading and panel-update modes.
- Adjust the startup status element to act as a polite live region and avoid duplicate announcements when the status text does not change.
- Deep-freeze the shared startup shell configuration to prevent runtime mutation.

Tests:
- Add a node-based test to verify the startup shell uses the shared copy config, exposes the accessibility attributes, and skips duplicated copy or configuration in the HTML.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将桌面启动屏幕的文案统一并外部化到共享配置中，同时提升其可访问性和本地化消息质量。

Enhancements:
- 从共享的、带命名空间的 `startup-copy` 配置中加载启动标题、描述和状态文本，而不是将它们硬编码在 HTML shell 中。
- 将启动标题统一为 “AstrBot Desktop”，并优化英文和中文的描述及状态消息，涵盖加载模式和面板更新模式。
- 调整启动状态元素，使其作为一个“礼貌”的实时区域（polite live region），并在状态文本未变化时避免重复朗读。
- 对共享的启动 shell 配置进行深度冻结（deep-freeze），以防止运行时被修改。

Tests:
- 添加基于 Node 的测试，用于验证启动 shell 是否使用共享文案配置、是否正确暴露可访问性属性，以及是否在 HTML 中避免重复文案或配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify and externalize the desktop startup screen copy into a shared config while improving its accessibility and localized messaging.

Enhancements:
- Load startup title, description, and status text from a shared namespaced startup-copy config instead of hardcoding them in the HTML shell.
- Standardize the startup title to "AstrBot Desktop" and refine English and Chinese descriptions and status messages for loading and panel-update modes.
- Adjust the startup status element to act as a polite live region and avoid duplicate announcements when the status text does not change.
- Deep-freeze the shared startup shell configuration to prevent runtime mutation.

Tests:
- Add a node-based test to verify the startup shell uses the shared copy config, exposes the accessibility attributes, and skips duplicated copy or configuration in the HTML.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将桌面启动屏幕的文案统一并外部化到共享配置中，同时提升其可访问性和本地化消息质量。

Enhancements:
- 从共享的、带命名空间的 `startup-copy` 配置中加载启动标题、描述和状态文本，而不是将它们硬编码在 HTML shell 中。
- 将启动标题统一为 “AstrBot Desktop”，并优化英文和中文的描述及状态消息，涵盖加载模式和面板更新模式。
- 调整启动状态元素，使其作为一个“礼貌”的实时区域（polite live region），并在状态文本未变化时避免重复朗读。
- 对共享的启动 shell 配置进行深度冻结（deep-freeze），以防止运行时被修改。

Tests:
- 添加基于 Node 的测试，用于验证启动 shell 是否使用共享文案配置、是否正确暴露可访问性属性，以及是否在 HTML 中避免重复文案或配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify and externalize the desktop startup screen copy into a shared config while improving its accessibility and localized messaging.

Enhancements:
- Load startup title, description, and status text from a shared namespaced startup-copy config instead of hardcoding them in the HTML shell.
- Standardize the startup title to "AstrBot Desktop" and refine English and Chinese descriptions and status messages for loading and panel-update modes.
- Adjust the startup status element to act as a polite live region and avoid duplicate announcements when the status text does not change.
- Deep-freeze the shared startup shell configuration to prevent runtime mutation.

Tests:
- Add a node-based test to verify the startup shell uses the shared copy config, exposes the accessibility attributes, and skips duplicated copy or configuration in the HTML.

</details>

</details>

</details>

</details>

增强内容：
- 在加载和面板更新模式中，将启动标题统一为 AstrBot Desktop。
- 改进桌面加载界面的中英文描述和状态文案，更清晰地区分产品身份、加载阶段和当前操作。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将桌面启动屏幕的文案统一并外部化到共享配置中，同时提升其可访问性和本地化消息质量。

Enhancements:
- 从共享的、带命名空间的 `startup-copy` 配置中加载启动标题、描述和状态文本，而不是将它们硬编码在 HTML shell 中。
- 将启动标题统一为 “AstrBot Desktop”，并优化英文和中文的描述及状态消息，涵盖加载模式和面板更新模式。
- 调整启动状态元素，使其作为一个“礼貌”的实时区域（polite live region），并在状态文本未变化时避免重复朗读。
- 对共享的启动 shell 配置进行深度冻结（deep-freeze），以防止运行时被修改。

Tests:
- 添加基于 Node 的测试，用于验证启动 shell 是否使用共享文案配置、是否正确暴露可访问性属性，以及是否在 HTML 中避免重复文案或配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify and externalize the desktop startup screen copy into a shared config while improving its accessibility and localized messaging.

Enhancements:
- Load startup title, description, and status text from a shared namespaced startup-copy config instead of hardcoding them in the HTML shell.
- Standardize the startup title to "AstrBot Desktop" and refine English and Chinese descriptions and status messages for loading and panel-update modes.
- Adjust the startup status element to act as a polite live region and avoid duplicate announcements when the status text does not change.
- Deep-freeze the shared startup shell configuration to prevent runtime mutation.

Tests:
- Add a node-based test to verify the startup shell uses the shared copy config, exposes the accessibility attributes, and skips duplicated copy or configuration in the HTML.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将桌面启动屏幕的文案统一并外部化到共享配置中，同时提升其可访问性和本地化消息质量。

Enhancements:
- 从共享的、带命名空间的 `startup-copy` 配置中加载启动标题、描述和状态文本，而不是将它们硬编码在 HTML shell 中。
- 将启动标题统一为 “AstrBot Desktop”，并优化英文和中文的描述及状态消息，涵盖加载模式和面板更新模式。
- 调整启动状态元素，使其作为一个“礼貌”的实时区域（polite live region），并在状态文本未变化时避免重复朗读。
- 对共享的启动 shell 配置进行深度冻结（deep-freeze），以防止运行时被修改。

Tests:
- 添加基于 Node 的测试，用于验证启动 shell 是否使用共享文案配置、是否正确暴露可访问性属性，以及是否在 HTML 中避免重复文案或配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify and externalize the desktop startup screen copy into a shared config while improving its accessibility and localized messaging.

Enhancements:
- Load startup title, description, and status text from a shared namespaced startup-copy config instead of hardcoding them in the HTML shell.
- Standardize the startup title to "AstrBot Desktop" and refine English and Chinese descriptions and status messages for loading and panel-update modes.
- Adjust the startup status element to act as a polite live region and avoid duplicate announcements when the status text does not change.
- Deep-freeze the shared startup shell configuration to prevent runtime mutation.

Tests:
- Add a node-based test to verify the startup shell uses the shared copy config, exposes the accessibility attributes, and skips duplicated copy or configuration in the HTML.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将桌面启动屏幕的文案统一并外部化到共享配置中，同时提升其可访问性和本地化消息质量。

Enhancements:
- 从共享的、带命名空间的 `startup-copy` 配置中加载启动标题、描述和状态文本，而不是将它们硬编码在 HTML shell 中。
- 将启动标题统一为 “AstrBot Desktop”，并优化英文和中文的描述及状态消息，涵盖加载模式和面板更新模式。
- 调整启动状态元素，使其作为一个“礼貌”的实时区域（polite live region），并在状态文本未变化时避免重复朗读。
- 对共享的启动 shell 配置进行深度冻结（deep-freeze），以防止运行时被修改。

Tests:
- 添加基于 Node 的测试，用于验证启动 shell 是否使用共享文案配置、是否正确暴露可访问性属性，以及是否在 HTML 中避免重复文案或配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify and externalize the desktop startup screen copy into a shared config while improving its accessibility and localized messaging.

Enhancements:
- Load startup title, description, and status text from a shared namespaced startup-copy config instead of hardcoding them in the HTML shell.
- Standardize the startup title to "AstrBot Desktop" and refine English and Chinese descriptions and status messages for loading and panel-update modes.
- Adjust the startup status element to act as a polite live region and avoid duplicate announcements when the status text does not change.
- Deep-freeze the shared startup shell configuration to prevent runtime mutation.

Tests:
- Add a node-based test to verify the startup shell uses the shared copy config, exposes the accessibility attributes, and skips duplicated copy or configuration in the HTML.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将桌面启动屏幕的文案统一并外部化到共享配置中，同时提升其可访问性和本地化消息质量。

Enhancements:
- 从共享的、带命名空间的 `startup-copy` 配置中加载启动标题、描述和状态文本，而不是将它们硬编码在 HTML shell 中。
- 将启动标题统一为 “AstrBot Desktop”，并优化英文和中文的描述及状态消息，涵盖加载模式和面板更新模式。
- 调整启动状态元素，使其作为一个“礼貌”的实时区域（polite live region），并在状态文本未变化时避免重复朗读。
- 对共享的启动 shell 配置进行深度冻结（deep-freeze），以防止运行时被修改。

Tests:
- 添加基于 Node 的测试，用于验证启动 shell 是否使用共享文案配置、是否正确暴露可访问性属性，以及是否在 HTML 中避免重复文案或配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify and externalize the desktop startup screen copy into a shared config while improving its accessibility and localized messaging.

Enhancements:
- Load startup title, description, and status text from a shared namespaced startup-copy config instead of hardcoding them in the HTML shell.
- Standardize the startup title to "AstrBot Desktop" and refine English and Chinese descriptions and status messages for loading and panel-update modes.
- Adjust the startup status element to act as a polite live region and avoid duplicate announcements when the status text does not change.
- Deep-freeze the shared startup shell configuration to prevent runtime mutation.

Tests:
- Add a node-based test to verify the startup shell uses the shared copy config, exposes the accessibility attributes, and skips duplicated copy or configuration in the HTML.

</details>

</details>

</details>

改进内容：
- 在加载和面板更新模式下统一启动标题为“AstrBot Desktop”。
- 改进中英文的加载描述和状态文本，更好地区分产品身份、加载阶段和当前操作。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将桌面启动屏幕的文案统一并外部化到共享配置中，同时提升其可访问性和本地化消息质量。

Enhancements:
- 从共享的、带命名空间的 `startup-copy` 配置中加载启动标题、描述和状态文本，而不是将它们硬编码在 HTML shell 中。
- 将启动标题统一为 “AstrBot Desktop”，并优化英文和中文的描述及状态消息，涵盖加载模式和面板更新模式。
- 调整启动状态元素，使其作为一个“礼貌”的实时区域（polite live region），并在状态文本未变化时避免重复朗读。
- 对共享的启动 shell 配置进行深度冻结（deep-freeze），以防止运行时被修改。

Tests:
- 添加基于 Node 的测试，用于验证启动 shell 是否使用共享文案配置、是否正确暴露可访问性属性，以及是否在 HTML 中避免重复文案或配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify and externalize the desktop startup screen copy into a shared config while improving its accessibility and localized messaging.

Enhancements:
- Load startup title, description, and status text from a shared namespaced startup-copy config instead of hardcoding them in the HTML shell.
- Standardize the startup title to "AstrBot Desktop" and refine English and Chinese descriptions and status messages for loading and panel-update modes.
- Adjust the startup status element to act as a polite live region and avoid duplicate announcements when the status text does not change.
- Deep-freeze the shared startup shell configuration to prevent runtime mutation.

Tests:
- Add a node-based test to verify the startup shell uses the shared copy config, exposes the accessibility attributes, and skips duplicated copy or configuration in the HTML.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将桌面启动屏幕的文案统一并外部化到共享配置中，同时提升其可访问性和本地化消息质量。

Enhancements:
- 从共享的、带命名空间的 `startup-copy` 配置中加载启动标题、描述和状态文本，而不是将它们硬编码在 HTML shell 中。
- 将启动标题统一为 “AstrBot Desktop”，并优化英文和中文的描述及状态消息，涵盖加载模式和面板更新模式。
- 调整启动状态元素，使其作为一个“礼貌”的实时区域（polite live region），并在状态文本未变化时避免重复朗读。
- 对共享的启动 shell 配置进行深度冻结（deep-freeze），以防止运行时被修改。

Tests:
- 添加基于 Node 的测试，用于验证启动 shell 是否使用共享文案配置、是否正确暴露可访问性属性，以及是否在 HTML 中避免重复文案或配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify and externalize the desktop startup screen copy into a shared config while improving its accessibility and localized messaging.

Enhancements:
- Load startup title, description, and status text from a shared namespaced startup-copy config instead of hardcoding them in the HTML shell.
- Standardize the startup title to "AstrBot Desktop" and refine English and Chinese descriptions and status messages for loading and panel-update modes.
- Adjust the startup status element to act as a polite live region and avoid duplicate announcements when the status text does not change.
- Deep-freeze the shared startup shell configuration to prevent runtime mutation.

Tests:
- Add a node-based test to verify the startup shell uses the shared copy config, exposes the accessibility attributes, and skips duplicated copy or configuration in the HTML.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将桌面启动屏幕的文案统一并外部化到共享配置中，同时提升其可访问性和本地化消息质量。

Enhancements:
- 从共享的、带命名空间的 `startup-copy` 配置中加载启动标题、描述和状态文本，而不是将它们硬编码在 HTML shell 中。
- 将启动标题统一为 “AstrBot Desktop”，并优化英文和中文的描述及状态消息，涵盖加载模式和面板更新模式。
- 调整启动状态元素，使其作为一个“礼貌”的实时区域（polite live region），并在状态文本未变化时避免重复朗读。
- 对共享的启动 shell 配置进行深度冻结（deep-freeze），以防止运行时被修改。

Tests:
- 添加基于 Node 的测试，用于验证启动 shell 是否使用共享文案配置、是否正确暴露可访问性属性，以及是否在 HTML 中避免重复文案或配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify and externalize the desktop startup screen copy into a shared config while improving its accessibility and localized messaging.

Enhancements:
- Load startup title, description, and status text from a shared namespaced startup-copy config instead of hardcoding them in the HTML shell.
- Standardize the startup title to "AstrBot Desktop" and refine English and Chinese descriptions and status messages for loading and panel-update modes.
- Adjust the startup status element to act as a polite live region and avoid duplicate announcements when the status text does not change.
- Deep-freeze the shared startup shell configuration to prevent runtime mutation.

Tests:
- Add a node-based test to verify the startup shell uses the shared copy config, exposes the accessibility attributes, and skips duplicated copy or configuration in the HTML.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将桌面启动屏幕的文案统一并外部化到共享配置中，同时提升其可访问性和本地化消息质量。

Enhancements:
- 从共享的、带命名空间的 `startup-copy` 配置中加载启动标题、描述和状态文本，而不是将它们硬编码在 HTML shell 中。
- 将启动标题统一为 “AstrBot Desktop”，并优化英文和中文的描述及状态消息，涵盖加载模式和面板更新模式。
- 调整启动状态元素，使其作为一个“礼貌”的实时区域（polite live region），并在状态文本未变化时避免重复朗读。
- 对共享的启动 shell 配置进行深度冻结（deep-freeze），以防止运行时被修改。

Tests:
- 添加基于 Node 的测试，用于验证启动 shell 是否使用共享文案配置、是否正确暴露可访问性属性，以及是否在 HTML 中避免重复文案或配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify and externalize the desktop startup screen copy into a shared config while improving its accessibility and localized messaging.

Enhancements:
- Load startup title, description, and status text from a shared namespaced startup-copy config instead of hardcoding them in the HTML shell.
- Standardize the startup title to "AstrBot Desktop" and refine English and Chinese descriptions and status messages for loading and panel-update modes.
- Adjust the startup status element to act as a polite live region and avoid duplicate announcements when the status text does not change.
- Deep-freeze the shared startup shell configuration to prevent runtime mutation.

Tests:
- Add a node-based test to verify the startup shell uses the shared copy config, exposes the accessibility attributes, and skips duplicated copy or configuration in the HTML.

</details>

</details>

</details>

</details>

</details>