### PR TITLE
fix： use Rust binary name for portable packaging

### DIFF
--- a/scripts/ci/package_windows_portable.py
+++ b/scripts/ci/package_windows_portable.py
@@ -91,7 +91,7 @@ def load_portable_runtime_marker(project_root: pathlib.Path) -> str:
 def load_project_config_from(start_path: pathlib.Path) -> ProjectConfig:
     project_root = resolve_project_root_from(start_path)
     product_name = resolve_product_name(project_root)
-    binary_name = load_cargo_package_name(project_root)
+    binary_name = load_binary_name_from_cargo(project_root)
     portable_marker_name = load_portable_runtime_marker(project_root)
     return ProjectConfig(
         root=project_root,
@@ -147,7 +147,7 @@ def load_tauri_config(project_root: pathlib.Path) -> dict:
     return json.loads(config_path.read_text(encoding="utf-8"))
 
 
-def load_cargo_package_name(project_root: pathlib.Path) -> str:
+def load_binary_name_from_cargo(project_root: pathlib.Path) -> str:
     cargo_toml_path = project_root / CARGO_TOML_RELATIVE_PATH
     if not cargo_toml_path.is_file():
         raise FileNotFoundError(f"Cargo.toml not found: {cargo_toml_path}")
@@ -165,11 +165,11 @@ def load_cargo_package_name(project_root: pathlib.Path) -> str:
 
     package_table = cargo_data.get("package")
     if not isinstance(package_table, dict):
-        raise ValueError(f"Missing [package] in {CARGO_TOML_RELATIVE_PATH}")
+        raise ValueError(f"Missing [package] in {cargo_toml_path}")
 
     binary_name = str(package_table.get("name", "")).strip()
     if not binary_name:
-        raise ValueError(f"Missing [package].name in {CARGO_TOML_RELATIVE_PATH}")
+        raise ValueError(f"Missing [package].name in {cargo_toml_path}")
 
     return binary_name
 

--- a/scripts/ci/test_package_windows_portable.py
+++ b/scripts/ci/test_package_windows_portable.py
@@ -1,3 +1,4 @@
+import re
 import tempfile
 import unittest
 from pathlib import Path
@@ -137,16 +138,19 @@ class PackageWindowsPortableTests(unittest.TestCase):
             )
 
             self.assertEqual(
-                MODULE.load_cargo_package_name(project_root),
+                MODULE.load_binary_name_from_cargo(project_root),
                 "astrbot-desktop-tauri",
             )
 
     def test_load_cargo_package_name_missing_cargo_toml_raises_file_not_found(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir)
+            cargo_toml_path = project_root / "src-tauri" / "Cargo.toml"
 
-            with self.assertRaises(FileNotFoundError):
-                MODULE.load_cargo_package_name(project_root)
+            with self.assertRaisesRegex(
+                FileNotFoundError, re.escape(str(cargo_toml_path))
+            ):
+                MODULE.load_binary_name_from_cargo(project_root)
 
     def test_load_cargo_package_name_missing_package_table_raises_value_error(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -155,8 +159,8 @@ class PackageWindowsPortableTests(unittest.TestCase):
             cargo_toml_path.parent.mkdir(parents=True)
             cargo_toml_path.write_text('[workspace]\nmembers = ["crates/*"]\n')
 
-            with self.assertRaises(ValueError):
-                MODULE.load_cargo_package_name(project_root)
+            with self.assertRaisesRegex(ValueError, re.escape(str(cargo_toml_path))):
+                MODULE.load_binary_name_from_cargo(project_root)
 
     def test_load_cargo_package_name_missing_package_name_raises_value_error(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -165,8 +169,8 @@ class PackageWindowsPortableTests(unittest.TestCase):
             cargo_toml_path.parent.mkdir(parents=True)
             cargo_toml_path.write_text('[package]\nversion = "0.1.0"\n')
 
-            with self.assertRaises(ValueError):
-                MODULE.load_cargo_package_name(project_root)
+            with self.assertRaisesRegex(ValueError, re.escape(str(cargo_toml_path))):
+                MODULE.load_binary_name_from_cargo(project_root)
 
     def test_load_cargo_package_name_empty_package_name_raises_value_error(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -175,8 +179,8 @@ class PackageWindowsPortableTests(unittest.TestCase):
             cargo_toml_path.parent.mkdir(parents=True)
             cargo_toml_path.write_text('[package]\nname = ""\n')
 
-            with self.assertRaises(ValueError):
-                MODULE.load_cargo_package_name(project_root)
+            with self.assertRaisesRegex(ValueError, re.escape(str(cargo_toml_path))):
+                MODULE.load_binary_name_from_cargo(project_root)
 
     def test_load_cargo_package_name_falls_back_to_package_when_bin_missing_name(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -191,7 +195,7 @@ class PackageWindowsPortableTests(unittest.TestCase):
             )
 
             self.assertEqual(
-                MODULE.load_cargo_package_name(project_root),
+                MODULE.load_binary_name_from_cargo(project_root),
                 "astrbot-desktop-tauri",
             )
 
@@ -207,7 +211,9 @@ class PackageWindowsPortableTests(unittest.TestCase):
                 'name = "AstrBot"\n'
             )
 
-            self.assertEqual(MODULE.load_cargo_package_name(project_root), "AstrBot")
+            self.assertEqual(
+                MODULE.load_binary_name_from_cargo(project_root), "AstrBot"
+            )
 
     def test_resolve_main_executable_path_uses_binary_name_not_product_name(self):
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary
- fix the Windows portable packaging step to use the actual Rust release binary name instead of the Tauri product name
- add regression tests covering the case where `productName` differs from the built `.exe` filename

## Problem
After PR #107 merged, the Windows portable zip step still failed in GitHub Actions. The portable packager looked for `src-tauri/target/release/AstrBot.exe` because it derived the executable name from `productName`, but the Windows build actually produces `src-tauri/target/release/astrbot-desktop-tauri.exe`.

## Root Cause
The packaging script conflated the user-facing Tauri `productName` with the real Rust package/binary name. On Windows those are different in this repository, so the portable packaging step could never find the built executable in CI.

## Fix
This change teaches `scripts/ci/package_windows_portable.py` to read the Rust package name from `src-tauri/Cargo.toml` and use that value when locating the built release executable. The existing `productName` handling stays intact for display-oriented metadata, while the actual file copy now targets the real binary path.

The tests were extended to cover the exact failing case: `productName = AstrBot` while the built executable is `astrbot-desktop-tauri.exe`. That locks in the expected behavior for future packaging changes.

## Validation
- `python3 -m unittest scripts.ci.test_package_windows_portable`
- `python3 -m unittest discover -s scripts/ci -p 'test_*.py'`
- `python3 -m compileall -q scripts`
- `node --test $(find scripts -type f -name '*.test.mjs' | sort)`

## Summary by Sourcery

Use the Rust binary name from Cargo.toml for Windows portable packaging instead of the Tauri product name.

Bug Fixes:
- Fix Windows portable packaging failing when the Tauri productName differs from the actual built .exe filename by resolving the binary name from Cargo.toml.

Tests:
- Add unit tests for loading the binary name from Cargo.toml, including various error conditions and bin-table precedence, and for using the binary name when resolving the main executable path for portable packaging.