### PR TITLE
fix: avoid Windows OpenSSL default context crash

### DIFF
--- a/scripts/backend/templates/launch_backend.py
+++ b/scripts/backend/templates/launch_backend.py
@@ -135,7 +135,14 @@ def configure_windows_safe_default_ssl_context() -> None:
     if already_patched is True:
         return
 
-    import certifi
+    try:
+        import certifi
+    except ImportError:
+        print(
+            "[ssl-context] certifi not available; skipping safe default context patch",
+            file=sys.stderr,
+        )
+        return
 
     original_create_default_context = ssl.create_default_context
 

--- a/scripts/backend/templates/launch_backend.py
+++ b/scripts/backend/templates/launch_backend.py
@@ -5,6 +5,7 @@ import ctypes
 import json
 import os
 import runpy
+import ssl
 import sys
 import threading
 import time
@@ -122,6 +123,52 @@ def preload_windows_runtime_dlls() -> None:
                     continue
 
 
+def configure_windows_safe_default_ssl_context() -> None:
+    if sys.platform != "win32":
+        return
+    already_patched = getattr(
+        ssl.create_default_context,
+        "_astrbot_desktop_safe_context",
+        False,
+    )
+    if already_patched is True:
+        return
+
+    import certifi
+
+    def create_default_context(
+        purpose: ssl.Purpose = ssl.Purpose.SERVER_AUTH,
+        *,
+        cafile: str | None = None,
+        capath: str | None = None,
+        cadata: str | bytes | None = None,
+    ) -> ssl.SSLContext:
+        protocol = (
+            ssl.PROTOCOL_TLS_SERVER
+            if purpose == ssl.Purpose.CLIENT_AUTH
+            else ssl.PROTOCOL_TLS_CLIENT
+        )
+        ssl_context = ssl.SSLContext(protocol)
+
+        if purpose == ssl.Purpose.SERVER_AUTH:
+            ssl_context.verify_mode = ssl.CERT_REQUIRED
+            ssl_context.check_hostname = True
+
+        if cafile is None and capath is None and cadata is None:
+            cafile = certifi.where()
+        if cafile is not None or capath is not None or cadata is not None:
+            ssl_context.load_verify_locations(
+                cafile=cafile,
+                capath=capath,
+                cadata=cadata,
+            )
+
+        return ssl_context
+
+    create_default_context._astrbot_desktop_safe_context = True
+    ssl.create_default_context = create_default_context
+
+
 def resolve_startup_heartbeat_path() -> Path | None:
     raw = os.environ.get(STARTUP_HEARTBEAT_ENV, "").strip()
     if not raw:
@@ -231,6 +278,7 @@ def main() -> None:
     configure_stdio_utf8()
     configure_windows_dll_search_path()
     preload_windows_runtime_dlls()
+    configure_windows_safe_default_ssl_context()
     start_startup_heartbeat()
     configure_runtime_core_lock_path()
 

--- a/scripts/backend/templates/launch_backend.py
+++ b/scripts/backend/templates/launch_backend.py
@@ -124,15 +124,16 @@ def preload_windows_runtime_dlls() -> None:
                     continue
 
 
+_ORIGINAL_CREATE_DEFAULT_CONTEXT = None
+
+# We globally monkey-patch ssl.create_default_context on Windows.
+# This prevents OpenSSL Applink crashes caused by default CA loading
+# by enforcing the use of certifi's CA bundle for SERVER_AUTH.
 def configure_windows_safe_default_ssl_context() -> None:
+    global _ORIGINAL_CREATE_DEFAULT_CONTEXT
     if sys.platform != "win32":
         return
-    already_patched = getattr(
-        ssl.create_default_context,
-        "_astrbot_desktop_safe_context",
-        False,
-    )
-    if already_patched is True:
+    if _ORIGINAL_CREATE_DEFAULT_CONTEXT is not None:
         return
 
     try:
@@ -144,10 +145,10 @@ def configure_windows_safe_default_ssl_context() -> None:
         )
         return
 
-    original_create_default_context = ssl.create_default_context
+    _ORIGINAL_CREATE_DEFAULT_CONTEXT = ssl.create_default_context
 
     # The launcher owns this process, so patching ssl globally is intentional.
