### PR TITLE
fix: guard packaged AstrBot runtime version

### DIFF
--- a/scripts/prepare-resources.mjs
+++ b/scripts/prepare-resources.mjs
@@ -61,9 +61,10 @@ const main = async () => {
   const astrbotVersion =
     desktopVersionOverride || (await readAstrbotVersionFromPyproject({ sourceDir }));
 
-  if (!desktopVersionOverride) {
-    await validateAstrbotRuntimeVersion({ sourceDir, expectedVersion: astrbotVersion });
-  }
+  await validateAstrbotRuntimeVersion({
+    sourceDir,
+    expectedVersion: desktopVersionOverride ? undefined : astrbotVersion,
+  });
 
   if (desktopVersionOverride && needsSourceRepo) {
     const sourceVersion = await readAstrbotVersionFromPyproject({ sourceDir });

--- a/scripts/prepare-resources.mjs
+++ b/scripts/prepare-resources.mjs
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import {
   readAstrbotVersionFromPyproject,
   syncDesktopVersionFiles,
+  validateAstrbotRuntimeVersion,
 } from './prepare-resources/version-sync.mjs';
 import {
   ensureSourceRepo,
@@ -59,6 +60,10 @@ const main = async () => {
   ensureStartupShellAssets(projectRoot);
   const astrbotVersion =
     desktopVersionOverride || (await readAstrbotVersionFromPyproject({ sourceDir }));
+
+  if (!desktopVersionOverride) {
+    await validateAstrbotRuntimeVersion({ sourceDir, expectedVersion: astrbotVersion });
+  }
 
   if (desktopVersionOverride && needsSourceRepo) {
     const sourceVersion = await readAstrbotVersionFromPyproject({ sourceDir });

--- a/scripts/prepare-resources/version-sync.mjs
+++ b/scripts/prepare-resources/version-sync.mjs
@@ -49,8 +49,11 @@ export const readAstrbotVersionFromPyproject = async ({ sourceDir }) => {
   throw new Error(`Cannot resolve [project].version from ${pyprojectPath}`);
 };
 
+export const resolveAstrbotRuntimeVersionPath = ({ sourceDir }) =>
+  path.join(sourceDir, 'astrbot', 'core', 'config', 'default.py');
+
 export const readAstrbotRuntimeVersion = async ({ sourceDir }) => {
-  const defaultConfigPath = path.join(sourceDir, 'astrbot', 'core', 'config', 'default.py');
+  const defaultConfigPath = resolveAstrbotRuntimeVersionPath({ sourceDir });
   if (!existsSync(defaultConfigPath)) {
     throw new Error(`Cannot find AstrBot runtime version file: ${defaultConfigPath}`);
   }
@@ -71,13 +74,11 @@ export const validateAstrbotRuntimeVersion = async ({ sourceDir, expectedVersion
       `AstrBot runtime VERSION resolved to 0.0.0 in ${sourceDir}. Use an AstrBot source ref that contains the static runtime VERSION fix.`,
     );
   }
-  if (runtimeVersion !== expectedVersion) {
+  if (expectedVersion && runtimeVersion !== expectedVersion) {
     throw new Error(
       `AstrBot version mismatch in ${sourceDir}: pyproject.toml has ${expectedVersion}, but runtime VERSION is ${runtimeVersion}.`,
     );
   }
-
-  return runtimeVersion;
 };
 
 const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/scripts/prepare-resources/version-sync.mjs
+++ b/scripts/prepare-resources/version-sync.mjs
@@ -49,6 +49,37 @@ export const readAstrbotVersionFromPyproject = async ({ sourceDir }) => {
   throw new Error(`Cannot resolve [project].version from ${pyprojectPath}`);
 };
 
+export const readAstrbotRuntimeVersion = async ({ sourceDir }) => {
+  const defaultConfigPath = path.join(sourceDir, 'astrbot', 'core', 'config', 'default.py');
+  if (!existsSync(defaultConfigPath)) {
+    throw new Error(`Cannot find AstrBot runtime version file: ${defaultConfigPath}`);
+  }
+
+  const content = await readFile(defaultConfigPath, 'utf8');
+  const match = /^\s*VERSION\s*=\s*["']([^"']+)["']\s*(?:#.*)?$/m.exec(content);
+  if (!match) {
+    throw new Error(`Cannot resolve AstrBot runtime VERSION from ${defaultConfigPath}`);
+  }
+
+  return match[1].trim();
+};
+
+export const validateAstrbotRuntimeVersion = async ({ sourceDir, expectedVersion }) => {
+  const runtimeVersion = await readAstrbotRuntimeVersion({ sourceDir });
+  if (runtimeVersion === '0.0.0') {
+    throw new Error(
+      `AstrBot runtime VERSION resolved to 0.0.0 in ${sourceDir}. Use an AstrBot source ref that contains the static runtime VERSION fix.`,
+    );
+  }
+  if (runtimeVersion !== expectedVersion) {
+    throw new Error(
+      `AstrBot version mismatch in ${sourceDir}: pyproject.toml has ${expectedVersion}, but runtime VERSION is ${runtimeVersion}.`,
+    );
+  }
+
+  return runtimeVersion;
+};
+
 const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 const CARGO_LOCK_PACKAGE_HEADER = /^\s*\[\[package\]\]\s*(?:#.*)?$/;
 const CARGO_LOCK_ANY_HEADER = /^\s*\[\[/;

--- a/scripts/prepare-resources/version-sync.test.mjs
+++ b/scripts/prepare-resources/version-sync.test.mjs
@@ -9,6 +9,7 @@ import {
   normalizeDesktopVersionOverride,
   readAstrbotRuntimeVersion,
   readAstrbotVersionFromPyproject,
+  resolveAstrbotRuntimeVersionPath,
   syncDesktopVersionFiles,
   validateAstrbotRuntimeVersion,
 } from './version-sync.mjs';
@@ -43,7 +44,8 @@ const createTempDesktopProject = async ({ cargoLockContents, version = '0.1.0' }
 
 const createTempAstrBotSource = async ({ pyprojectVersion = '1.2.3', runtimeVersion = '1.2.3' }) => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), 'astrbot-source-'));
-  const configDir = path.join(tempDir, 'astrbot', 'core', 'config');
+  const runtimeVersionPath = resolveAstrbotRuntimeVersionPath({ sourceDir: tempDir });
+  const configDir = path.dirname(runtimeVersionPath);
   await mkdir(configDir, { recursive: true });
   await writeFile(
     path.join(tempDir, 'pyproject.toml'),
@@ -51,7 +53,7 @@ const createTempAstrBotSource = async ({ pyprojectVersion = '1.2.3', runtimeVers
     'utf8',
   );
   await writeFile(
-    path.join(configDir, 'default.py'),
+    runtimeVersionPath,
     `import os\n\nVERSION = "${runtimeVersion}"\n`,
     'utf8',
   );
@@ -119,6 +121,30 @@ test('validateAstrbotRuntimeVersion rejects runtime version drift', async () => 
     await assert.rejects(
       validateAstrbotRuntimeVersion({ sourceDir: tempDir, expectedVersion }),
       /pyproject\.toml has 4\.26\.0-beta\.10, but runtime VERSION is 4\.26\.0-beta\.9/,
+    );
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('validateAstrbotRuntimeVersion allows drift when no expected version is supplied', async () => {
+  const tempDir = await createTempAstrBotSource({
+    pyprojectVersion: '4.26.0-beta.10',
+    runtimeVersion: '4.26.0-beta.9',
+  });
+  try {
+    await validateAstrbotRuntimeVersion({ sourceDir: tempDir });
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('validateAstrbotRuntimeVersion still rejects 0.0.0 when no expected version is supplied', async () => {
+  const tempDir = await createTempAstrBotSource({ runtimeVersion: '0.0.0' });
+  try {
+    await assert.rejects(
+      validateAstrbotRuntimeVersion({ sourceDir: tempDir }),
+      /runtime VERSION resolved to 0\.0\.0/,
     );
   } finally {
     await rm(tempDir, { recursive: true, force: true });

--- a/scripts/prepare-resources/version-sync.test.mjs
+++ b/scripts/prepare-resources/version-sync.test.mjs
@@ -7,8 +7,10 @@ import assert from 'node:assert/strict';
 import {
   DESKTOP_TAURI_CRATE_NAME,
   normalizeDesktopVersionOverride,
+  readAstrbotRuntimeVersion,
   readAstrbotVersionFromPyproject,
   syncDesktopVersionFiles,
+  validateAstrbotRuntimeVersion,
 } from './version-sync.mjs';
 
 const createTempDesktopProject = async ({ cargoLockContents, version = '0.1.0' }) => {
@@ -39,6 +41,23 @@ const createTempDesktopProject = async ({ cargoLockContents, version = '0.1.0' }
   return { tempDir, srcTauriDir };
 };
 
+const createTempAstrBotSource = async ({ pyprojectVersion = '1.2.3', runtimeVersion = '1.2.3' }) => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'astrbot-source-'));
+  const configDir = path.join(tempDir, 'astrbot', 'core', 'config');
+  await mkdir(configDir, { recursive: true });
+  await writeFile(
+    path.join(tempDir, 'pyproject.toml'),
+    `[project]\nname = "AstrBot"\nversion = "${pyprojectVersion}"\n`,
+    'utf8',
+  );
+  await writeFile(
+    path.join(configDir, 'default.py'),
+    `import os\n\nVERSION = "${runtimeVersion}"\n`,
+    'utf8',
+  );
+  return tempDir;
+};
+
 test('normalizeDesktopVersionOverride trims and strips leading v', () => {
   assert.equal(normalizeDesktopVersionOverride(' v1.2.3 '), '1.2.3');
   assert.equal(normalizeDesktopVersionOverride('2.0.0'), '2.0.0');
@@ -63,6 +82,44 @@ version = "1.9.1"
 
     const version = await readAstrbotVersionFromPyproject({ sourceDir: tempDir });
     assert.equal(version, '1.9.1');
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('readAstrbotRuntimeVersion reads static VERSION from default.py', async () => {
+  const tempDir = await createTempAstrBotSource({ runtimeVersion: '4.26.0-beta.10' });
+  try {
+    const version = await readAstrbotRuntimeVersion({ sourceDir: tempDir });
+    assert.equal(version, '4.26.0-beta.10');
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('validateAstrbotRuntimeVersion rejects 0.0.0 runtime version', async () => {
+  const tempDir = await createTempAstrBotSource({ runtimeVersion: '0.0.0' });
+  try {
+    await assert.rejects(
+      validateAstrbotRuntimeVersion({ sourceDir: tempDir, expectedVersion: '4.26.0-beta.10' }),
+      /runtime VERSION resolved to 0\.0\.0/,
+    );
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('validateAstrbotRuntimeVersion rejects runtime version drift', async () => {
+  const tempDir = await createTempAstrBotSource({
+    pyprojectVersion: '4.26.0-beta.10',
+    runtimeVersion: '4.26.0-beta.9',
+  });
+  try {
+    const expectedVersion = await readAstrbotVersionFromPyproject({ sourceDir: tempDir });
+    await assert.rejects(
+      validateAstrbotRuntimeVersion({ sourceDir: tempDir, expectedVersion }),
+      /pyproject\.toml has 4\.26\.0-beta\.10, but runtime VERSION is 4\.26\.0-beta\.9/,
+    );
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- validate AstrBot's runtime VERSION during desktop resource preparation
- fail early when the packaged source reports 0.0.0 or drifts from pyproject.toml
- add prepare-resources tests for runtime version parsing, 0.0.0 rejection, and drift rejection

## Why
AstrBot core briefly derived VERSION dynamically and could fall back to 0.0.0 in packaged desktop resource layouts. Core has restored a static VERSION, but desktop builds should still fail before producing artifacts if the selected AstrBot source ref has a broken or mismatched runtime version.

## Testing
- pnpm run test:prepare-resources
- ASTRBOT_SOURCE_DIR="/Users/buding/Code/AstrBot" pnpm run sync:version

Co-Authored-By: OpenCode <opencode@local>

## Summary by Sourcery

Enforce validation of the packaged AstrBot runtime version during desktop resource preparation to fail early on invalid or mismatched versions.

Bug Fixes:
- Prevent desktop builds from succeeding when the AstrBot runtime VERSION file is missing, unparsable, or set to the placeholder 0.0.0.
- Detect and block builds when the AstrBot runtime VERSION disagrees with the version declared in pyproject.toml, unless a manual desktop version override is used.

Enhancements:
- Introduce helpers to locate and read the static AstrBot runtime VERSION from the core config.
- Integrate runtime version validation into the prepare-resources workflow so that version integrity is checked as part of the build step.

Tests:
- Add unit tests covering runtime VERSION parsing, rejection of 0.0.0, rejection of version drift against pyproject.toml, and allowed drift when no expected version is provided.