### PR TITLE
chore(ci): update action dependencies

### DIFF
--- a/.github/workflows/build-desktop-tauri.yml
+++ b/.github/workflows/build-desktop-tauri.yml
@@ -109,7 +109,7 @@ jobs:
           setup-python: 'false'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4.4.0
+        uses: pnpm/action-setup@v6.0.3
         with:
           version: 10.28.2
 
@@ -223,7 +223,7 @@ jobs:
           node scripts/ci/backend-smoke-test.mjs --label "linux-${{ matrix.arch }}"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v6.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: astrbot-desktop-tauri-${{ needs.resolve_build_context.outputs.astrbot_version }}-linux-${{ matrix.arch }}
           if-no-files-found: error
@@ -496,7 +496,7 @@ jobs:
           echo "Collected ${release_dir}/${release_base}"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v6.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: astrbot-desktop-tauri-${{ needs.resolve_build_context.outputs.astrbot_version }}-macos-${{ matrix.arch }}
           if-no-files-found: error
@@ -577,7 +577,7 @@ jobs:
         run: bash scripts/ci/verify-windows-installer-outputs.sh
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v6.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: astrbot-desktop-tauri-${{ needs.resolve_build_context.outputs.astrbot_version }}-windows-${{ matrix.arch }}
           if-no-files-found: error
@@ -607,7 +607,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v7.0.0
+        uses: actions/download-artifact@v8.0.1
         with:
           pattern: astrbot-desktop-tauri-${{ needs.resolve_build_context.outputs.astrbot_version }}-*
           path: release-artifacts
@@ -676,7 +676,7 @@ jobs:
         run: bash scripts/ci/cleanup-release-assets.sh
 
       - name: Create or update release
-        uses: softprops/action-gh-release@v2.5.0
+        uses: softprops/action-gh-release@v3.0.0
         with:
           tag_name: ${{ needs.resolve_build_context.outputs.release_tag }}
           name: ${{ needs.resolve_build_context.outputs.release_name }}

--- a/.github/workflows/check-rust.yml
+++ b/.github/workflows/check-rust.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Cache Cargo registry, git, and target
         if: steps.detect-tauri.outputs.has_tauri == 'true'
-        uses: actions/cache@v5.0.3
+        uses: actions/cache@v5.0.5
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/check-scripts.yml
+++ b/.github/workflows/check-scripts.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4.4.0
+        uses: pnpm/action-setup@v6.0.3
         with:
           version: 10.28.2
 

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -19,4 +19,4 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Run actionlint
-        uses: rhysd/actionlint@v1.7.11
+        uses: rhysd/actionlint@v1.7.12


### PR DESCRIPTION
## Summary
- Updates GitHub Actions workflow dependencies to current stable tags.
- Keeps already-current actions unchanged and preserves existing workflow behavior.

## Verification
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`

## Summary by Sourcery

Update GitHub Actions workflows to use newer stable versions of key third-party actions while preserving existing CI behavior.

Build:
- Bump pnpm/action-setup to v6.0.3 in workflows using pnpm.
- Upgrade actions/cache to v5.0.5 in Rust check workflow.

CI:
- Update actions/upload-artifact to v7.0.1 and actions/download-artifact to v8.0.1 in desktop build workflow.
- Upgrade softprops/action-gh-release to v3.0.0 in the release job.
- Bump rhysd/actionlint used in workflow linting to v1.7.12.