### PR TITLE
更新MacOS签名，避免应用已损坏问题

### DIFF
--- a/.github/workflows/build-desktop-tauri.yml
+++ b/.github/workflows/build-desktop-tauri.yml
@@ -291,6 +291,20 @@ jobs:
           echo "APPLE_SIGNING_IDENTITY=$CERT_ID" >> "$GITHUB_ENV"
           echo "Imported signing identity: $CERT_ID"
 
+      - name: Pre-sign backend resources (macOS)
+        if: ${{ env.APPLE_SIGNING_IDENTITY != '' }}
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ env.APPLE_SIGNING_IDENTITY }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -d "resources/backend" ]; then
+            echo "Pre-signing Mach-O binaries in resources/backend..."
+            bash scripts/ci/codesign-macos-nested.sh "resources/backend" "src-tauri/entitlements.plist"
+          else
+            echo "resources/backend not found; skipping pre-sign."
+          fi
+
       - name: Resolve macOS app bundle name
         id: resolve_macos_app_bundle
         env:
@@ -382,20 +396,6 @@ jobs:
             echo "macOS build hit transient failure on attempt ${attempt}/${max_attempts}; retrying in ${retry_sleep_seconds}s..."
             sleep "${retry_sleep_seconds}"
           done
-
-      - name: Codesign nested binaries (macOS)
-        if: ${{ env.APPLE_SIGNING_IDENTITY != '' }}
-        env:
-          APPLE_SIGNING_IDENTITY: ${{ env.APPLE_SIGNING_IDENTITY }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          app_bundle="src-tauri/target/${{ matrix.target }}/release/bundle/macos/AstrBot.app"
-          if [ ! -d "${app_bundle}" ]; then
-            echo "::warning::App bundle not found at ${app_bundle}; skipping nested signing."
-            exit 0
-          fi
-          bash scripts/ci/codesign-macos-nested.sh "${app_bundle}" "src-tauri/entitlements.plist"
 
       - name: Smoke test backend startup (macOS)
         shell: bash

--- a/.github/workflows/build-desktop-tauri.yml
+++ b/.github/workflows/build-desktop-tauri.yml
@@ -267,7 +267,7 @@ jobs:
           astrbot_version: ${{ steps.desktop_version.outputs.normalized }}
 
       - name: Import Apple Developer Certificate
-        if: ${{ env.APPLE_CERTIFICATE != '' }}
+        if: ${{ secrets.APPLE_CERTIFICATE != '' }}
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}

--- a/.github/workflows/build-desktop-tauri.yml
+++ b/.github/workflows/build-desktop-tauri.yml
@@ -295,15 +295,28 @@ jobs:
         if: ${{ env.APPLE_SIGNING_IDENTITY != '' }}
         env:
           APPLE_SIGNING_IDENTITY: ${{ env.APPLE_SIGNING_IDENTITY }}
+          ASTRBOT_SOURCE_GIT_URL: ${{ needs.resolve_build_context.outputs.source_git_url }}
+          ASTRBOT_SOURCE_GIT_REF: ${{ needs.resolve_build_context.outputs.source_git_ref }}
+          ASTRBOT_DESKTOP_VERSION: ${{ steps.desktop_version.outputs.prefixed }}
+          ASTRBOT_DESKTOP_UPDATER_PUBLIC_KEY: ${{ env.ASTRBOT_DESKTOP_UPDATER_PUBLIC_KEY }}
         shell: bash
         run: |
           set -euo pipefail
-          if [ -d "resources/backend" ]; then
-            echo "Pre-signing Mach-O binaries in resources/backend..."
-            bash scripts/ci/codesign-macos-nested.sh "resources/backend" "src-tauri/entitlements.plist"
-          else
-            echo "resources/backend not found; skipping pre-sign."
+          pnpm run prepare:resources
+          if [ ! -d "resources/backend" ]; then
+            echo "::error::resources/backend not found after prepare:resources." >&2
+            exit 1
           fi
