### PR TITLE
fix(ci): prepare macOS signing assets for desktop builds

### DIFF
--- a/.github/workflows/build-desktop-tauri.yml
+++ b/.github/workflows/build-desktop-tauri.yml
@@ -291,6 +291,20 @@ jobs:
           echo "APPLE_SIGNING_IDENTITY=$CERT_ID" >> "$GITHUB_ENV"
           echo "Imported signing identity: $CERT_ID"
 
+      - name: Pre-sign backend resources (macOS)
+        if: ${{ env.APPLE_SIGNING_IDENTITY != '' }}
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ env.APPLE_SIGNING_IDENTITY }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -d "resources/backend" ]; then
+            echo "Pre-signing Mach-O binaries in resources/backend..."
+            bash scripts/ci/codesign-macos-nested.sh "resources/backend" "src-tauri/entitlements.plist"
+          else
+            echo "resources/backend not found; skipping pre-sign."
+          fi
+
       - name: Resolve macOS app bundle name
         id: resolve_macos_app_bundle
         env:
@@ -382,20 +396,6 @@ jobs:
             echo "macOS build hit transient failure on attempt ${attempt}/${max_attempts}; retrying in ${retry_sleep_seconds}s..."
             sleep "${retry_sleep_seconds}"
           done
-
-      - name: Codesign nested binaries (macOS)
-        if: ${{ env.APPLE_SIGNING_IDENTITY != '' }}
-        env:
-          APPLE_SIGNING_IDENTITY: ${{ env.APPLE_SIGNING_IDENTITY }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          app_bundle="src-tauri/target/${{ matrix.target }}/release/bundle/macos/AstrBot.app"
-          if [ ! -d "${app_bundle}" ]; then
-            echo "::warning::App bundle not found at ${app_bundle}; skipping nested signing."
-            exit 0
-          fi
-          bash scripts/ci/codesign-macos-nested.sh "${app_bundle}" "src-tauri/entitlements.plist"
 
       - name: Smoke test backend startup (macOS)
         shell: bash

--- a/.github/workflows/build-desktop-tauri.yml
+++ b/.github/workflows/build-desktop-tauri.yml
@@ -267,7 +267,7 @@ jobs:
           astrbot_version: ${{ steps.desktop_version.outputs.normalized }}
 
       - name: Import Apple Developer Certificate
-        if: ${{ env.APPLE_CERTIFICATE != '' }}
+        if: ${{ secrets.APPLE_CERTIFICATE != '' }}
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}

--- a/.github/workflows/build-desktop-tauri.yml
+++ b/.github/workflows/build-desktop-tauri.yml
@@ -295,15 +295,28 @@ jobs:
         if: ${{ env.APPLE_SIGNING_IDENTITY != '' }}
         env:
           APPLE_SIGNING_IDENTITY: ${{ env.APPLE_SIGNING_IDENTITY }}
+          ASTRBOT_SOURCE_GIT_URL: ${{ needs.resolve_build_context.outputs.source_git_url }}
+          ASTRBOT_SOURCE_GIT_REF: ${{ needs.resolve_build_context.outputs.source_git_ref }}
+          ASTRBOT_DESKTOP_VERSION: ${{ steps.desktop_version.outputs.prefixed }}
+          ASTRBOT_DESKTOP_UPDATER_PUBLIC_KEY: ${{ env.ASTRBOT_DESKTOP_UPDATER_PUBLIC_KEY }}
         shell: bash
         run: |
           set -euo pipefail
-          if [ -d "resources/backend" ]; then
-            echo "Pre-signing Mach-O binaries in resources/backend..."
-            bash scripts/ci/codesign-macos-nested.sh "resources/backend" "src-tauri/entitlements.plist"
-          else
-            echo "resources/backend not found; skipping pre-sign."
+          pnpm run prepare:resources
+          if [ ! -d "resources/backend" ]; then
+            echo "::error::resources/backend not found after prepare:resources." >&2
+            exit 1
           fi
