### PR TITLE
fix: stop backend before tray quit exits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ runtime/
 # generated resources
 resources/backend/
 resources/webui/
+docs/plans/
 
 # rust/tauri build outputs
 src-tauri/target/

--- a/src-tauri/src/lifecycle/cleanup.rs
+++ b/src-tauri/src/lifecycle/cleanup.rs
@@ -37,6 +37,20 @@ where
     false
 }
 
+pub fn stop_backend_for_exit<F>(state: &BackendState, trigger: ExitTrigger, log: F)
+where
+    F: Fn(&str),
+{
+    let failure_prefix = stop_failure_prefix(trigger);
+    if let Err(error) = state.stop_backend() {
+        log(&format!("{failure_prefix}: {error}"));
+    }
+
+    if matches!(trigger, ExitTrigger::ExitRequested | ExitTrigger::TrayQuit) {
+        log("backend stop finished, exiting desktop process");
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{duplicate_cleanup_message, ExitTrigger};
@@ -55,19 +69,5 @@ mod tests {
             super::stop_failure_prefix(ExitTrigger::TrayQuit),
             "backend graceful stop on tray quit failed"
         );
-    }
-}
-
-pub fn stop_backend_for_exit<F>(state: &BackendState, trigger: ExitTrigger, log: F)
-where
-    F: Fn(&str),
-{
-    let failure_prefix = stop_failure_prefix(trigger);
-    if let Err(error) = state.stop_backend() {
-        log(&format!("{failure_prefix}: {error}"));
-    }
-
-    if matches!(trigger, ExitTrigger::ExitRequested | ExitTrigger::TrayQuit) {
-        log("backend stop finished, exiting desktop process");
     }
 }

--- a/src-tauri/src/lifecycle/cleanup.rs
+++ b/src-tauri/src/lifecycle/cleanup.rs
@@ -62,9 +62,9 @@ pub fn stop_backend_for_exit<F>(state: &BackendState, trigger: ExitTrigger, log:
 where
     F: Fn(&str),
 {
-    let stop_failure_prefix = stop_failure_prefix(trigger);
+    let failure_prefix = stop_failure_prefix(trigger);
     if let Err(error) = state.stop_backend() {
-        log(&format!("{stop_failure_prefix}: {error}"));
+        log(&format!("{failure_prefix}: {error}"));
     }
 
     if matches!(trigger, ExitTrigger::ExitRequested | ExitTrigger::TrayQuit) {

--- a/src-tauri/src/lifecycle/cleanup.rs
+++ b/src-tauri/src/lifecycle/cleanup.rs
@@ -4,6 +4,25 @@ use crate::BackendState;
 pub enum ExitTrigger {
     ExitRequested,
     ExitFallback,
+    TrayQuit,
+}
+
+fn duplicate_cleanup_message(trigger: ExitTrigger) -> &'static str {
+    match trigger {
+        ExitTrigger::ExitRequested => "exit requested while backend cleanup is already running",
+        ExitTrigger::ExitFallback => {
+            "exit fallback cleanup skipped: backend cleanup already running"
+        }
+        ExitTrigger::TrayQuit => "tray quit while backend cleanup is already running",
+    }
+}
+
+fn stop_failure_prefix(trigger: ExitTrigger) -> &'static str {
+    match trigger {
+        ExitTrigger::ExitRequested => "backend graceful stop on ExitRequested failed",
+        ExitTrigger::ExitFallback => "backend fallback stop on Exit failed",
+        ExitTrigger::TrayQuit => "backend graceful stop on tray quit failed",
+    }
 }
 
 pub fn try_begin_exit_cleanup<F>(state: &BackendState, trigger: ExitTrigger, log: F) -> bool
@@ -14,29 +33,41 @@ where
         return true;
     }
 
-    let message = match trigger {
-        ExitTrigger::ExitRequested => "exit requested while backend cleanup is already running",
-        ExitTrigger::ExitFallback => {
-            "exit fallback cleanup skipped: backend cleanup already running"
-        }
-    };
-    log(message);
+    log(duplicate_cleanup_message(trigger));
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{duplicate_cleanup_message, ExitTrigger};
+
+    #[test]
+    fn duplicate_cleanup_message_describes_tray_quit_trigger() {
+        assert_eq!(
+            duplicate_cleanup_message(ExitTrigger::TrayQuit),
+            "tray quit while backend cleanup is already running"
+        );
+    }
+
+    #[test]
+    fn stop_failure_prefix_describes_tray_quit_trigger() {
+        assert_eq!(
+            super::stop_failure_prefix(ExitTrigger::TrayQuit),
+            "backend graceful stop on tray quit failed"
+        );
+    }
 }
 
 pub fn stop_backend_for_exit<F>(state: &BackendState, trigger: ExitTrigger, log: F)
 where
     F: Fn(&str),
 {
-    let stop_failure_prefix = match trigger {
-        ExitTrigger::ExitRequested => "backend graceful stop on ExitRequested failed",
-        ExitTrigger::ExitFallback => "backend fallback stop on Exit failed",
-    };
+    let stop_failure_prefix = stop_failure_prefix(trigger);
     if let Err(error) = state.stop_backend() {
         log(&format!("{stop_failure_prefix}: {error}"));
     }
 
-    if matches!(trigger, ExitTrigger::ExitRequested) {
+    if matches!(trigger, ExitTrigger::ExitRequested | ExitTrigger::TrayQuit) {
         log("backend stop finished, exiting desktop process");
     }
 }

--- a/src-tauri/src/lifecycle/events.rs
+++ b/src-tauri/src/lifecycle/events.rs
@@ -48,6 +48,24 @@ pub fn handle_exit_requested(app_handle: &AppHandle, api: &tauri::ExitRequestApi
     });
 }
 