+          echo "Pre-signing Mach-O binaries in resources/backend..."
+          bash scripts/ci/codesign-macos-nested.sh "resources/backend" "src-tauri/entitlements.plist"
+          python3 -c "
+          import json
+          p = 'src-tauri/tauri.conf.json'
+          with open(p) as f: c = json.load(f)
+          c['build']['beforeBuildCommand'] = ''
+          with open(p, 'w') as f: json.dump(c, f, indent=2)
+          print('Cleared beforeBuildCommand to prevent re-generating resources.')
+          "
 
       - name: Resolve macOS app bundle name
         id: resolve_macos_app_bundle

--- a/.github/workflows/build-desktop-tauri.yml
+++ b/.github/workflows/build-desktop-tauri.yml
@@ -299,6 +299,8 @@ jobs:
           ASTRBOT_SOURCE_GIT_REF: ${{ needs.resolve_build_context.outputs.source_git_ref }}
           ASTRBOT_DESKTOP_VERSION: ${{ steps.desktop_version.outputs.prefixed }}
           ASTRBOT_DESKTOP_UPDATER_PUBLIC_KEY: ${{ env.ASTRBOT_DESKTOP_UPDATER_PUBLIC_KEY }}
+          GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/build-desktop-tauri.yml
+++ b/.github/workflows/build-desktop-tauri.yml
@@ -383,6 +383,20 @@ jobs:
             sleep "${retry_sleep_seconds}"
           done
 
+      - name: Codesign nested binaries (macOS)
+        if: ${{ env.APPLE_SIGNING_IDENTITY != '' }}
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ env.APPLE_SIGNING_IDENTITY }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          app_bundle="src-tauri/target/${{ matrix.target }}/release/bundle/macos/AstrBot.app"
+          if [ ! -d "${app_bundle}" ]; then
+            echo "::warning::App bundle not found at ${app_bundle}; skipping nested signing."
+            exit 0
+          fi
+          bash scripts/ci/codesign-macos-nested.sh "${app_bundle}" "src-tauri/entitlements.plist"
+
       - name: Smoke test backend startup (macOS)
         shell: bash
         run: |

--- a/.github/workflows/build-desktop-tauri.yml
+++ b/.github/workflows/build-desktop-tauri.yml
@@ -280,6 +280,7 @@ jobs:
 
           echo "$APPLE_CERTIFICATE" | base64 --decode > "$CERT_PATH"
           security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security default-keychain -s "$KEYCHAIN_PATH"
           security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           security import "$CERT_PATH" -P "$APPLE_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"

--- a/.github/workflows/build-desktop-tauri.yml
+++ b/.github/workflows/build-desktop-tauri.yml
@@ -267,7 +267,6 @@ jobs:
           astrbot_version: ${{ steps.desktop_version.outputs.normalized }}
 
       - name: Import Apple Developer Certificate
-        if: ${{ secrets.APPLE_CERTIFICATE != '' }}
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -275,6 +274,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          if [ -z "${APPLE_CERTIFICATE:-}" ]; then
+            echo "APPLE_CERTIFICATE is not configured; skipping certificate import."
+            exit 0
+          fi
           CERT_PATH="$RUNNER_TEMP/certificate.p12"
           KEYCHAIN_PATH="$RUNNER_TEMP/build.keychain"
 

--- a/.github/workflows/build-desktop-tauri.yml
+++ b/.github/workflows/build-desktop-tauri.yml
@@ -266,6 +266,31 @@ jobs:
         with:
           astrbot_version: ${{ steps.desktop_version.outputs.normalized }}
 
