### PR TITLE
fix(ci): suppress nightly generated release notes

### DIFF
--- a/.github/workflows/build-desktop-tauri.yml
+++ b/.github/workflows/build-desktop-tauri.yml
@@ -687,7 +687,7 @@ jobs:
             - Mode: `${{ needs.resolve_build_context.outputs.build_mode }}`
             - Windows package formats: `nsis installer` and `portable zip`.
             - Windows portable zip uses manual replacement updates and requires WebView2 to already exist on the host.
-          generate_release_notes: true
+          generate_release_notes: ${{ needs.resolve_build_context.outputs.build_mode != 'nightly' }}
           prerelease: ${{ needs.resolve_build_context.outputs.release_prerelease == 'true' }}
           make_latest: ${{ needs.resolve_build_context.outputs.release_make_latest == 'true' }}
           overwrite_files: true

--- a/scripts/ci/build-desktop-tauri-workflow.test.mjs
+++ b/scripts/ci/build-desktop-tauri-workflow.test.mjs
@@ -9,6 +9,7 @@ import {
 
 const WORKFLOW_FILE = 'build-desktop-tauri.yml';
 const BUILD_MACOS_JOB = 'build-macos';
+const RELEASE_JOB = 'release';
 const PREPARE_RESOURCES_RUN = /pnpm run prepare:resources/;
 const PRESIGN_BACKEND_RUN = /codesign-macos-nested\.sh\s+"resources\/backend"/;
 const BUILD_APP_BUNDLE_RUN = /cargo tauri build --verbose --target/;
@@ -66,5 +67,20 @@ test('macOS workflow prepares resources before optional pre-signing', async () =
   assert.match(
     buildStep.run,
     /Resources are already prepared/,
+  );
+});
+
+test('release workflow disables generated release notes for nightly builds', async () => {
+  const workflowObject = await readWorkflowObject(WORKFLOW_FILE);
+  const steps = extractWorkflowJobSteps(workflowObject, RELEASE_JOB);
+  const releaseStep = findStep(
+    steps,
+    'Create or update release',
+    (step) => step.name === 'Create or update release' && /^softprops\/action-gh-release@/.test(step.uses ?? ''),
+  );
+
+  assert.equal(
+    releaseStep.with?.generate_release_notes,
+    "${{ needs.resolve_build_context.outputs.build_mode != 'nightly' }}",
   );
 });


### PR DESCRIPTION
## Summary

This PR stops nightly GitHub releases from using GitHub's generated release notes.

The nightly release uses a stable `nightly` tag that is updated repeatedly. With `generate_release_notes: true`, GitHub compares the moving nightly tag against repository history and can show a very large "What's Changed" section containing unrelated or accumulated PRs. That makes the nightly release page noisy and misleading for users who only need the current package metadata and assets.

The workflow now enables generated release notes only for non-nightly builds, so stable/tag-poll releases keep their generated changelog while nightly releases keep the explicit workflow body. A workflow-level regression test was added so the nightly exception does not get removed accidentally.

## Test Plan

- `pnpm run test:prepare-resources`
- `git diff --check`

## Summary by Sourcery

Adjust nightly desktop release workflow to avoid using GitHub-generated release notes while keeping them for non-nightly builds.

CI:
- Conditionally disable GitHub-generated release notes in the desktop Tauri release job when the build mode is nightly.
- Add a workflow test ensuring the nightly release job keeps generated release notes disabled.