### PR TITLE
fix: allow local dashboard setup without default password

### DIFF
--- a/src-tauri/src/backend/launch.rs
+++ b/src-tauri/src/backend/launch.rs
@@ -1,5 +1,6 @@
 use std::{
     env,
+    ffi::OsStr,
     fs::{self, OpenOptions},
     process::{Command, Stdio},
 };
@@ -43,32 +44,53 @@ where
 }
 
 fn configure_desktop_dashboard_environment(command: &mut Command) {
-    let dashboard_host =
-        env::var_os(DASHBOARD_HOST_ENV).or_else(|| env::var_os(ASTRBOT_DASHBOARD_HOST_ENV));
+    let dashboard_host_env = env::var_os(DASHBOARD_HOST_ENV);
+    let astrbot_dashboard_host_env = env::var_os(ASTRBOT_DASHBOARD_HOST_ENV);
+    let dashboard_port_env = env::var_os(DASHBOARD_PORT_ENV);
+    let astrbot_dashboard_port_env = env::var_os(ASTRBOT_DASHBOARD_PORT_ENV);
+    let astrbot_skip_auth_env = env::var_os(ASTRBOT_DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV);
+    let legacy_skip_auth_env = env::var_os(DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV);
 
-    if dashboard_host.is_none() {
+    let effective_host = dashboard_host_env
+        .as_ref()
+        .or(astrbot_dashboard_host_env.as_ref())
+        .map(OsStr::new);
+    let has_explicit_skip_auth = astrbot_skip_auth_env.is_some() || legacy_skip_auth_env.is_some();
+
+    if dashboard_host_env.is_none() && astrbot_dashboard_host_env.is_none() {
         command.env(DASHBOARD_HOST_ENV, DEFAULT_DASHBOARD_HOST);
     }
-    if env::var_os(DASHBOARD_PORT_ENV).is_none()
-        && env::var_os(ASTRBOT_DASHBOARD_PORT_ENV).is_none()
-    {
+    if dashboard_port_env.is_none() && astrbot_dashboard_port_env.is_none() {
         command.env(DASHBOARD_PORT_ENV, DEFAULT_DASHBOARD_PORT);
     }
-    if env::var_os(ASTRBOT_DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV).is_none()
-        && env::var_os(DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV).is_none()
-        && dashboard_host
-            .as_ref()
-            .is_none_or(|host| host.to_str().is_some_and(is_local_dashboard_host))
-    {
+    if should_skip_default_password_auth(has_explicit_skip_auth, effective_host) {
         command.env(ASTRBOT_DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV, "true");
     }
 }
 
+fn should_skip_default_password_auth(
+    has_explicit_skip_auth: bool,
+    effective_host: Option<&OsStr>,
+) -> bool {
+    if has_explicit_skip_auth {
+        return false;
+    }
+
+    let Some(effective_host) = effective_host else {
+        return true;
+    };
+    let Some(host) = effective_host.to_str() else {
+        return false;
+    };
+
+    is_local_dashboard_host(host)
+}
+
 fn is_local_dashboard_host(host: &str) -> bool {
-    matches!(
-        host.trim().to_ascii_lowercase().as_str(),
-        "127.0.0.1" | "localhost" | "::1"
-    )
+    let trimmed = host.trim();
+    trimmed.eq_ignore_ascii_case("127.0.0.1")
+        || trimmed.eq_ignore_ascii_case("localhost")
+        || trimmed.eq_ignore_ascii_case("::1")
 }
 
 impl BackendState {
@@ -237,7 +259,14 @@ impl BackendState {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, env, ffi::OsStr, process::Command, sync::Mutex};
+    use std::{
+        collections::HashMap,
+        env,
+        ffi::OsStr,
+        panic::{catch_unwind, resume_unwind, AssertUnwindSafe},
+        process::Command,
+        sync::Mutex,
+    };
 
     #[cfg(unix)]
     use std::os::unix::ffi::OsStringExt;
@@ -267,45 +296,43 @@ mod tests {
             .map(|(_, value)| value.map(|v| v.to_string_lossy().into_owned()))
     }
 
-    struct DashboardEnvSnapshot {
-        previous: HashMap<&'static str, Option<std::ffi::OsString>>,
+    fn save_dashboard_env() -> HashMap<&'static str, Option<std::ffi::OsString>> {
+        DASHBOARD_ENV_KEYS
+            .iter()
+            .map(|&key| (key, env::var_os(key)))
+            .collect()
     }
 
-    impl DashboardEnvSnapshot {
-        fn capture() -> Self {
-            Self {
-                previous: DASHBOARD_ENV_KEYS
-                    .iter()
-                    .map(|&key| (key, env::var_os(key)))
-                    .collect(),
+    fn restore_dashboard_env(saved: HashMap<&'static str, Option<std::ffi::OsString>>) {
+        for (key, value) in saved {
+            match value {
+                Some(value) => env::set_var(key, value),
+                None => env::remove_var(key),
             }
         }
     }
 
-    impl Drop for DashboardEnvSnapshot {
-        fn drop(&mut self) {
-            for (key, previous) in &self.previous {
-                match previous {
-                    Some(value) => env::set_var(key, value),
-                    None => env::remove_var(key),
-                }
-            }
-        }
-    }
-
-    fn with_dashboard_env<FSetup, FTest>(setup: FSetup, test: FTest)
-    where
-        FSetup: FnOnce(),
-        FTest: FnOnce(),
-    {
-        let _lock = ENV_TEST_LOCK.lock().unwrap();
-        let _snapshot = DashboardEnvSnapshot::capture();
-
+    fn clear_dashboard_env() {
         for key in DASHBOARD_ENV_KEYS {
             env::remove_var(key);
         }
-        setup();
-        test();
+    }
+
+    fn with_clean_dashboard_env<F>(test: F)
+    where
+        F: FnOnce(),
+    {
+        let _lock = ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let saved = save_dashboard_env();
+
+        clear_dashboard_env();
+        let result = catch_unwind(AssertUnwindSafe(test));
+        restore_dashboard_env(saved);
+        if let Err(payload) = result {
+            resume_unwind(payload);
+        }
     }
 
     #[test]
@@ -334,93 +361,70 @@ mod tests {
 
     #[test]
     fn configure_desktop_dashboard_environment_enables_local_setup_without_default_password() {
-        with_dashboard_env(
-            || {},
-            || {
-                let mut command = Command::new("sh");
+        with_clean_dashboard_env(|| {
+            let mut command = Command::new("sh");
 
-                configure_desktop_dashboard_environment(&mut command);
+            configure_desktop_dashboard_environment(&mut command);
 
-                assert_eq!(
-                    get_command_env_value(
-                        &command,
-                        ASTRBOT_DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV
-                    ),
-                    Some(Some("true".to_string()))
-                );
-                assert_eq!(
-                    get_command_env_value(&command, DASHBOARD_HOST_ENV),
-                    Some(Some(DEFAULT_DASHBOARD_HOST.to_string()))
-                );
-            },
-        );
+            assert_eq!(
+                get_command_env_value(&command, ASTRBOT_DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV),
+                Some(Some("true".to_string()))
+            );
+            assert_eq!(
+                get_command_env_value(&command, DASHBOARD_HOST_ENV),
+                Some(Some(DEFAULT_DASHBOARD_HOST.to_string()))
+            );
+        });
     }
 
     #[test]
     fn configure_desktop_dashboard_environment_preserves_explicit_dashboard_env() {
-        with_dashboard_env(
-            || {
-                env::set_var(ASTRBOT_DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV, "false");
-                env::set_var(DASHBOARD_HOST_ENV, "localhost");
-                env::set_var(DASHBOARD_PORT_ENV, "7000");
-            },
-            || {
-                let mut command = Command::new("sh");
+        with_clean_dashboard_env(|| {
+            env::set_var(ASTRBOT_DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV, "false");
+            env::set_var(DASHBOARD_HOST_ENV, "localhost");
+            env::set_var(DASHBOARD_PORT_ENV, "7000");
+            let mut command = Command::new("sh");
 
-                configure_desktop_dashboard_environment(&mut command);
+            configure_desktop_dashboard_environment(&mut command);
 
-                assert_eq!(
-                    get_command_env_value(
-                        &command,
-                        ASTRBOT_DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV
-                    ),
-                    None
-                );
-                assert_eq!(get_command_env_value(&command, DASHBOARD_HOST_ENV), None);
-                assert_eq!(get_command_env_value(&command, DASHBOARD_PORT_ENV), None);
-            },
-        );
+            assert_eq!(
+                get_command_env_value(&command, ASTRBOT_DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV),
+                None
+            );
+            assert_eq!(get_command_env_value(&command, DASHBOARD_HOST_ENV), None);
+            assert_eq!(get_command_env_value(&command, DASHBOARD_PORT_ENV), None);
+        });
     }
 
     #[test]
     fn configure_desktop_dashboard_environment_does_not_skip_auth_for_remote_host() {
-        with_dashboard_env(
-            || env::set_var(DASHBOARD_HOST_ENV, "0.0.0.0"),
-            || {
-                let mut command = Command::new("sh");
+        with_clean_dashboard_env(|| {
+            env::set_var(DASHBOARD_HOST_ENV, "0.0.0.0");
+            let mut command = Command::new("sh");
 
-                configure_desktop_dashboard_environment(&mut command);
+            configure_desktop_dashboard_environment(&mut command);
 
-                assert_eq!(
-                    get_command_env_value(
-                        &command,
-                        ASTRBOT_DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV
-                    ),
-                    None
-                );
-            },
-        );
+            assert_eq!(
+                get_command_env_value(&command, ASTRBOT_DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV),
+                None
+            );
+        });
     }
 
     #[cfg(unix)]
     #[test]
     fn configure_desktop_dashboard_environment_does_not_skip_auth_for_non_utf8_host() {
-        with_dashboard_env(
-            || env::set_var(DASHBOARD_HOST_ENV, std::ffi::OsString::from_vec(vec![0xff])),
-            || {
-                let mut command = Command::new("sh");
+        with_clean_dashboard_env(|| {
+            env::set_var(DASHBOARD_HOST_ENV, std::ffi::OsString::from_vec(vec![0xff]));
+            let mut command = Command::new("sh");
 
-                configure_desktop_dashboard_environment(&mut command);
+            configure_desktop_dashboard_environment(&mut command);
 
-                assert_eq!(
-                    get_command_env_value(
-                        &command,
-                        ASTRBOT_DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV
-                    ),
-                    None
-                );
-                assert_eq!(get_command_env_value(&command, DASHBOARD_HOST_ENV), None);
-            },
-        );
+            assert_eq!(
+                get_command_env_value(&command, ASTRBOT_DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV),
+                None
+            );
+            assert_eq!(get_command_env_value(&command, DASHBOARD_HOST_ENV), None);
+        });
     }
 }

--- a/src-tauri/src/backend/launch.rs
+++ b/src-tauri/src/backend/launch.rs
@@ -52,9 +52,8 @@ fn configure_desktop_dashboard_environment(command: &mut Command) {
     let legacy_skip_auth_env = env::var_os(DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV);
 
     let effective_host = dashboard_host_env
-        .as_ref()
-        .or(astrbot_dashboard_host_env.as_ref())
-        .map(OsStr::new);
+        .as_deref()
+        .or(astrbot_dashboard_host_env.as_deref());
     let has_explicit_skip_auth = astrbot_skip_auth_env.is_some() || legacy_skip_auth_env.is_some();
 
     if dashboard_host_env.is_none() && astrbot_dashboard_host_env.is_none() {
@@ -260,10 +259,8 @@ impl BackendState {
 #[cfg(test)]
 mod tests {
     use std::{
-        collections::HashMap,
         env,
-        ffi::OsStr,
-        panic::{catch_unwind, resume_unwind, AssertUnwindSafe},
+        ffi::{OsStr, OsString},
         process::Command,
         sync::Mutex,
     };
@@ -280,7 +277,7 @@ mod tests {
 
     static ENV_TEST_LOCK: Mutex<()> = Mutex::new(());
 
-    const DASHBOARD_ENV_KEYS: &[&str] = &[
+    const DASHBOARD_ENV_KEYS: [&str; 6] = [
         ASTRBOT_DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV,
         DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV,
         DASHBOARD_HOST_ENV,
@@ -296,25 +293,32 @@ mod tests {
             .map(|(_, value)| value.map(|v| v.to_string_lossy().into_owned()))
     }
 
-    fn save_dashboard_env() -> HashMap<&'static str, Option<std::ffi::OsString>> {
-        DASHBOARD_ENV_KEYS
-            .iter()
-            .map(|&key| (key, env::var_os(key)))
-            .collect()
+    struct DashboardEnvGuard {
+        saved: [Option<OsString>; 6],
     }
 
-    fn restore_dashboard_env(saved: HashMap<&'static str, Option<std::ffi::OsString>>) {
-        for (key, value) in saved {
-            match value {
-                Some(value) => env::set_var(key, value),
-                None => env::remove_var(key),
+    impl DashboardEnvGuard {
+        fn new() -> Self {
+            Self {
+                saved: DASHBOARD_ENV_KEYS.map(env::var_os),
+            }
+        }
+
+        fn clear() {
+            for key in DASHBOARD_ENV_KEYS {
+                env::remove_var(key);
             }
         }
     }
 
-    fn clear_dashboard_env() {
-        for key in DASHBOARD_ENV_KEYS {
-            env::remove_var(key);
+    impl Drop for DashboardEnvGuard {
+        fn drop(&mut self) {
+            for (key, value) in DASHBOARD_ENV_KEYS.iter().zip(self.saved.iter()) {
+                match value {
+                    Some(value) => env::set_var(key, value),
+                    None => env::remove_var(key),
+                }
+            }
         }
     }
 
@@ -325,14 +329,10 @@ mod tests {
         let _lock = ENV_TEST_LOCK
             .lock()
             .unwrap_or_else(|error| error.into_inner());
-        let saved = save_dashboard_env();
+        let _guard = DashboardEnvGuard::new();
 
-        clear_dashboard_env();
-        let result = catch_unwind(AssertUnwindSafe(test));
-        restore_dashboard_env(saved);
-        if let Err(payload) = result {
-            resume_unwind(payload);
-        }
+        DashboardEnvGuard::clear();
+        test();
     }
 
     #[test]

--- a/src-tauri/src/backend/launch.rs
+++ b/src-tauri/src/backend/launch.rs
@@ -16,6 +16,16 @@ use crate::{
 #[cfg(target_os = "windows")]
 use crate::{CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW};
 
+const DASHBOARD_HOST_ENV: &str = "DASHBOARD_HOST";
+const ASTRBOT_DASHBOARD_HOST_ENV: &str = "ASTRBOT_DASHBOARD_HOST";
+const DASHBOARD_PORT_ENV: &str = "DASHBOARD_PORT";
+const ASTRBOT_DASHBOARD_PORT_ENV: &str = "ASTRBOT_DASHBOARD_PORT";
+const ASTRBOT_DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV: &str =
+    "ASTRBOT_DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH";
+const DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV: &str = "DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH";
+const DEFAULT_DASHBOARD_HOST: &str = "127.0.0.1";
+const DEFAULT_DASHBOARD_PORT: &str = "6185";
+
 fn sanitize_packaged_python_environment<F>(command: &mut Command, log: F)
 where
     F: Fn(&str),
@@ -30,6 +40,35 @@ where
         command.env_remove(key);
     }
     command.env("PYTHONNOUSERSITE", "1");
+}
+
+fn configure_desktop_dashboard_environment(command: &mut Command) {
+    let dashboard_host =
+        env::var_os(DASHBOARD_HOST_ENV).or_else(|| env::var_os(ASTRBOT_DASHBOARD_HOST_ENV));
+
+    if dashboard_host.is_none() {
+        command.env(DASHBOARD_HOST_ENV, DEFAULT_DASHBOARD_HOST);
+    }
+    if env::var_os(DASHBOARD_PORT_ENV).is_none()
+        && env::var_os(ASTRBOT_DASHBOARD_PORT_ENV).is_none()
+    {
+        command.env(DASHBOARD_PORT_ENV, DEFAULT_DASHBOARD_PORT);
+    }
+    if env::var_os(ASTRBOT_DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV).is_none()
+        && env::var_os(DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV).is_none()
+        && dashboard_host
+            .as_ref()
+            .is_none_or(|host| host.to_str().is_some_and(is_local_dashboard_host))
+    {
+        command.env(ASTRBOT_DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV, "true");
+    }
+}
+
+fn is_local_dashboard_host(host: &str) -> bool {
+    matches!(
+        host.trim().to_ascii_lowercase().as_str(),
+        "127.0.0.1" | "localhost" | "::1"
+    )
 }
 
 impl BackendState {
@@ -104,6 +143,7 @@ impl BackendState {
         if let Some(path_override) = backend_path_override() {
             command.env("PATH", path_override);
         }
+        configure_desktop_dashboard_environment(&mut command);
         #[cfg(target_os = "windows")]
         {
             if plan.packaged_mode {
@@ -114,12 +154,6 @@ impl BackendState {
         if plan.packaged_mode {
             sanitize_packaged_python_environment(&mut command, append_desktop_log);
             command.env("ASTRBOT_DESKTOP_CLIENT", "1");
-            if env::var("DASHBOARD_HOST").is_err() && env::var("ASTRBOT_DASHBOARD_HOST").is_err() {
-                command.env("DASHBOARD_HOST", "127.0.0.1");
-            }
-            if env::var("DASHBOARD_PORT").is_err() && env::var("ASTRBOT_DASHBOARD_PORT").is_err() {
-                command.env("DASHBOARD_PORT", "6185");
-            }
         }
 
         if let Some(root_dir) = &plan.root_dir {
@@ -203,15 +237,75 @@ impl BackendState {
 
 #[cfg(test)]
 mod tests {
-    use std::{ffi::OsStr, process::Command};
+    use std::{collections::HashMap, env, ffi::OsStr, process::Command, sync::Mutex};
 
-    use super::sanitize_packaged_python_environment;
+    #[cfg(unix)]
+    use std::os::unix::ffi::OsStringExt;
+
+    use super::{
+        configure_desktop_dashboard_environment, sanitize_packaged_python_environment,
+        ASTRBOT_DASHBOARD_HOST_ENV, ASTRBOT_DASHBOARD_PORT_ENV,
+        ASTRBOT_DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV, DASHBOARD_HOST_ENV, DASHBOARD_PORT_ENV,
+        DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV, DEFAULT_DASHBOARD_HOST,
+    };
+
+    static ENV_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    const DASHBOARD_ENV_KEYS: &[&str] = &[
+        ASTRBOT_DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV,
+        DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV,
+        DASHBOARD_HOST_ENV,
+        ASTRBOT_DASHBOARD_HOST_ENV,
+        DASHBOARD_PORT_ENV,
+        ASTRBOT_DASHBOARD_PORT_ENV,
+    ];
 
     fn get_command_env_value(command: &Command, key: &str) -> Option<Option<String>> {
         command
             .get_envs()
             .find(|(existing_key, _)| *existing_key == OsStr::new(key))
             .map(|(_, value)| value.map(|v| v.to_string_lossy().into_owned()))
+    }
+
+    struct DashboardEnvSnapshot {
+        previous: HashMap<&'static str, Option<std::ffi::OsString>>,
+    }
+
+    impl DashboardEnvSnapshot {
+        fn capture() -> Self {
+            Self {
+                previous: DASHBOARD_ENV_KEYS
+                    .iter()
+                    .map(|&key| (key, env::var_os(key)))
+                    .collect(),
+            }
+        }
+    }
+
+    impl Drop for DashboardEnvSnapshot {
+        fn drop(&mut self) {
+            for (key, previous) in &self.previous {
+                match previous {
+                    Some(value) => env::set_var(key, value),
+                    None => env::remove_var(key),
+                }
+            }
+        }
+    }
+
+    fn with_dashboard_env<FSetup, FTest>(setup: FSetup, test: FTest)
+    where
+        FSetup: FnOnce(),
+        FTest: FnOnce(),
+    {
+        let _lock = ENV_TEST_LOCK.lock().unwrap();
+        let _snapshot = DashboardEnvSnapshot::capture();
+
+        for key in DASHBOARD_ENV_KEYS {
+            env::remove_var(key);
+        }
+        setup();
+        test();
     }
 
     #[test]
@@ -235,6 +329,98 @@ mod tests {
         assert_eq!(
             get_command_env_value(&command, "PYTHONNOUSERSITE"),
             Some(Some("1".to_string()))
+        );
+    }
+
+    #[test]
+    fn configure_desktop_dashboard_environment_enables_local_setup_without_default_password() {
+        with_dashboard_env(
+            || {},
+            || {
+                let mut command = Command::new("sh");
+
+                configure_desktop_dashboard_environment(&mut command);
+
+                assert_eq!(
+                    get_command_env_value(
+                        &command,
+                        ASTRBOT_DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV
+                    ),
+                    Some(Some("true".to_string()))
+                );
+                assert_eq!(
+                    get_command_env_value(&command, DASHBOARD_HOST_ENV),
+                    Some(Some(DEFAULT_DASHBOARD_HOST.to_string()))
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn configure_desktop_dashboard_environment_preserves_explicit_dashboard_env() {
+        with_dashboard_env(
+            || {
+                env::set_var(ASTRBOT_DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV, "false");
+                env::set_var(DASHBOARD_HOST_ENV, "localhost");
+                env::set_var(DASHBOARD_PORT_ENV, "7000");
+            },
+            || {
+                let mut command = Command::new("sh");
+
+                configure_desktop_dashboard_environment(&mut command);
+
+                assert_eq!(
+                    get_command_env_value(
+                        &command,
+                        ASTRBOT_DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV
+                    ),
+                    None
+                );
+                assert_eq!(get_command_env_value(&command, DASHBOARD_HOST_ENV), None);
+                assert_eq!(get_command_env_value(&command, DASHBOARD_PORT_ENV), None);
+            },
+        );
+    }
+
+    #[test]
+    fn configure_desktop_dashboard_environment_does_not_skip_auth_for_remote_host() {
+        with_dashboard_env(
+            || env::set_var(DASHBOARD_HOST_ENV, "0.0.0.0"),
+            || {
+                let mut command = Command::new("sh");
+
+                configure_desktop_dashboard_environment(&mut command);
+
+                assert_eq!(
+                    get_command_env_value(
+                        &command,
+                        ASTRBOT_DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV
+                    ),
+                    None
+                );
+            },
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn configure_desktop_dashboard_environment_does_not_skip_auth_for_non_utf8_host() {
+        with_dashboard_env(
+            || env::set_var(DASHBOARD_HOST_ENV, std::ffi::OsString::from_vec(vec![0xff])),
+            || {
+                let mut command = Command::new("sh");
+
+                configure_desktop_dashboard_environment(&mut command);
+
+                assert_eq!(
+                    get_command_env_value(
+                        &command,
+                        ASTRBOT_DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV
+                    ),
+                    None
+                );
+                assert_eq!(get_command_env_value(&command, DASHBOARD_HOST_ENV), None);
+            },
         );
     }
 }


### PR DESCRIPTION
## Summary
- Set desktop-launched dashboard defaults for local setup with AstrBot's new randomized default password flow.
- Preserve explicit dashboard env overrides and avoid injecting skip-auth when binding to remote hosts.
- Add Rust tests for default local setup, explicit env preservation, and remote-host auth safety.

## Verification
- `make update`
- `make prepare`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --locked --all-targets -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked`
- `pnpm run test:prepare-resources`

## Summary by Sourcery

Adjust desktop dashboard launch environment to support AstrBot's new default password flow while keeping remote deployments safe.

Bug Fixes:
- Ensure locally launched dashboards default to localhost/port 6185 and automatically skip default-password auth only for local hosts when no explicit auth env vars are set.
- Preserve any explicitly configured dashboard host, port, or auth-related environment variables instead of overriding them from the desktop launcher.
- Avoid enabling skip-auth when the dashboard is bound to non-local or non-UTF-8 hosts to prevent unintentionally weakening remote security.

Enhancements:
- Centralize desktop dashboard environment configuration into a dedicated helper used during backend process launch.

Tests:
- Add Rust tests covering local default dashboard setup, preservation of explicit env overrides, and remote-host/non-UTF-8 host auth behavior, including utilities to isolate env-dependent tests.