+      - name: Import Apple Developer Certificate
+        if: ${{ env.APPLE_CERTIFICATE != '' }}
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          CERT_PATH="$RUNNER_TEMP/certificate.p12"
+          KEYCHAIN_PATH="$RUNNER_TEMP/build.keychain"
+
+          echo "$APPLE_CERTIFICATE" | base64 --decode > "$CERT_PATH"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" -P "$APPLE_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          rm -f "$CERT_PATH"
+
+          CERT_INFO=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" | grep "Developer ID Application")
+          CERT_ID=$(echo "$CERT_INFO" | awk -F'"' '{print $2}')
+          echo "APPLE_SIGNING_IDENTITY=$CERT_ID" >> "$GITHUB_ENV"
+          echo "Imported signing identity: $CERT_ID"
+
       - name: Resolve macOS app bundle name
         id: resolve_macos_app_bundle
         env:
@@ -295,6 +320,12 @@ jobs:
           ASTRBOT_DESKTOP_CRYPTOGRAPHY_FALLBACK_VERSIONS: ${{ vars.ASTRBOT_DESKTOP_CRYPTOGRAPHY_FALLBACK_VERSIONS || '' }}
           ASTRBOT_MACOS_BUILD_MAX_ATTEMPTS: ${{ vars.ASTRBOT_MACOS_BUILD_MAX_ATTEMPTS || '3' }}
           ASTRBOT_MACOS_BUILD_RETRY_SLEEP_SECONDS: ${{ vars.ASTRBOT_MACOS_BUILD_RETRY_SLEEP_SECONDS || '8' }}
