### PR TITLE
fix: desktop update banner for desktop releases

### DIFF
--- a/scripts/prepare-resources/desktop-bridge-checks.mjs
+++ b/scripts/prepare-resources/desktop-bridge-checks.mjs
@@ -60,6 +60,43 @@ export const patchMonacoCssNestingWarnings = async ({ dashboardDir, projectRoot 
   }
 };
 
+export const patchDesktopReleaseUpdateIndicator = async ({ dashboardDir, projectRoot }) => {
+  const file = path.join(
+    dashboardDir,
+    'src',
+    'layouts',
+    'full',
+    'vertical-header',
+    'VerticalHeader.vue',
+  );
+  if (!existsSync(file)) {
+    return;
+  }
+
+  const source = await readFile(file, 'utf8');
+  if (source.includes('const backendHasNewVersion = !isDesktopReleaseMode.value && res.data.data.has_new_version;')) {
+    return;
+  }
+
+  const target = "      hasNewVersion.value = res.data.data.has_new_version;\n\n      if (res.data.data.has_new_version) {";
+  const replacement =
+    "      const backendHasNewVersion = !isDesktopReleaseMode.value && res.data.data.has_new_version;\n" +
+    "      hasNewVersion.value = backendHasNewVersion;\n\n" +
+    "      if (backendHasNewVersion) {";
+
+  if (!source.includes(target)) {
+    return;
+  }
+
+  const patched = source.replace(target, replacement);
+  if (patched !== source) {
+    await writeFile(file, patched, 'utf8');
+    console.log(
+      `[prepare-resources] Patched desktop release update banner gating in ${path.relative(projectRoot, file)}`,
+    );
+  }
+};
+
 export const verifyDesktopBridgeArtifacts = async ({
   dashboardDir,
   projectRoot,

--- a/scripts/prepare-resources/desktop-bridge-checks.mjs
+++ b/scripts/prepare-resources/desktop-bridge-checks.mjs
@@ -78,17 +78,23 @@ export const patchDesktopReleaseUpdateIndicator = async ({ dashboardDir, project
     return;
   }
 
-  const target = "      hasNewVersion.value = res.data.data.has_new_version;\n\n      if (res.data.data.has_new_version) {";
-  const replacement =
-    "      const backendHasNewVersion = !isDesktopReleaseMode.value && res.data.data.has_new_version;\n" +
-    "      hasNewVersion.value = backendHasNewVersion;\n\n" +
-    "      if (backendHasNewVersion) {";
+  const targetPattern =
+    /^(\s*)hasNewVersion\.value\s*=\s*res\.data\.data\.has_new_version;\s*\n\s*if\s*\(\s*res\.data\.data\.has_new_version\s*\)\s*\{/m;
 
-  if (!source.includes(target)) {
+  if (!targetPattern.test(source)) {
+    console.warn(
+      `[prepare-resources] Could not patch desktop release update banner gating in ${path.relative(projectRoot, file)} because the expected update check pattern was not found.`,
+    );
     return;
   }
 
-  const patched = source.replace(target, replacement);
+  const patched = source.replace(
+    targetPattern,
+    (_, indent) =>
+      `${indent}const backendHasNewVersion = !isDesktopReleaseMode.value && res.data.data.has_new_version;\n` +
+      `${indent}hasNewVersion.value = backendHasNewVersion;\n\n` +
+      `${indent}if (backendHasNewVersion) {`,
+  );
   if (patched !== source) {
     await writeFile(file, patched, 'utf8');
     console.log(

--- a/scripts/prepare-resources/desktop-bridge-checks.test.mjs
+++ b/scripts/prepare-resources/desktop-bridge-checks.test.mjs
@@ -65,7 +65,7 @@ test('shouldEnforceDesktopBridgeExpectation enforces required expectations on no
   );
 });
 
-test('patchDesktopReleaseUpdateIndicator suppresses backend update banner in desktop release mode', async () => {
+test('patchDesktopReleaseUpdateIndicator tolerates minor formatting changes in the upstream source', async () => {
   const dashboardDir = await mkdtemp(path.join(tmpdir(), 'astrbot-dashboard-'));
   const headerFile = path.join(
     dashboardDir,
@@ -81,9 +81,8 @@ test('patchDesktopReleaseUpdateIndicator suppresses backend update banner in des
     `function checkUpdate() {
   axios.get('/api/update/check')
     .then((res) => {
-      hasNewVersion.value = res.data.data.has_new_version;
-
-      if (res.data.data.has_new_version) {
+        hasNewVersion.value   =   res.data.data.has_new_version;
+      if   ( res.data.data.has_new_version )   {
         releaseMessage.value = res.data.message;
         updateStatus.value = t('core.header.version.hasNewVersion');
       } else {
@@ -108,4 +107,42 @@ test('patchDesktopReleaseUpdateIndicator suppresses backend update banner in des
   assert.match(patched, /hasNewVersion\.value = backendHasNewVersion;/);
   assert.match(patched, /if \(backendHasNewVersion\) \{/);
   assert.doesNotMatch(patched, /hasNewVersion\.value = res\.data\.data\.has_new_version;/);
+});
+
+test('patchDesktopReleaseUpdateIndicator warns when the expected update pattern is missing', async () => {
+  const dashboardDir = await mkdtemp(path.join(tmpdir(), 'astrbot-dashboard-'));
+  const headerFile = path.join(
+    dashboardDir,
+    'src',
+    'layouts',
+    'full',
+    'vertical-header',
+    'VerticalHeader.vue',
+  );
+  await mkdir(path.dirname(headerFile), { recursive: true });
+  await writeFile(
+    headerFile,
+    `function checkUpdate() {
+  axios.get('/api/update/check')
+    .then((res) => {
+      updateStatus.value = res.data.message;
+    })
+}
+`,
+    'utf8',
+  );
+
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = (message) => warnings.push(String(message));
+
+  try {
+    await patchDesktopReleaseUpdateIndicator({ dashboardDir, projectRoot: dashboardDir });
+  } finally {
+    console.warn = originalWarn;
+  }
+
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /Could not patch desktop release update banner gating/);
+  assert.match(warnings[0], /VerticalHeader\.vue/);
 });

--- a/scripts/prepare-resources/desktop-bridge-checks.test.mjs
+++ b/scripts/prepare-resources/desktop-bridge-checks.test.mjs
@@ -1,10 +1,14 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 
 import {
   getDesktopBridgeExpectations,
   shouldEnforceDesktopBridgeExpectation,
 } from './desktop-bridge-expectations.mjs';
+import { patchDesktopReleaseUpdateIndicator } from './desktop-bridge-checks.mjs';
 
 test('getDesktopBridgeExpectations returns stable expectation metadata', () => {
   const expectations = getDesktopBridgeExpectations();
@@ -59,4 +63,49 @@ test('shouldEnforceDesktopBridgeExpectation enforces required expectations on no
     ),
     true,
   );
+});
+
+test('patchDesktopReleaseUpdateIndicator suppresses backend update banner in desktop release mode', async () => {
+  const dashboardDir = await mkdtemp(path.join(tmpdir(), 'astrbot-dashboard-'));
+  const headerFile = path.join(
+    dashboardDir,
+    'src',
+    'layouts',
+    'full',
+    'vertical-header',
+    'VerticalHeader.vue',
+  );
+  await mkdir(path.dirname(headerFile), { recursive: true });
+  await writeFile(
+    headerFile,
+    `function checkUpdate() {
+  axios.get('/api/update/check')
+    .then((res) => {
+      hasNewVersion.value = res.data.data.has_new_version;
+
+      if (res.data.data.has_new_version) {
+        releaseMessage.value = res.data.message;
+        updateStatus.value = t('core.header.version.hasNewVersion');
+      } else {
+        updateStatus.value = res.data.message;
+      }
+      dashboardHasNewVersion.value = isDesktopReleaseMode.value
+        ? false
+        : res.data.data.dashboard_has_new_version;
+    })
+}
+`,
+    'utf8',
+  );
+
+  await patchDesktopReleaseUpdateIndicator({ dashboardDir, projectRoot: dashboardDir });
+
+  const patched = await readFile(headerFile, 'utf8');
+  assert.match(
+    patched,
+    /const backendHasNewVersion = !isDesktopReleaseMode\.value && res\.data\.data\.has_new_version;/,
+  );
+  assert.match(patched, /hasNewVersion\.value = backendHasNewVersion;/);
+  assert.match(patched, /if \(backendHasNewVersion\) \{/);
+  assert.doesNotMatch(patched, /hasNewVersion\.value = res\.data\.data\.has_new_version;/);
 });

--- a/scripts/prepare-resources/mode-tasks.mjs
+++ b/scripts/prepare-resources/mode-tasks.mjs
@@ -3,6 +3,7 @@ import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import {
+  patchDesktopReleaseUpdateIndicator,
   patchMonacoCssNestingWarnings,
   verifyDesktopBridgeArtifacts,
 } from './desktop-bridge-checks.mjs';
@@ -66,6 +67,7 @@ export const prepareWebui = async ({
   const dashboardDir = path.join(sourceDir, 'dashboard');
   ensurePackageInstall(dashboardDir, 'AstrBot dashboard');
   await patchMonacoCssNestingWarnings({ dashboardDir, projectRoot });
+  await patchDesktopReleaseUpdateIndicator({ dashboardDir, projectRoot });
   await verifyDesktopBridgeArtifacts({
     dashboardDir,
     projectRoot,


### PR DESCRIPTION
This fixes a desktop-only update UX mismatch where the top header could show `AstrBot 有新版本！` while the desktop updater dialog reported that the current app was already up to date.

In desktop release mode, the upstream dashboard still used `/api/update/check` to drive the header badge. That API reports backend update availability, not desktop shell update availability. Clicking the badge in desktop mode opens the desktop app updater dialog, so users could see a backend-originated update hint followed by a desktop updater result that correctly said there was no newer app build.

The root cause was that `VerticalHeader.vue` assigned `hasNewVersion` directly from `res.data.data.has_new_version` even when `isDesktopReleaseMode` was true. The desktop shell already routes the actual update action through `window.astrbotAppUpdater`, so the header badge needed to stop reflecting backend release checks in that mode.

This change patches the upstream dashboard source during `prepare:webui` so the backend update badge is only enabled outside desktop release mode. It also adds a regression test for the patch helper and wires the helper into the WebUI prepare pipeline.

Validation:
- `node --test "scripts/prepare-resources/desktop-bridge-checks.test.mjs"`
- `node --test "scripts/prepare-resources/mode-dispatch.test.mjs" "scripts/prepare-resources/context.test.mjs" "scripts/prepare-resources/bridge-bootstrap-updater-contract.test.mjs"`
- `pnpm test:prepare-resources`

## Summary by Sourcery

Ensure the desktop app header update banner no longer reflects backend update availability when running in desktop release mode.

Bug Fixes:
- Prevent the desktop header update indicator from showing backend-originated update prompts that do not correspond to desktop shell updates in desktop release mode.

Enhancements:
- Add a prepare-resources patch that rewrites the dashboard header update logic to gate the backend update banner by desktop release mode and integrate it into the WebUI preparation pipeline.

Tests:
- Add regression tests for the desktop release update indicator patch helper, including tolerance of minor upstream formatting changes and warning behavior when the expected pattern is missing.