+          echo "Pre-signing Mach-O binaries in resources/backend..."
+          bash scripts/ci/codesign-macos-nested.sh "resources/backend" "src-tauri/entitlements.plist"
+          python3 -c "
+          import json
+          p = 'src-tauri/tauri.conf.json'
+          with open(p) as f: c = json.load(f)
+          c['build']['beforeBuildCommand'] = ''
+          with open(p, 'w') as f: json.dump(c, f, indent=2)
+          print('Cleared beforeBuildCommand to prevent re-generating resources.')
+          "
 
       - name: Resolve macOS app bundle name
         id: resolve_macos_app_bundle

--- a/.github/workflows/build-desktop-tauri.yml
+++ b/.github/workflows/build-desktop-tauri.yml
@@ -299,6 +299,8 @@ jobs:
           ASTRBOT_SOURCE_GIT_REF: ${{ needs.resolve_build_context.outputs.source_git_ref }}
           ASTRBOT_DESKTOP_VERSION: ${{ steps.desktop_version.outputs.prefixed }}
           ASTRBOT_DESKTOP_UPDATER_PUBLIC_KEY: ${{ env.ASTRBOT_DESKTOP_UPDATER_PUBLIC_KEY }}
+          GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/build-desktop-tauri.yml
+++ b/.github/workflows/build-desktop-tauri.yml
@@ -383,6 +383,20 @@ jobs:
             sleep "${retry_sleep_seconds}"
           done
 
+      - name: Codesign nested binaries (macOS)
+        if: ${{ env.APPLE_SIGNING_IDENTITY != '' }}
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ env.APPLE_SIGNING_IDENTITY }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          app_bundle="src-tauri/target/${{ matrix.target }}/release/bundle/macos/AstrBot.app"
+          if [ ! -d "${app_bundle}" ]; then
+            echo "::warning::App bundle not found at ${app_bundle}; skipping nested signing."
+            exit 0
+          fi
+          bash scripts/ci/codesign-macos-nested.sh "${app_bundle}" "src-tauri/entitlements.plist"
+
       - name: Smoke test backend startup (macOS)
         shell: bash
         run: |

--- a/.github/workflows/build-desktop-tauri.yml
+++ b/.github/workflows/build-desktop-tauri.yml
@@ -280,6 +280,7 @@ jobs:
 
           echo "$APPLE_CERTIFICATE" | base64 --decode > "$CERT_PATH"
           security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security default-keychain -s "$KEYCHAIN_PATH"
           security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           security import "$CERT_PATH" -P "$APPLE_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"

--- a/.github/workflows/build-desktop-tauri.yml
+++ b/.github/workflows/build-desktop-tauri.yml
@@ -290,9 +290,26 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           rm -f "$CERT_PATH"
 
-          CERT_INFO=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" | grep "Developer ID Application")
-          CERT_ID=$(echo "$CERT_INFO" | awk -F'"' '{print $2}')
-          echo "APPLE_SIGNING_IDENTITY=$CERT_ID" >> "$GITHUB_ENV"
+          signing_identities=()
+          while IFS= read -r identity; do
+            signing_identities+=("$identity")
+          done < <(security find-identity -v -p codesigning "$KEYCHAIN_PATH" | grep "Developer ID Application" || true)
+          if [ "${#signing_identities[@]}" -eq 0 ]; then
+            echo "::error::No Developer ID Application identity found in the imported keychain." >&2
+            security find-identity -v -p codesigning "$KEYCHAIN_PATH" || true
+            exit 1
+          fi
+          if [ "${#signing_identities[@]}" -ne 1 ]; then
+            echo "::error::Expected exactly one Developer ID Application identity, found ${#signing_identities[@]}." >&2
+            printf '%s\n' "${signing_identities[@]}" >&2
+            exit 1
+          fi
+          CERT_ID=$(printf '%s\n' "${signing_identities[0]}" | awk -F'"' '{print $2}')
+          if [ -z "$CERT_ID" ]; then
+            echo "::error::Failed to parse the imported Developer ID Application identity." >&2
+            exit 1
+          fi
+          printf 'APPLE_SIGNING_IDENTITY=%s\n' "$CERT_ID" >> "$GITHUB_ENV"
           echo "Imported signing identity: $CERT_ID"
 
       - name: Pre-sign backend resources (macOS)
@@ -315,14 +332,6 @@ jobs:
           fi
           echo "Pre-signing Mach-O binaries in resources/backend..."
           bash scripts/ci/codesign-macos-nested.sh "resources/backend" "src-tauri/entitlements.plist"