-    @functools.wraps(original_create_default_context)
+    @functools.wraps(_ORIGINAL_CREATE_DEFAULT_CONTEXT)
     def create_default_context(
         purpose: ssl.Purpose = ssl.Purpose.SERVER_AUTH,
         *,
@@ -162,14 +163,13 @@ def configure_windows_safe_default_ssl_context() -> None:
             and cadata is None
         ):
             cafile = certifi.where()
-        return original_create_default_context(
+        return _ORIGINAL_CREATE_DEFAULT_CONTEXT(
             purpose,
             cafile=cafile,
             capath=capath,
             cadata=cadata,
         )
 
-    create_default_context._astrbot_desktop_safe_context = True
     ssl.create_default_context = create_default_context
 
 

--- a/scripts/backend/templates/launch_backend.py
+++ b/scripts/backend/templates/launch_backend.py
@@ -136,6 +136,8 @@ def configure_windows_safe_default_ssl_context() -> None:
 
     import certifi
 
+    original_create_default_context = ssl.create_default_context
+
     def create_default_context(
         purpose: ssl.Purpose = ssl.Purpose.SERVER_AUTH,
         *,
@@ -143,27 +145,14 @@ def configure_windows_safe_default_ssl_context() -> None:
         capath: str | None = None,
         cadata: str | bytes | None = None,
     ) -> ssl.SSLContext:
-        protocol = (
-            ssl.PROTOCOL_TLS_SERVER
-            if purpose == ssl.Purpose.CLIENT_AUTH
-            else ssl.PROTOCOL_TLS_CLIENT
-        )
-        ssl_context = ssl.SSLContext(protocol)
-
-        if purpose == ssl.Purpose.SERVER_AUTH:
-            ssl_context.verify_mode = ssl.CERT_REQUIRED
-            ssl_context.check_hostname = True
-
         if cafile is None and capath is None and cadata is None:
             cafile = certifi.where()
-        if cafile is not None or capath is not None or cadata is not None:
-            ssl_context.load_verify_locations(
-                cafile=cafile,
-                capath=capath,
-                cadata=cadata,
-            )
-
-        return ssl_context
+        return original_create_default_context(
+            purpose,
+            cafile=cafile,
+            capath=capath,
+            cadata=cadata,
+        )
 
     create_default_context._astrbot_desktop_safe_context = True
     ssl.create_default_context = create_default_context

--- a/scripts/backend/templates/launch_backend.py
+++ b/scripts/backend/templates/launch_backend.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import atexit
 import ctypes
+import functools
 import json
 import os
 import runpy
@@ -138,6 +139,8 @@ def configure_windows_safe_default_ssl_context() -> None:
 
     original_create_default_context = ssl.create_default_context
 
+    # The launcher owns this process, so patching ssl globally is intentional.
+    @functools.wraps(original_create_default_context)
     def create_default_context(
         purpose: ssl.Purpose = ssl.Purpose.SERVER_AUTH,
         *,
@@ -145,7 +148,12 @@ def configure_windows_safe_default_ssl_context() -> None:
         capath: str | None = None,
         cadata: str | bytes | None = None,
     ) -> ssl.SSLContext:
-        if cafile is None and capath is None and cadata is None:
+        if (
+            purpose == ssl.Purpose.SERVER_AUTH
+            and cafile is None
+            and capath is None
+            and cadata is None
+        ):
             cafile = certifi.where()
         return original_create_default_context(
             purpose,

--- a/scripts/backend/templates/test_launch_backend.py
+++ b/scripts/backend/templates/test_launch_backend.py
@@ -90,6 +90,46 @@ class StartupHeartbeatTests(unittest.TestCase):
         )
         fake_certifi.where.assert_not_called()
 
+    def test_non_windows_ssl_context_not_patched(self) -> None:
+        original_create_default_context = launch_backend.ssl.create_default_context
+
+        with mock.patch.object(launch_backend.sys, "platform", "linux"):
+            launch_backend.configure_windows_safe_default_ssl_context()
+
+        self.assertIs(
+            launch_backend.ssl.create_default_context, original_create_default_context
+        )
+
+    def test_windows_ssl_context_patch_is_idempotent(self) -> None:
+        sentinel_context = mock.Mock(spec=ssl.SSLContext)
+        original_create_default_context = mock.Mock(return_value=sentinel_context)
+        fake_certifi = mock.Mock()
+        fake_certifi.where.return_value = "certifi.pem"
+
+        with mock.patch.object(launch_backend.sys, "platform", "win32"):
+            with mock.patch.object(
+                launch_backend.ssl,
+                "create_default_context",
+                original_create_default_context,
+            ):
+                with mock.patch.dict("sys.modules", {"certifi": fake_certifi}):
+                    launch_backend.configure_windows_safe_default_ssl_context()
+                    first_patched = launch_backend.ssl.create_default_context
+                    launch_backend.configure_windows_safe_default_ssl_context()
+                    second_patched = launch_backend.ssl.create_default_context
+
+        self.assertIs(first_patched, second_patched)
+        self.assertTrue(
+            getattr(second_patched, "_astrbot_desktop_safe_context", False)
+        )
+
+    def test_windows_ssl_context_patch_handles_certifi_import_error(self) -> None:
+        with mock.patch.object(launch_backend.sys, "platform", "win32"):
+            with mock.patch.dict("sys.modules", {"certifi": None}):
+                original = launch_backend.ssl.create_default_context
+                launch_backend.configure_windows_safe_default_ssl_context()
+                self.assertIs(launch_backend.ssl.create_default_context, original)
+
     def test_atomic_write_json_cleans_up_temp_file_when_replace_fails(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             heartbeat_path = Path(temp_dir) / "heartbeat.json"

--- a/scripts/backend/templates/test_launch_backend.py
+++ b/scripts/backend/templates/test_launch_backend.py
@@ -15,6 +15,9 @@ SPEC.loader.exec_module(launch_backend)
 
 
 class StartupHeartbeatTests(unittest.TestCase):
+    def setUp(self) -> None:
+        launch_backend._ORIGINAL_CREATE_DEFAULT_CONTEXT = None
+
     def test_windows_ssl_context_patch_uses_certifi_with_original_context(self) -> None:
         sentinel_context = mock.Mock(spec=ssl.SSLContext)
         original_create_default_context = mock.Mock(return_value=sentinel_context)
@@ -119,9 +122,7 @@ class StartupHeartbeatTests(unittest.TestCase):
                     second_patched = launch_backend.ssl.create_default_context
 
         self.assertIs(first_patched, second_patched)
-        self.assertTrue(
-            getattr(second_patched, "_astrbot_desktop_safe_context", False)
-        )
+        self.assertIsNotNone(launch_backend._ORIGINAL_CREATE_DEFAULT_CONTEXT)
 
     def test_windows_ssl_context_patch_handles_certifi_import_error(self) -> None:
         with mock.patch.object(launch_backend.sys, "platform", "win32"):

--- a/scripts/backend/templates/test_launch_backend.py
+++ b/scripts/backend/templates/test_launch_backend.py
@@ -15,24 +15,11 @@ SPEC.loader.exec_module(launch_backend)
 
 
 class StartupHeartbeatTests(unittest.TestCase):
-    def test_windows_ssl_context_patch_avoids_default_context(self) -> None:
+    def test_windows_ssl_context_patch_uses_certifi_with_original_context(self) -> None:
         sentinel_context = mock.Mock(spec=ssl.SSLContext)
-        original_create_default_context = mock.Mock(
-            side_effect=AssertionError("original default context should not be used")
-        )
+        original_create_default_context = mock.Mock(return_value=sentinel_context)
         fake_certifi = mock.Mock()
         fake_certifi.where.return_value = "certifi.pem"
-        loaded_locations: list[dict[str, object]] = []
-
-        def record_loaded_locations(**kwargs: object) -> None:
-            loaded_locations.append(kwargs)
-
-        def fake_ssl_context(protocol: int) -> mock.Mock:
-            self.assertEqual(protocol, ssl.PROTOCOL_TLS_CLIENT)
-            sentinel_context.check_hostname = False
-            sentinel_context.verify_mode = ssl.CERT_NONE
-            sentinel_context.load_verify_locations.side_effect = record_loaded_locations
-            return sentinel_context
 
         with mock.patch.object(launch_backend.sys, "platform", "win32"):
             with mock.patch.object(
@@ -40,23 +27,62 @@ class StartupHeartbeatTests(unittest.TestCase):
                 "create_default_context",
                 original_create_default_context,
             ):
-                with mock.patch.object(
-                    launch_backend.ssl,
-                    "SSLContext",
-                    fake_ssl_context,
-                ):
-                    with mock.patch.dict("sys.modules", {"certifi": fake_certifi}):
-                        launch_backend.configure_windows_safe_default_ssl_context()
-                        patched_context = launch_backend.ssl.create_default_context()
+                with mock.patch.dict("sys.modules", {"certifi": fake_certifi}):
+                    launch_backend.configure_windows_safe_default_ssl_context()
+                    patched_context = launch_backend.ssl.create_default_context()
 
         self.assertIs(patched_context, sentinel_context)
-        self.assertEqual(
-            loaded_locations,
-            [{"cafile": "certifi.pem", "capath": None, "cadata": None}],
+        original_create_default_context.assert_called_once_with(
+            ssl.Purpose.SERVER_AUTH,
+            cafile="certifi.pem",
+            capath=None,
+            cadata=None,
         )
-        original_create_default_context.assert_not_called()
-        self.assertTrue(sentinel_context.check_hostname)
-        self.assertEqual(sentinel_context.verify_mode, ssl.CERT_REQUIRED)
+
+    def test_windows_ssl_context_patch_preserves_client_auth_defaults(self) -> None:
+        original_create_default_context = ssl.create_default_context
+        with mock.patch.object(launch_backend.sys, "platform", "win32"):
+            with mock.patch.object(
+                launch_backend.ssl,
+                "create_default_context",
+                original_create_default_context,
+            ):
+                launch_backend.configure_windows_safe_default_ssl_context()
+                patched_context = launch_backend.ssl.create_default_context(
+                    ssl.Purpose.CLIENT_AUTH
+                )
+
+        self.assertEqual(patched_context.protocol, ssl.PROTOCOL_TLS_SERVER)
+        self.assertFalse(patched_context.check_hostname)
+        self.assertEqual(patched_context.verify_mode, ssl.CERT_NONE)
+
+    def test_windows_ssl_context_patch_passes_explicit_ca_parameters(self) -> None:
+        sentinel_context = mock.Mock(spec=ssl.SSLContext)
+        original_create_default_context = mock.Mock(return_value=sentinel_context)
+        fake_certifi = mock.Mock()
+
+        with mock.patch.object(launch_backend.sys, "platform", "win32"):
+            with mock.patch.object(
+                launch_backend.ssl,
+                "create_default_context",
+                original_create_default_context,
+            ):
+                with mock.patch.dict("sys.modules", {"certifi": fake_certifi}):
+                    launch_backend.configure_windows_safe_default_ssl_context()
+                    patched_context = launch_backend.ssl.create_default_context(
+                        cafile="custom.pem",
+                        capath=None,
+                        cadata=b"custom-ca",
+                    )
+
+        self.assertIs(patched_context, sentinel_context)
+        original_create_default_context.assert_called_once_with(
+            ssl.Purpose.SERVER_AUTH,
+            cafile="custom.pem",
+            capath=None,
+            cadata=b"custom-ca",
+        )
+        fake_certifi.where.assert_not_called()
 
     def test_atomic_write_json_cleans_up_temp_file_when_replace_fails(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/backend/templates/test_launch_backend.py
+++ b/scripts/backend/templates/test_launch_backend.py
@@ -40,7 +40,9 @@ class StartupHeartbeatTests(unittest.TestCase):
         )
 
     def test_windows_ssl_context_patch_preserves_client_auth_defaults(self) -> None:
-        original_create_default_context = ssl.create_default_context
+        sentinel_context = mock.Mock(spec=ssl.SSLContext)
+        original_create_default_context = mock.Mock(return_value=sentinel_context)
+
         with mock.patch.object(launch_backend.sys, "platform", "win32"):
             with mock.patch.object(
                 launch_backend.ssl,
@@ -52,9 +54,13 @@ class StartupHeartbeatTests(unittest.TestCase):
                     ssl.Purpose.CLIENT_AUTH
                 )
 
-        self.assertEqual(patched_context.protocol, ssl.PROTOCOL_TLS_SERVER)
-        self.assertFalse(patched_context.check_hostname)
-        self.assertEqual(patched_context.verify_mode, ssl.CERT_NONE)
+        self.assertIs(patched_context, sentinel_context)
+        original_create_default_context.assert_called_once_with(
+            ssl.Purpose.CLIENT_AUTH,
+            cafile=None,
+            capath=None,
+            cadata=None,
+        )
 
     def test_windows_ssl_context_patch_passes_explicit_ca_parameters(self) -> None:
         sentinel_context = mock.Mock(spec=ssl.SSLContext)

--- a/scripts/backend/templates/test_launch_backend.py
+++ b/scripts/backend/templates/test_launch_backend.py
@@ -1,4 +1,5 @@
 import importlib.util
+import ssl
 import tempfile
 import unittest
 from pathlib import Path
@@ -14,6 +15,49 @@ SPEC.loader.exec_module(launch_backend)
 
 
 class StartupHeartbeatTests(unittest.TestCase):
+    def test_windows_ssl_context_patch_avoids_default_context(self) -> None:
+        sentinel_context = mock.Mock(spec=ssl.SSLContext)
+        original_create_default_context = mock.Mock(
+            side_effect=AssertionError("original default context should not be used")
+        )
+        fake_certifi = mock.Mock()
+        fake_certifi.where.return_value = "certifi.pem"
+        loaded_locations: list[dict[str, object]] = []
+
+        def record_loaded_locations(**kwargs: object) -> None:
+            loaded_locations.append(kwargs)
+
+        def fake_ssl_context(protocol: int) -> mock.Mock:
+            self.assertEqual(protocol, ssl.PROTOCOL_TLS_CLIENT)
+            sentinel_context.check_hostname = False
+            sentinel_context.verify_mode = ssl.CERT_NONE
+            sentinel_context.load_verify_locations.side_effect = record_loaded_locations
+            return sentinel_context
+
+        with mock.patch.object(launch_backend.sys, "platform", "win32"):
+            with mock.patch.object(
+                launch_backend.ssl,
+                "create_default_context",
+                original_create_default_context,
+            ):
+                with mock.patch.object(
+                    launch_backend.ssl,
+                    "SSLContext",
+                    fake_ssl_context,
+                ):
+                    with mock.patch.dict("sys.modules", {"certifi": fake_certifi}):
+                        launch_backend.configure_windows_safe_default_ssl_context()
+                        patched_context = launch_backend.ssl.create_default_context()
+
+        self.assertIs(patched_context, sentinel_context)
+        self.assertEqual(
+            loaded_locations,
+            [{"cafile": "certifi.pem", "capath": None, "cadata": None}],
+        )
+        original_create_default_context.assert_not_called()
+        self.assertTrue(sentinel_context.check_hostname)
+        self.assertEqual(sentinel_context.verify_mode, ssl.CERT_REQUIRED)
+
     def test_atomic_write_json_cleans_up_temp_file_when_replace_fails(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             heartbeat_path = Path(temp_dir) / "heartbeat.json"


### PR DESCRIPTION
### Summary / 改动概述

Fixes #130.

- Install a Windows-only safe `ssl.create_default_context` replacement in the bundled backend launcher before `app/main.py` imports AstrBot backend modules.
- Build the replacement context with `ssl.SSLContext` plus certifi, avoiding the packaged Windows OpenSSL Applink crash path triggered by `aiohttp.connector` import-time default context creation.
- Add a launcher template regression test that ensures the original default context function is not called.

### Verification / 验证方式

- `python3 -m unittest scripts.backend.templates.test_launch_backend`
- `pnpm test:prepare-resources`

---

### Checklist / 检查清单

- [x] This change is **not** a breaking change. / 此改动**不是**破坏性变更。
- [x] I have verified the change locally (and provided logs/screenshots above). / 我已在本地验证并在上方提供日志/截图。
- [x] If workflows are changed, I attached at least one related Actions run link. / 如果修改了工作流，我已附上至少一个相关 Actions 运行链接。
- [x] If dependencies are updated, lockfiles are updated accordingly (`src-tauri/Cargo.lock`, lockfiles under changed package dirs). / 如果引入或升级依赖，已同步更新相关 lock 文件（如 `src-tauri/Cargo.lock`、对应包目录中的 lock 文件）。
- [x] This PR does not include malicious code. / 此 PR 不包含恶意代码。

## Summary by Sourcery

Patch the backend launcher to install a Windows-safe SSL default context before backend startup to avoid OpenSSL Applink crashes, and add regression tests for the new behavior.

Bug Fixes:
- Prevent OpenSSL Applink crashes on Windows by routing default SERVER_AUTH contexts through a certifi-backed SSL context in the backend launcher.

Tests:
- Add unit tests covering the Windows SSL default-context patch behavior, including certifi usage, parameter handling, idempotency, and non-Windows no-op behavior.