### PR TITLE
fix(runtime): guard Windows bundled runtime arch detection

### DIFF
--- a/scripts/backend/runtime-arch-utils.mjs
+++ b/scripts/backend/runtime-arch-utils.mjs
@@ -7,6 +7,12 @@ const PROCESS_ARCH_MAP = {
   arm64: 'arm64',
 };
 
+const hasNonEmptyEnvOverride = (env, key) => Boolean(String(env[key] ?? '').trim());
+
+export const hasRuntimeArchOverride = (env = process.env) =>
+  hasNonEmptyEnvOverride(env, BUNDLED_RUNTIME_ARCH_ENV) ||
+  hasNonEmptyEnvOverride(env, DESKTOP_TARGET_ARCH_ENV);
+
 export const normalizeDesktopArch = (rawArch, sourceName) => {
   const raw = String(rawArch ?? '').trim().toLowerCase();
   if (raw === 'amd64' || raw === 'x64') {
@@ -22,7 +28,7 @@ export const normalizeDesktopArch = (rawArch, sourceName) => {
 
 export const resolveDesktopTargetArch = ({ arch = process.arch, env = process.env } = {}) => {
   const overrideRaw = env[DESKTOP_TARGET_ARCH_ENV];
-  if (overrideRaw !== undefined && String(overrideRaw).trim()) {
+  if (hasNonEmptyEnvOverride(env, DESKTOP_TARGET_ARCH_ENV)) {
     return normalizeDesktopArch(overrideRaw, DESKTOP_TARGET_ARCH_ENV);
   }
 
@@ -40,7 +46,7 @@ export const resolveBundledRuntimeArch = ({
   env = process.env,
 } = {}) => {
   const explicitBundledRuntimeArch = env[BUNDLED_RUNTIME_ARCH_ENV];
-  if (explicitBundledRuntimeArch !== undefined && String(explicitBundledRuntimeArch).trim()) {
+  if (hasNonEmptyEnvOverride(env, BUNDLED_RUNTIME_ARCH_ENV)) {
     return normalizeDesktopArch(explicitBundledRuntimeArch, BUNDLED_RUNTIME_ARCH_ENV);
   }
 
@@ -50,7 +56,7 @@ export const resolveBundledRuntimeArch = ({
   }
 
   const windowsArmBackendArch = env[WINDOWS_ARM_BACKEND_ARCH_ENV];
-  if (windowsArmBackendArch === undefined || !String(windowsArmBackendArch).trim()) {
+  if (!hasNonEmptyEnvOverride(env, WINDOWS_ARM_BACKEND_ARCH_ENV)) {
     return 'amd64';
   }
 
@@ -66,11 +72,7 @@ export const isWindowsArm64BundledRuntime = ({
     return false;
   }
 
-  const hasBundledRuntimeOverride =
-    env[BUNDLED_RUNTIME_ARCH_ENV] !== undefined && String(env[BUNDLED_RUNTIME_ARCH_ENV]).trim();
-  const hasTargetArchOverride =
-    env[DESKTOP_TARGET_ARCH_ENV] !== undefined && String(env[DESKTOP_TARGET_ARCH_ENV]).trim();
-  if (!hasBundledRuntimeOverride && !hasTargetArchOverride && !PROCESS_ARCH_MAP[arch]) {
+  if (!hasRuntimeArchOverride(env) && !PROCESS_ARCH_MAP[arch]) {
     return false;
   }
 

--- a/scripts/backend/runtime-arch-utils.test.mjs
+++ b/scripts/backend/runtime-arch-utils.test.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
+import * as runtimeArchUtils from './runtime-arch-utils.mjs';
 import {
   isWindowsArm64BundledRuntime,
   resolveBundledRuntimeArch,
@@ -64,5 +65,25 @@ test('isWindowsArm64BundledRuntime returns false for unsupported Windows host ar
       env: {},
     }),
     false,
+  );
+});
+
+test('hasRuntimeArchOverride returns booleans for recognized override env vars', () => {
+  assert.equal(typeof runtimeArchUtils.hasRuntimeArchOverride, 'function');
+  assert.equal(runtimeArchUtils.hasRuntimeArchOverride({}), false);
+  assert.equal(
+    runtimeArchUtils.hasRuntimeArchOverride({
+      ASTRBOT_DESKTOP_BUNDLED_RUNTIME_ARCH: '   ',
+      ASTRBOT_DESKTOP_TARGET_ARCH: ' ',
+    }),
+    false,
+  );
+  assert.equal(
+    runtimeArchUtils.hasRuntimeArchOverride({ ASTRBOT_DESKTOP_BUNDLED_RUNTIME_ARCH: 'arm64' }),
+    true,
+  );
+  assert.equal(
+    runtimeArchUtils.hasRuntimeArchOverride({ ASTRBOT_DESKTOP_TARGET_ARCH: 'arm64' }),
+    true,
   );
 });


### PR DESCRIPTION
## Summary
- make `isWindowsArm64BundledRuntime` return `false` instead of throwing when it runs on `win32` with an unsupported host `process.arch` and no explicit arch override
- keep explicit bundled-runtime and target-arch overrides working by only short-circuiting the unsupported-host fallback case
- add a regression test covering the unsupported Windows host arch path

## Test Plan
- [x] `node --test scripts/backend/runtime-arch-utils.test.mjs`
- [x] `pnpm run test:prepare-resources`

## Summary by Sourcery

Guard Windows bundled runtime architecture detection against unsupported host architectures and centralize runtime-arch override handling.

Bug Fixes:
- Make Windows ARM64 bundled runtime detection return false instead of erroring when running on win32 with an unsupported host architecture and no override.

Enhancements:
- Introduce shared helpers to detect non-empty runtime architecture override environment variables and reuse them in runtime arch resolution logic.

Tests:
- Add regression tests for unsupported Windows host architectures and for runtime-arch override environment variable handling.