-          python3 -c "
-          import json
-          p = 'src-tauri/tauri.conf.json'
-          with open(p) as f: c = json.load(f)
-          c['build']['beforeBuildCommand'] = ''
-          with open(p, 'w') as f: json.dump(c, f, indent=2)
-          print('Cleared beforeBuildCommand to prevent re-generating resources.')
-          "
 
       - name: Resolve macOS app bundle name
         id: resolve_macos_app_bundle
@@ -370,6 +379,8 @@ jobs:
 
           max_attempts="${ASTRBOT_MACOS_BUILD_MAX_ATTEMPTS}"
           retry_sleep_seconds="${ASTRBOT_MACOS_BUILD_RETRY_SLEEP_SECONDS}"
+          # Resources are already prepared and pre-signed in the previous step.
+          tauri_config_override='{"build":{"beforeBuildCommand":""}}'
           # Retry only for known transient cargo/crates network failures.
           # Spurious retry hints emitted by cargo.
           transient_retry_spurious='spurious network error|network failure seems to have happened'
@@ -394,7 +405,7 @@ jobs:
 
           for attempt in $(seq 1 "${max_attempts}"); do
             build_log="$(mktemp -t tauri-macos-build.XXXXXX.log)"
-            if cargo tauri build --verbose --target ${{ matrix.target }} --bundles app 2>&1 | tee "${build_log}"; then
+            if cargo tauri build --verbose --target ${{ matrix.target }} --bundles app --config "${tauri_config_override}" 2>&1 | tee "${build_log}"; then
               rm -f "${build_log}" || true
               break
             fi

--- a/.github/workflows/build-desktop-tauri.yml
+++ b/.github/workflows/build-desktop-tauri.yml
@@ -267,7 +267,6 @@ jobs:
           astrbot_version: ${{ steps.desktop_version.outputs.normalized }}
 
       - name: Import Apple Developer Certificate
-        if: ${{ secrets.APPLE_CERTIFICATE != '' }}
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -275,6 +274,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          if [ -z "${APPLE_CERTIFICATE:-}" ]; then
+            echo "APPLE_CERTIFICATE is not configured; skipping certificate import."
+            exit 0
+          fi
           CERT_PATH="$RUNNER_TEMP/certificate.p12"
           KEYCHAIN_PATH="$RUNNER_TEMP/build.keychain"
 

--- a/.github/workflows/build-desktop-tauri.yml
+++ b/.github/workflows/build-desktop-tauri.yml
@@ -267,6 +267,7 @@ jobs:
           astrbot_version: ${{ steps.desktop_version.outputs.normalized }}
 
       - name: Import Apple Developer Certificate
+        id: import_apple_certificate
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -276,6 +277,7 @@ jobs:
           set -euo pipefail
           if [ -z "${APPLE_CERTIFICATE:-}" ]; then
             echo "APPLE_CERTIFICATE is not configured; skipping certificate import."
+            printf 'signing_identity=\n' >> "$GITHUB_OUTPUT"
             exit 0
           fi
           CERT_PATH="$RUNNER_TEMP/certificate.p12"
@@ -310,12 +312,12 @@ jobs:
             exit 1
           fi
           printf 'APPLE_SIGNING_IDENTITY=%s\n' "$CERT_ID" >> "$GITHUB_ENV"
+          printf 'signing_identity=%s\n' "$CERT_ID" >> "$GITHUB_OUTPUT"
           echo "Imported signing identity: $CERT_ID"
 
       - name: Pre-sign backend resources (macOS)
-        if: ${{ env.APPLE_SIGNING_IDENTITY != '' }}
+        if: ${{ steps.import_apple_certificate.outputs.signing_identity != '' }}
         env:
-          APPLE_SIGNING_IDENTITY: ${{ env.APPLE_SIGNING_IDENTITY }}
           ASTRBOT_SOURCE_GIT_URL: ${{ needs.resolve_build_context.outputs.source_git_url }}
           ASTRBOT_SOURCE_GIT_REF: ${{ needs.resolve_build_context.outputs.source_git_ref }}
           ASTRBOT_DESKTOP_VERSION: ${{ steps.desktop_version.outputs.prefixed }}
