### PR TITLE
ci: update workflow actions for Node 24

### DIFF
--- a/.github/actions/setup-desktop-build/action.yml
+++ b/.github/actions/setup-desktop-build/action.yml
@@ -33,7 +33,7 @@ runs:
         node-version: ${{ inputs.node-version }}
 
     - name: Setup pnpm
-      uses: pnpm/action-setup@v4.2.0
+      uses: pnpm/action-setup@v4.4.0
       with:
         version: ${{ inputs.pnpm-version }}
 

--- a/.github/workflows/build-desktop-tauri.yml
+++ b/.github/workflows/build-desktop-tauri.yml
@@ -38,6 +38,7 @@ permissions:
 
 env:
   ASTRBOT_SOURCE_GIT_URL: ${{ vars.ASTRBOT_SOURCE_GIT_URL || 'https://github.com/AstrBotDevs/AstrBot.git' }}
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
   ASTRBOT_SOURCE_GIT_REF: ${{ vars.ASTRBOT_SOURCE_GIT_REF || 'master' }}
   ASTRBOT_NIGHTLY_SOURCE_GIT_REF: ${{ vars.ASTRBOT_NIGHTLY_SOURCE_GIT_REF || 'master' }}
   ASTRBOT_NIGHTLY_SCHEDULE_CRON: ${{ vars.ASTRBOT_NIGHTLY_SCHEDULE_CRON || '7 3 * * *' }}
@@ -108,7 +109,7 @@ jobs:
           setup-python: 'false'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4.2.0
+        uses: pnpm/action-setup@v4.4.0
         with:
           version: 10.28.2
 


### PR DESCRIPTION
## Summary
GitHub Actions is warning that this workflow still depends on JavaScript actions that declare a Node 20 runtime. The desktop build matrix reports the warning for `pnpm/action-setup@v4.2.0`, and the release publishing job reports the same deprecation for `softprops/action-gh-release@v2.5.0`.

The immediate user-facing effect is noisy CI across all desktop targets and a clear upgrade deadline from GitHub Actions. Left unchanged, these jobs will eventually be forced onto Node 24 by the runner platform anyway, which increases the risk of surprise behavior changes landing at the same time as a release build.

The root cause is that the workflow pins an older `pnpm/action-setup` release that still declares `runs.using: node20`, and `softprops/action-gh-release` does not currently publish a released tag with a Node 24 runtime. That means a version bump alone is enough for pnpm setup, but not for the release publishing step.

This PR applies the smallest safe fix for both cases. It upgrades both `pnpm/action-setup` call sites to `v4.4.0`, whose published action metadata switches to `node24`, and it sets `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` at the `build-desktop-tauri` workflow level so the remaining `softprops/action-gh-release` step runs under Node 24 until that action ships a released Node 24 build.

## Verification
- confirmed both `pnpm/action-setup` references now point at `v4.4.0`
- confirmed `pnpm/action-setup@v4.4.0` publishes `runs: using: node24`
- confirmed the latest released and default-branch metadata for `softprops/action-gh-release` still publish `runs: using: node20`
- ran `git diff --check`

## Summary by Sourcery

Update CI workflows to run JavaScript GitHub Actions on Node 24 for desktop builds and releases.

CI:
- Set FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 at the build-desktop-tauri workflow level so remaining JavaScript actions run on Node 24.
- Bump pnpm/action-setup from v4.2.0 to v4.4.0 in desktop build workflows to use an action version that targets Node 24.