+          APPLE_SIGNING_IDENTITY: ${{ env.APPLE_SIGNING_IDENTITY }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           GITHUB_TOKEN: ${{ github.token }}
           GH_TOKEN: ${{ github.token }}
         shell: bash

--- a/scripts/ci/codesign-macos-nested.sh
+++ b/scripts/ci/codesign-macos-nested.sh
@@ -36,8 +36,13 @@ echo "Found ${#NESTED_BINARIES[@]} Mach-O binary(ies) to sign in ${TARGET}."
 
 for binary in "${NESTED_BINARIES[@]}"; do
   echo "  Signing: ${binary}"
+  # Only apply entitlements to executables, not dylibs
+  CURRENT_ENTITLEMENTS=()
+  if [ ${#ENTITLEMENTS_ARGS[@]} -gt 0 ] && file --brief "${binary}" | grep -q "executable"; then
+    CURRENT_ENTITLEMENTS=("${ENTITLEMENTS_ARGS[@]}")
+  fi
   codesign "${SIGN_OPTS[@]}" \
-    "${ENTITLEMENTS_ARGS[@]+"${ENTITLEMENTS_ARGS[@]}"}" \
+    ${CURRENT_ENTITLEMENTS[@]+"${CURRENT_ENTITLEMENTS[@]}"} \
     "${binary}"
 done
 

--- a/scripts/ci/codesign-macos-nested.sh
+++ b/scripts/ci/codesign-macos-nested.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "${APPLE_SIGNING_IDENTITY:-}" ]; then
+  echo "::warning::APPLE_SIGNING_IDENTITY is not set; skipping nested code signing."
+  exit 0
+fi
+
+APP_BUNDLE="${1:?Usage: $0 <path-to-app-bundle>}"
+if [ ! -d "${APP_BUNDLE}" ]; then
+  echo "::error::App bundle not found: ${APP_BUNDLE}" >&2
+  exit 1
+fi
+
+ENTITLEMENTS_PATH="${2:-}"
+ENTITLEMENTS_ARGS=()
+if [ -n "${ENTITLEMENTS_PATH}" ] && [ -f "${ENTITLEMENTS_PATH}" ]; then
+  ENTITLEMENTS_ARGS=(--entitlements "${ENTITLEMENTS_PATH}")
+fi
+
+echo "Signing nested binaries inside ${APP_BUNDLE} with identity: ${APPLE_SIGNING_IDENTITY}"
+
+NESTED_BINARIES=()
+while IFS= read -r -d '' file; do
+  if file --brief "${file}" | grep -q "Mach-O"; then
+    NESTED_BINARIES+=("${file}")
+  fi
+done < <(find "${APP_BUNDLE}/Contents/Resources" -type f -print0 2>/dev/null || true)
+
+if [ "${#NESTED_BINARIES[@]}" -eq 0 ]; then
+  echo "No nested Mach-O binaries found in Resources; nothing extra to sign."
+  exit 0
+fi
+
+echo "Found ${#NESTED_BINARIES[@]} nested Mach-O binary(ies) to sign."
+
+for binary in "${NESTED_BINARIES[@]}"; do
+  echo "  Signing: ${binary}"
+  codesign --force --options runtime \
+    "${ENTITLEMENTS_ARGS[@]+"${ENTITLEMENTS_ARGS[@]}"}" \
+    --sign "${APPLE_SIGNING_IDENTITY}" \
+    "${binary}"
+done
+
+echo "Re-signing the app bundle itself..."
+codesign --force --options runtime \
+  "${ENTITLEMENTS_ARGS[@]+"${ENTITLEMENTS_ARGS[@]}"}" \
+  --sign "${APPLE_SIGNING_IDENTITY}" \
+  --deep \
+  "${APP_BUNDLE}"
+
+echo "Verifying signature..."
+codesign --verify --verbose=2 --deep --strict "${APP_BUNDLE}"
+
+echo "Nested code signing completed successfully."

--- a/scripts/ci/codesign-macos-nested.sh
+++ b/scripts/ci/codesign-macos-nested.sh
@@ -25,7 +25,7 @@ while IFS= read -r -d '' file; do
   if file --brief "${file}" | grep -q "Mach-O"; then
     NESTED_BINARIES+=("${file}")
   fi
-done < <(find "${TARGET}" -type f -print0 2>/dev/null || true)
+done < <(find "${TARGET}" -type f -print0 2>/dev/null | sort -rz)
 
 if [ "${#NESTED_BINARIES[@]}" -eq 0 ]; then
   echo "No Mach-O binaries found in ${TARGET}; nothing to sign."

--- a/scripts/ci/codesign-macos-nested.sh
+++ b/scripts/ci/codesign-macos-nested.sh
@@ -2,54 +2,43 @@
 set -euo pipefail
 
 if [ -z "${APPLE_SIGNING_IDENTITY:-}" ]; then
-  echo "::warning::APPLE_SIGNING_IDENTITY is not set; skipping nested code signing."
+  echo "::warning::APPLE_SIGNING_IDENTITY is not set; skipping code signing."
   exit 0
 fi
 
-APP_BUNDLE="${1:?Usage: $0 <path-to-app-bundle>}"
-if [ ! -d "${APP_BUNDLE}" ]; then
-  echo "::error::App bundle not found: ${APP_BUNDLE}" >&2
-  exit 1
-fi
-
+TARGET="${1:?Usage: $0 <path-to-directory-or-app-bundle> [entitlements.plist]}"
 ENTITLEMENTS_PATH="${2:-}"
 ENTITLEMENTS_ARGS=()
 if [ -n "${ENTITLEMENTS_PATH}" ] && [ -f "${ENTITLEMENTS_PATH}" ]; then
   ENTITLEMENTS_ARGS=(--entitlements "${ENTITLEMENTS_PATH}")
 fi
 
-echo "Signing nested binaries inside ${APP_BUNDLE} with identity: ${APPLE_SIGNING_IDENTITY}"
+SIGN_OPTS=(--force --options runtime --sign "${APPLE_SIGNING_IDENTITY}")
+
+if [ ! -d "${TARGET}" ]; then
+  echo "::error::Target not found: ${TARGET}" >&2
+  exit 1
+fi
 
 NESTED_BINARIES=()
 while IFS= read -r -d '' file; do
   if file --brief "${file}" | grep -q "Mach-O"; then
     NESTED_BINARIES+=("${file}")
   fi
-done < <(find "${APP_BUNDLE}/Contents/Resources" -type f -print0 2>/dev/null || true)
+done < <(find "${TARGET}" -type f -print0 2>/dev/null || true)
 
 if [ "${#NESTED_BINARIES[@]}" -eq 0 ]; then
-  echo "No nested Mach-O binaries found in Resources; nothing extra to sign."
+  echo "No Mach-O binaries found in ${TARGET}; nothing to sign."
   exit 0
 fi
 
-echo "Found ${#NESTED_BINARIES[@]} nested Mach-O binary(ies) to sign."
+echo "Found ${#NESTED_BINARIES[@]} Mach-O binary(ies) to sign in ${TARGET}."
 
 for binary in "${NESTED_BINARIES[@]}"; do
   echo "  Signing: ${binary}"
-  codesign --force --options runtime \
+  codesign "${SIGN_OPTS[@]}" \
     "${ENTITLEMENTS_ARGS[@]+"${ENTITLEMENTS_ARGS[@]}"}" \
-    --sign "${APPLE_SIGNING_IDENTITY}" \
     "${binary}"
 done
 
-echo "Re-signing the app bundle itself..."
-codesign --force --options runtime \
-  "${ENTITLEMENTS_ARGS[@]+"${ENTITLEMENTS_ARGS[@]}"}" \
-  --sign "${APPLE_SIGNING_IDENTITY}" \
-  --deep \
-  "${APP_BUNDLE}"
-
-echo "Verifying signature..."
-codesign --verify --verbose=2 --deep --strict "${APP_BUNDLE}"
-
-echo "Nested code signing completed successfully."
+echo "Code signing completed successfully for ${#NESTED_BINARIES[@]} binary(ies)."

--- a/scripts/ci/lib/nightly_version.py
+++ b/scripts/ci/lib/nightly_version.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 
 SPEC_PATH = Path(__file__).resolve().parents[3] / "src-tauri" / "nightly-version-format.json"
-BASE_VERSION_PATTERN = r"[0-9]+(?:\.[0-9]+){1,2}"
+BASE_VERSION_PATTERN = r"[0-9]+(?:\.[0-9]+){1,2}(?:-[a-zA-Z0-9.]+)?"
 
 _SPEC = json.loads(SPEC_PATH.read_text(encoding="utf-8"))
 NIGHTLY_CANONICAL_FORMAT = str(_SPEC["canonicalFormat"])

--- a/src-tauri/entitlements.plist
+++ b/src-tauri/entitlements.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>

--- a/src-tauri/entitlements.plist
+++ b/src-tauri/entitlements.plist
@@ -6,8 +6,6 @@
     <true/>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
     <true/>
-    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
-    <true/>
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
 </dict>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -31,6 +31,9 @@
     "active": true,
     "createUpdaterArtifacts": true,
     "targets": "all",
+    "macOS": {
+      "entitlements": "entitlements.plist"
+    },
     "windows": {
       "webviewInstallMode": {
         "type": "downloadBootstrapper",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -64,7 +64,7 @@
   },
   "plugins": {
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDlFOEY1REYyNTZEQ0VBMDkKUldRSjZ0eFc4bDJQbnNqTDVIUmNudXEwcXVMUWVPb0RxZHRiNHR0Y3JuRlJVSDlLRzhDWE9ZSkMK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEREMUZDOUE1RTlCNjgzNEYKUldSUGc3YnBwY2tmM1RLMThLTndZT3NiSVVha1J4VXRvaWJmTThVRm0zR1JSTG1EQUhZaG82MEEK",
       "endpoints": [
         "https://github.com/AstrBotDevs/AstrBot-desktop/releases/latest/download/latest-stable.json"
       ],

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -64,7 +64,7 @@
   },
   "plugins": {
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEREMUZDOUE1RTlCNjgzNEYKUldSUGc3YnBwY2tmM1RLMThLTndZT3NiSVVha1J4VXRvaWJmTThVRm0zR1JSTG1EQUhZaG82MEEK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDlFOEY1REYyNTZEQ0VBMDkKUldRSjZ0eFc4bDJQbnNqTDVIUmNudXEwcXVMUWVPb0RxZHRiNHR0Y3JuRlJVSDlLRzhDWE9ZSkMK",
       "endpoints": [
         "https://github.com/AstrBotDevs/AstrBot-desktop/releases/latest/download/latest-stable.json"
       ],


### PR DESCRIPTION
<!-- Please explain the motivation of this PR and what problem it solves. -->
<!-- 请说明这个 PR 的动机，以及它解决了什么问题。 -->

### **secret更新前请勿合并PR**

### Summary / 改动概述

更新MacOS签名，避免应用已损坏问题

<!-- Please summarize the core changes and affected files. -->
<!-- 请简要说明核心改动和涉及的文件。 -->

### Verification / 验证方式

GitHub Action 打包后在 MacOS 上安装，确认其可以正常打开，已在fork版本上完成验证

尚需更新的 secret key：APPLE_CERTIFICATE、APPLE_CERTIFICATE_PASSWORD、KEYCHAIN_PASSWORD、APPLE_ID、APPLE_PASSWORD、APPLE_TEAM_ID

**secret更新前请勿合并PR**

<img width="2880" height="1574" alt="image" src="https://github.com/user-attachments/assets/06ea3303-4934-4a52-9910-1ec5faa8af70" />

<img width="680" height="574" alt="4ce214757671dea7248db44a7e60867e" src="https://github.com/user-attachments/assets/24c457e5-a5bb-40fd-b2a5-e4d803c252fe" />

<!-- Paste test logs, screenshots, or CI links that prove this change works. -->
<!-- 请粘贴测试日志、截图或 CI 链接，证明改动有效。 -->

---

### Checklist / 检查清单

- [x] This change is **not** a breaking change. / 此改动**不是**破坏性变更。
- [x] I have verified the change locally (and provided logs/screenshots above). / 我已在本地验证并在上方提供日志/截图。
- [x] If workflows are changed, I attached at least one related Actions run link. / 如果修改了工作流，我已附上至少一个相关 Actions 运行链接。
- [x] If dependencies are updated, lockfiles are updated accordingly (`src-tauri/Cargo.lock`, lockfiles under changed package dirs). / 如果引入或升级依赖，已同步更新相关 lock 文件（如 `src-tauri/Cargo.lock`、对应包目录中的 lock 文件）。
- [x] This PR does not include malicious code. / 此 PR 不包含恶意代码。

## Summary by Sourcery

Update macOS build and signing pipeline to correctly sign nested binaries and accept extended version formats for nightly builds.

Enhancements:
- Add a reusable script to recursively codesign nested Mach-O binaries with optional entitlements and introduce an entitlements plist for macOS builds.
- Relax nightly version pattern parsing to support base versions with optional prerelease-style suffixes.

Build:
- Extend desktop Tauri GitHub Actions workflow to import Apple signing certificates, pre-sign macOS backend resources, and pass Apple signing credentials into the macOS build job.

## Summary by Sourcery

Update macOS desktop build pipeline to properly import Apple signing credentials, pre-sign bundled backend binaries, and support more flexible nightly version strings.

New Features:
- Add a reusable script to recursively codesign nested Mach-O binaries with optional entitlements for macOS builds.

Enhancements:
- Introduce a macOS entitlements plist enabling required code-signing capabilities for JIT and unsigned executable memory.
- Allow nightly version parsing to accept base versions with optional prerelease-style suffixes.

Build:
- Extend the desktop Tauri GitHub Actions workflow to import Apple Developer certificates into a temporary keychain, pre-sign macOS backend resources, and pass Apple signing credentials into the macOS build job.