@@ -362,7 +364,6 @@ jobs:
           ASTRBOT_DESKTOP_CRYPTOGRAPHY_FALLBACK_VERSIONS: ${{ vars.ASTRBOT_DESKTOP_CRYPTOGRAPHY_FALLBACK_VERSIONS || '' }}
           ASTRBOT_MACOS_BUILD_MAX_ATTEMPTS: ${{ vars.ASTRBOT_MACOS_BUILD_MAX_ATTEMPTS || '3' }}
           ASTRBOT_MACOS_BUILD_RETRY_SLEEP_SECONDS: ${{ vars.ASTRBOT_MACOS_BUILD_RETRY_SLEEP_SECONDS || '8' }}
-          APPLE_SIGNING_IDENTITY: ${{ env.APPLE_SIGNING_IDENTITY }}
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           APPLE_ID: ${{ secrets.APPLE_ID }}

--- a/.github/workflows/build-desktop-tauri.yml
+++ b/.github/workflows/build-desktop-tauri.yml
@@ -266,6 +266,31 @@ jobs:
         with:
           astrbot_version: ${{ steps.desktop_version.outputs.normalized }}
 
+      - name: Import Apple Developer Certificate
+        if: ${{ env.APPLE_CERTIFICATE != '' }}
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          CERT_PATH="$RUNNER_TEMP/certificate.p12"
+          KEYCHAIN_PATH="$RUNNER_TEMP/build.keychain"
+
+          echo "$APPLE_CERTIFICATE" | base64 --decode > "$CERT_PATH"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" -P "$APPLE_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          rm -f "$CERT_PATH"
+
+          CERT_INFO=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" | grep "Developer ID Application")
+          CERT_ID=$(echo "$CERT_INFO" | awk -F'"' '{print $2}')
+          echo "APPLE_SIGNING_IDENTITY=$CERT_ID" >> "$GITHUB_ENV"
+          echo "Imported signing identity: $CERT_ID"
+
       - name: Resolve macOS app bundle name
         id: resolve_macos_app_bundle
         env:
@@ -295,6 +320,12 @@ jobs:
           ASTRBOT_DESKTOP_CRYPTOGRAPHY_FALLBACK_VERSIONS: ${{ vars.ASTRBOT_DESKTOP_CRYPTOGRAPHY_FALLBACK_VERSIONS || '' }}
           ASTRBOT_MACOS_BUILD_MAX_ATTEMPTS: ${{ vars.ASTRBOT_MACOS_BUILD_MAX_ATTEMPTS || '3' }}
           ASTRBOT_MACOS_BUILD_RETRY_SLEEP_SECONDS: ${{ vars.ASTRBOT_MACOS_BUILD_RETRY_SLEEP_SECONDS || '8' }}