+pub fn handle_tray_quit(app_handle: &AppHandle) {
+    let state = app_handle.state::<BackendState>();
+    state.mark_quitting();
+    if !cleanup::try_begin_exit_cleanup(&state, cleanup::ExitTrigger::TrayQuit, append_shutdown_log)
+    {
+        return;
+    }
+
+    append_shutdown_log("tray quit requested, stopping backend asynchronously");
+    let app_handle_cloned = app_handle.clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        let state = app_handle_cloned.state::<BackendState>();
+        cleanup::stop_backend_for_exit(&state, cleanup::ExitTrigger::TrayQuit, append_shutdown_log);
+        state.allow_next_exit_request();
+        app_handle_cloned.exit(0);
+    });
+}
+
 pub fn handle_exit_event(app_handle: &AppHandle) {
     let state = app_handle.state::<BackendState>();
     if !cleanup::try_begin_exit_cleanup(

--- a/src-tauri/src/lifecycle/events.rs
+++ b/src-tauri/src/lifecycle/events.rs
@@ -16,6 +16,16 @@ fn decide_exit_requested_flow(has_exit_request_allowance: bool) -> ExitRequested
     }
 }
 
+fn stop_backend_then_exit(app_handle: &AppHandle, trigger: cleanup::ExitTrigger) {
+    let app_handle_cloned = app_handle.clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        let state = app_handle_cloned.state::<BackendState>();
+        cleanup::stop_backend_for_exit(&state, trigger, append_shutdown_log);
+        state.allow_next_exit_request();
+        app_handle_cloned.exit(0);
+    });
+}
+
 pub fn handle_exit_requested(app_handle: &AppHandle, api: &tauri::ExitRequestApi) {
     let state = app_handle.state::<BackendState>();
     match decide_exit_requested_flow(state.take_exit_request_allowance()) {
@@ -35,17 +45,7 @@ pub fn handle_exit_requested(app_handle: &AppHandle, api: &tauri::ExitRequestApi
     }
 
     append_shutdown_log("exit requested, stopping backend asynchronously");
-    let app_handle_cloned = app_handle.clone();
-    tauri::async_runtime::spawn_blocking(move || {
-        let state = app_handle_cloned.state::<BackendState>();
-        cleanup::stop_backend_for_exit(
-            &state,
-            cleanup::ExitTrigger::ExitRequested,
-            append_shutdown_log,
-        );
-        state.allow_next_exit_request();
-        app_handle_cloned.exit(0);
-    });
+    stop_backend_then_exit(app_handle, cleanup::ExitTrigger::ExitRequested);
 }
 
 pub fn handle_tray_quit(app_handle: &AppHandle) {
@@ -57,13 +57,7 @@ pub fn handle_tray_quit(app_handle: &AppHandle) {
     }
 
     append_shutdown_log("tray quit requested, stopping backend asynchronously");
-    let app_handle_cloned = app_handle.clone();
-    tauri::async_runtime::spawn_blocking(move || {
-        let state = app_handle_cloned.state::<BackendState>();
-        cleanup::stop_backend_for_exit(&state, cleanup::ExitTrigger::TrayQuit, append_shutdown_log);
-        state.allow_next_exit_request();
-        app_handle_cloned.exit(0);
-    });
+    stop_backend_then_exit(app_handle, cleanup::ExitTrigger::TrayQuit);
 }
 
 pub fn handle_exit_event(app_handle: &AppHandle) {

--- a/src-tauri/src/tray/menu_handler.rs
+++ b/src-tauri/src/tray/menu_handler.rs
@@ -1,7 +1,7 @@
 use tauri::{AppHandle, Manager};
 
 use crate::{
-    append_desktop_log, append_restart_log, append_shutdown_log, restart_backend_flow,
+    append_desktop_log, append_restart_log, lifecycle, restart_backend_flow,
     tray::{actions, bridge_event},
     ui_dispatch, window, BackendState, DEFAULT_SHELL_LOCALE, TRAY_RESTART_BACKEND_EVENT,
 };
@@ -72,10 +72,7 @@ pub fn handle_tray_menu_event(app_handle: &AppHandle, menu_id: &str) {
             });
         }
         Some(actions::TrayMenuAction::Quit) => {
-            let state = app_handle.state::<BackendState>();
-            state.mark_quitting();
-            append_shutdown_log("tray quit requested, exiting desktop process");
-            app_handle.exit(0);
+            lifecycle::events::handle_tray_quit(app_handle);
         }
         None => {}
     }


### PR DESCRIPTION
## Summary
- Route tray menu Quit through the existing backend exit cleanup flow before exiting the Tauri shell.
- Add a tray-specific exit trigger so shutdown logs distinguish tray quit cleanup and duplicate cleanup attempts.
- Ignore local `docs/plans/` task planning files.

## Testing
- `cargo test`

Closes AstrBotDevs/AstrBot#8072

## Summary by Sourcery

Route tray quit through the existing backend cleanup flow so the backend is shut down gracefully before the app exits and improve exit logging.

Bug Fixes:
- Ensure quitting from the system tray triggers backend shutdown and cleanup before the desktop process exits.

Enhancements:
- Add a dedicated tray quit exit trigger and shared helpers to standardize exit-related log messages and backend stop behavior.

Tests:
- Add unit tests covering tray quit-specific exit trigger messages for duplicate cleanup and stop failures.

Chores:
- Ignore local task planning files under docs/plans/ in version control.