### PR TITLE
fix(runtime): isolate packaged Python from user site-packages

### DIFF
--- a/src-tauri/src/backend/launch.rs
+++ b/src-tauri/src/backend/launch.rs
@@ -29,6 +29,7 @@ where
         }
         command.env_remove(key);
     }
+    command.env("PYTHONNOUSERSITE", "1");
 }
 
 impl BackendState {
@@ -220,5 +221,17 @@ mod tests {
 
         assert_eq!(get_command_env_value(&command, "PYTHONHOME"), Some(None));
         assert_eq!(get_command_env_value(&command, "PYTHONPATH"), Some(None));
+    }
+
+    #[test]
+    fn sanitize_packaged_python_environment_disables_user_site_packages() {
+        let mut command = Command::new("sh");
+
+        sanitize_packaged_python_environment(&mut command, |_| {});
+
+        assert_eq!(
+            get_command_env_value(&command, "PYTHONNOUSERSITE"),
+            Some(Some("1".to_string()))
+        );
     }
 }


### PR DESCRIPTION
## Summary
- disable Python user site-packages when launching the packaged backend runtime so user-installed packages cannot shadow bundled dependencies
- add a regression test for packaged backend environment sanitization to keep bundled `pydantic-settings` from importing an incompatible user-installed `pydantic`
- supersedes #92 with a clean branch based on the current upstream `main`

## Test Plan
- [x] `cargo test sanitize_packaged_python_environment`
- [x] `cargo test`
- [x] `cargo fmt --check`

## Summary by Sourcery

Ensure the packaged backend runtime launches with a sanitized Python environment that ignores user site-packages to prevent interference with bundled dependencies.

Bug Fixes:
- Prevent user-installed Python packages from shadowing bundled dependencies in the packaged backend runtime.

Tests:
- Add a regression test verifying that the packaged Python environment disables user site-packages via PYTHONNOUSERSITE.