+          APPLE_SIGNING_IDENTITY: ${{ env.APPLE_SIGNING_IDENTITY }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           GITHUB_TOKEN: ${{ github.token }}
           GH_TOKEN: ${{ github.token }}
         shell: bash

--- a/scripts/ci/codesign-macos-nested.sh
+++ b/scripts/ci/codesign-macos-nested.sh
@@ -28,7 +28,7 @@ while IFS= read -r -d '' file; do
     NESTED_BINARIES+=("${file}")
     BINARY_FILE_DESCRIPTIONS+=("${file_description}")
   fi
-done < <(find "${TARGET}" -type f -print0 2>/dev/null | sort -rz)
+done < <(find "${TARGET}" -type f -print0 2>/dev/null)
 
 if [ "${#NESTED_BINARIES[@]}" -eq 0 ]; then
   echo "No Mach-O binaries found in ${TARGET}; nothing to sign."

--- a/scripts/ci/codesign-macos-nested.sh
+++ b/scripts/ci/codesign-macos-nested.sh
@@ -36,8 +36,13 @@ echo "Found ${#NESTED_BINARIES[@]} Mach-O binary(ies) to sign in ${TARGET}."
 
 for binary in "${NESTED_BINARIES[@]}"; do
   echo "  Signing: ${binary}"
+  # Only apply entitlements to executables, not dylibs
+  CURRENT_ENTITLEMENTS=()
+  if [ ${#ENTITLEMENTS_ARGS[@]} -gt 0 ] && file --brief "${binary}" | grep -q "executable"; then
+    CURRENT_ENTITLEMENTS=("${ENTITLEMENTS_ARGS[@]}")
+  fi
   codesign "${SIGN_OPTS[@]}" \
-    "${ENTITLEMENTS_ARGS[@]+"${ENTITLEMENTS_ARGS[@]}"}" \
+    ${CURRENT_ENTITLEMENTS[@]+"${CURRENT_ENTITLEMENTS[@]}"} \
     "${binary}"
 done
 

--- a/scripts/ci/codesign-macos-nested.sh
+++ b/scripts/ci/codesign-macos-nested.sh
@@ -20,10 +20,13 @@ if [ ! -d "${TARGET}" ]; then
   exit 1
 fi
 
+BINARY_FILE_DESCRIPTIONS=()
 NESTED_BINARIES=()
 while IFS= read -r -d '' file; do
-  if file --brief "${file}" | grep -q "Mach-O"; then
+  file_description="$(file --brief "${file}")"
+  if [[ "${file_description}" == *"Mach-O"* ]]; then
     NESTED_BINARIES+=("${file}")
+    BINARY_FILE_DESCRIPTIONS+=("${file_description}")
   fi
 done < <(find "${TARGET}" -type f -print0 2>/dev/null | sort -rz)
 
@@ -34,11 +37,13 @@ fi
 
 echo "Found ${#NESTED_BINARIES[@]} Mach-O binary(ies) to sign in ${TARGET}."
 
-for binary in "${NESTED_BINARIES[@]}"; do
+for index in "${!NESTED_BINARIES[@]}"; do
+  binary="${NESTED_BINARIES[${index}]}"
+  file_description="${BINARY_FILE_DESCRIPTIONS[${index}]}"
   echo "  Signing: ${binary}"
   # Only apply entitlements to executables, not dylibs
   CURRENT_ENTITLEMENTS=()
-  if [ ${#ENTITLEMENTS_ARGS[@]} -gt 0 ] && file --brief "${binary}" | grep -q "executable"; then
+  if [ ${#ENTITLEMENTS_ARGS[@]} -gt 0 ] && [[ "${file_description}" == *"executable"* ]]; then
     CURRENT_ENTITLEMENTS=("${ENTITLEMENTS_ARGS[@]}")
   fi
   codesign "${SIGN_OPTS[@]}" \

--- a/scripts/ci/codesign-macos-nested.sh
+++ b/scripts/ci/codesign-macos-nested.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "${APPLE_SIGNING_IDENTITY:-}" ]; then
+  echo "::warning::APPLE_SIGNING_IDENTITY is not set; skipping nested code signing."
+  exit 0
+fi
+
+APP_BUNDLE="${1:?Usage: $0 <path-to-app-bundle>}"
+if [ ! -d "${APP_BUNDLE}" ]; then
+  echo "::error::App bundle not found: ${APP_BUNDLE}" >&2
+  exit 1
+fi
+
+ENTITLEMENTS_PATH="${2:-}"
+ENTITLEMENTS_ARGS=()
+if [ -n "${ENTITLEMENTS_PATH}" ] && [ -f "${ENTITLEMENTS_PATH}" ]; then
+  ENTITLEMENTS_ARGS=(--entitlements "${ENTITLEMENTS_PATH}")
+fi
+
+echo "Signing nested binaries inside ${APP_BUNDLE} with identity: ${APPLE_SIGNING_IDENTITY}"
+
+NESTED_BINARIES=()
+while IFS= read -r -d '' file; do
+  if file --brief "${file}" | grep -q "Mach-O"; then
+    NESTED_BINARIES+=("${file}")
+  fi
+done < <(find "${APP_BUNDLE}/Contents/Resources" -type f -print0 2>/dev/null || true)
+
+if [ "${#NESTED_BINARIES[@]}" -eq 0 ]; then
+  echo "No nested Mach-O binaries found in Resources; nothing extra to sign."
+  exit 0
+fi
+
+echo "Found ${#NESTED_BINARIES[@]} nested Mach-O binary(ies) to sign."
+
+for binary in "${NESTED_BINARIES[@]}"; do
+  echo "  Signing: ${binary}"
+  codesign --force --options runtime \
+    "${ENTITLEMENTS_ARGS[@]+"${ENTITLEMENTS_ARGS[@]}"}" \
+    --sign "${APPLE_SIGNING_IDENTITY}" \
+    "${binary}"
+done
+
+echo "Re-signing the app bundle itself..."
+codesign --force --options runtime \
+  "${ENTITLEMENTS_ARGS[@]+"${ENTITLEMENTS_ARGS[@]}"}" \
+  --sign "${APPLE_SIGNING_IDENTITY}" \
+  --deep \
+  "${APP_BUNDLE}"
+
+echo "Verifying signature..."
+codesign --verify --verbose=2 --deep --strict "${APP_BUNDLE}"
+
+echo "Nested code signing completed successfully."

--- a/scripts/ci/codesign-macos-nested.sh
+++ b/scripts/ci/codesign-macos-nested.sh
@@ -25,7 +25,7 @@ while IFS= read -r -d '' file; do
   if file --brief "${file}" | grep -q "Mach-O"; then
     NESTED_BINARIES+=("${file}")
   fi
-done < <(find "${TARGET}" -type f -print0 2>/dev/null || true)
+done < <(find "${TARGET}" -type f -print0 2>/dev/null | sort -rz)
 
 if [ "${#NESTED_BINARIES[@]}" -eq 0 ]; then
   echo "No Mach-O binaries found in ${TARGET}; nothing to sign."

--- a/scripts/ci/codesign-macos-nested.sh
+++ b/scripts/ci/codesign-macos-nested.sh
@@ -2,54 +2,43 @@
 set -euo pipefail
 
 if [ -z "${APPLE_SIGNING_IDENTITY:-}" ]; then
-  echo "::warning::APPLE_SIGNING_IDENTITY is not set; skipping nested code signing."
+  echo "::warning::APPLE_SIGNING_IDENTITY is not set; skipping code signing."
   exit 0
 fi
 
-APP_BUNDLE="${1:?Usage: $0 <path-to-app-bundle>}"
-if [ ! -d "${APP_BUNDLE}" ]; then
-  echo "::error::App bundle not found: ${APP_BUNDLE}" >&2
-  exit 1
-fi
-
+TARGET="${1:?Usage: $0 <path-to-directory-or-app-bundle> [entitlements.plist]}"
 ENTITLEMENTS_PATH="${2:-}"
 ENTITLEMENTS_ARGS=()
 if [ -n "${ENTITLEMENTS_PATH}" ] && [ -f "${ENTITLEMENTS_PATH}" ]; then
   ENTITLEMENTS_ARGS=(--entitlements "${ENTITLEMENTS_PATH}")
 fi
 
-echo "Signing nested binaries inside ${APP_BUNDLE} with identity: ${APPLE_SIGNING_IDENTITY}"
+SIGN_OPTS=(--force --options runtime --sign "${APPLE_SIGNING_IDENTITY}")
+
+if [ ! -d "${TARGET}" ]; then
+  echo "::error::Target not found: ${TARGET}" >&2
+  exit 1
+fi
 
 NESTED_BINARIES=()
 while IFS= read -r -d '' file; do
   if file --brief "${file}" | grep -q "Mach-O"; then
     NESTED_BINARIES+=("${file}")
   fi
-done < <(find "${APP_BUNDLE}/Contents/Resources" -type f -print0 2>/dev/null || true)
+done < <(find "${TARGET}" -type f -print0 2>/dev/null || true)
 
 if [ "${#NESTED_BINARIES[@]}" -eq 0 ]; then
-  echo "No nested Mach-O binaries found in Resources; nothing extra to sign."
+  echo "No Mach-O binaries found in ${TARGET}; nothing to sign."
   exit 0
 fi
 
-echo "Found ${#NESTED_BINARIES[@]} nested Mach-O binary(ies) to sign."
+echo "Found ${#NESTED_BINARIES[@]} Mach-O binary(ies) to sign in ${TARGET}."
 
 for binary in "${NESTED_BINARIES[@]}"; do
   echo "  Signing: ${binary}"
-  codesign --force --options runtime \
+  codesign "${SIGN_OPTS[@]}" \
     "${ENTITLEMENTS_ARGS[@]+"${ENTITLEMENTS_ARGS[@]}"}" \
-    --sign "${APPLE_SIGNING_IDENTITY}" \
     "${binary}"
 done
 
-echo "Re-signing the app bundle itself..."
-codesign --force --options runtime \
-  "${ENTITLEMENTS_ARGS[@]+"${ENTITLEMENTS_ARGS[@]}"}" \
-  --sign "${APPLE_SIGNING_IDENTITY}" \
-  --deep \
-  "${APP_BUNDLE}"
-
-echo "Verifying signature..."
-codesign --verify --verbose=2 --deep --strict "${APP_BUNDLE}"
-
-echo "Nested code signing completed successfully."
+echo "Code signing completed successfully for ${#NESTED_BINARIES[@]} binary(ies)."

--- a/scripts/ci/lib/nightly_version.py
+++ b/scripts/ci/lib/nightly_version.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 
 SPEC_PATH = Path(__file__).resolve().parents[3] / "src-tauri" / "nightly-version-format.json"
-BASE_VERSION_PATTERN = r"[0-9]+(?:\.[0-9]+){1,2}"
+BASE_VERSION_PATTERN = r"[0-9]+(?:\.[0-9]+){1,2}(?:-[a-zA-Z0-9.]+)?"
 
 _SPEC = json.loads(SPEC_PATH.read_text(encoding="utf-8"))
 NIGHTLY_CANONICAL_FORMAT = str(_SPEC["canonicalFormat"])

--- a/src-tauri/entitlements.plist
+++ b/src-tauri/entitlements.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>

--- a/src-tauri/entitlements.plist
+++ b/src-tauri/entitlements.plist
@@ -6,8 +6,6 @@
     <true/>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
     <true/>
-    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
-    <true/>
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
 </dict>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -31,6 +31,9 @@
     "active": true,
     "createUpdaterArtifacts": true,
     "targets": "all",
+    "macOS": {
+      "entitlements": "entitlements.plist"
+    },
     "windows": {
       "webviewInstallMode": {
         "type": "downloadBootstrapper",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -64,7 +64,7 @@
   },
   "plugins": {
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDlFOEY1REYyNTZEQ0VBMDkKUldRSjZ0eFc4bDJQbnNqTDVIUmNudXEwcXVMUWVPb0RxZHRiNHR0Y3JuRlJVSDlLRzhDWE9ZSkMK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEREMUZDOUE1RTlCNjgzNEYKUldSUGc3YnBwY2tmM1RLMThLTndZT3NiSVVha1J4VXRvaWJmTThVRm0zR1JSTG1EQUhZaG82MEEK",
       "endpoints": [
         "https://github.com/AstrBotDevs/AstrBot-desktop/releases/latest/download/latest-stable.json"
       ],

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -64,7 +64,7 @@
   },
   "plugins": {
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEREMUZDOUE1RTlCNjgzNEYKUldSUGc3YnBwY2tmM1RLMThLTndZT3NiSVVha1J4VXRvaWJmTThVRm0zR1JSTG1EQUhZaG82MEEK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDlFOEY1REYyNTZEQ0VBMDkKUldRSjZ0eFc4bDJQbnNqTDVIUmNudXEwcXVMUWVPb0RxZHRiNHR0Y3JuRlJVSDlLRzhDWE9ZSkMK",
       "endpoints": [
         "https://github.com/AstrBotDevs/AstrBot-desktop/releases/latest/download/latest-stable.json"
       ],


### PR DESCRIPTION
## Summary
- import the Apple Developer certificate in the macOS workflow and expose the signing identity to later build steps
- pre-sign nested Mach-O binaries in `resources/backend` with a dedicated script and wire the macOS entitlements into Tauri config
- allow prerelease suffixes in the nightly version base pattern so beta version strings still pass validation

## Testing
- Not run locally; this PR packages existing commits on `dev-osx`

## Summary by Sourcery

Prepare macOS desktop builds for proper Apple code signing and broaden nightly version validation.

New Features:
- Pre-sign nested Mach-O binaries in backend resources during the macOS CI workflow using a dedicated codesigning script and entitlements configuration.

Bug Fixes:
- Allow prerelease suffixes in the nightly base version pattern so beta-style version strings pass validation.

Enhancements:
- Import and configure the Apple Developer signing certificate and related credentials in the macOS build workflow and propagate the signing identity to subsequent build steps.
- Adjust the macOS Tauri build step to reuse already prepared and signed resources via a configuration override.