### PR TITLE
fix: skip runtime version check without source repo

### DIFF
--- a/scripts/prepare-resources.mjs
+++ b/scripts/prepare-resources.mjs
@@ -18,7 +18,7 @@ import { createPrepareResourcesContext } from './prepare-resources/context.mjs';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = path.resolve(__dirname, '..');
 
-const resolveAstrbotVersionForSync = async ({ context }) => {
+const prepareAstrbotVersionSync = async ({ context }) => {
   const {
     mode,
     projectRoot,
@@ -87,7 +87,7 @@ const main = async () => {
     );
   }
 
-  const astrbotVersion = await resolveAstrbotVersionForSync({ context });
+  const astrbotVersion = await prepareAstrbotVersionSync({ context });
 
   await syncDesktopVersionFiles({ projectRoot, version: astrbotVersion });
   if (desktopVersionOverride) {

--- a/scripts/prepare-resources.mjs
+++ b/scripts/prepare-resources.mjs
@@ -18,6 +18,50 @@ import { createPrepareResourcesContext } from './prepare-resources/context.mjs';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = path.resolve(__dirname, '..');
 
+const resolveAstrbotVersionForSync = async ({
+  needsSourceRepo,
+  sourceDir,
+  sourceRepoUrl,
+  sourceRepoRef,
+  isSourceRepoRefCommitSha,
+  sourceDirOverrideInput,
+  desktopVersionInput,
+  desktopVersionOverride,
+}) => {
+  if (!needsSourceRepo) {
+    console.log(
+      '[prepare-resources] Skip source repo sync in version-only mode because ASTRBOT_DESKTOP_VERSION is set.',
+    );
+    return desktopVersionOverride;
+  }
+
+  ensureSourceRepo({
+    sourceDir,
+    sourceRepoUrl,
+    sourceRepoRef,
+    isSourceRepoRefCommitSha,
+    sourceDirOverrideRaw: sourceDirOverrideInput,
+  });
+
+  const astrbotVersion =
+    desktopVersionOverride || (await readAstrbotVersionFromPyproject({ sourceDir }));
+  await validateAstrbotRuntimeVersion({
+    sourceDir,
+    expectedVersion: desktopVersionOverride ? undefined : astrbotVersion,
+  });
+
+  if (desktopVersionOverride) {
+    const sourceVersion = await readAstrbotVersionFromPyproject({ sourceDir });
+    if (sourceVersion !== desktopVersionOverride) {
+      console.warn(
+        `[prepare-resources] Version override drift detected: ASTRBOT_DESKTOP_VERSION=${desktopVersionInput} (normalized=${desktopVersionOverride}), source pyproject version=${sourceVersion} (${sourceDir})`,
+      );
+    }
+  }
+
+  return astrbotVersion;
+};
+
 const main = async () => {
   const context = createPrepareResourcesContext({
     argv: process.argv,
@@ -43,39 +87,18 @@ const main = async () => {
     );
   }
 
-  if (needsSourceRepo) {
-    ensureSourceRepo({
-      sourceDir,
-      sourceRepoUrl,
-      sourceRepoRef,
-      isSourceRepoRefCommitSha,
-      sourceDirOverrideRaw: sourceDirOverrideInput,
-    });
-  } else {
-    console.log(
-      '[prepare-resources] Skip source repo sync in version-only mode because ASTRBOT_DESKTOP_VERSION is set.',
-    );
-  }
-
   ensureStartupShellAssets(projectRoot);
-  const astrbotVersion =
-    desktopVersionOverride || (await readAstrbotVersionFromPyproject({ sourceDir }));
 
-  if (needsSourceRepo) {
-    await validateAstrbotRuntimeVersion({
-      sourceDir,
-      expectedVersion: desktopVersionOverride ? undefined : astrbotVersion,
-    });
-  }
-
-  if (desktopVersionOverride && needsSourceRepo) {
-    const sourceVersion = await readAstrbotVersionFromPyproject({ sourceDir });
-    if (sourceVersion !== desktopVersionOverride) {
-      console.warn(
-        `[prepare-resources] Version override drift detected: ASTRBOT_DESKTOP_VERSION=${desktopVersionInput} (normalized=${desktopVersionOverride}), source pyproject version=${sourceVersion} (${sourceDir})`,
-      );
-    }
-  }
+  const astrbotVersion = await resolveAstrbotVersionForSync({
+    needsSourceRepo,
+    sourceDir,
+    sourceRepoUrl,
+    sourceRepoRef,
+    isSourceRepoRefCommitSha,
+    sourceDirOverrideInput,
+    desktopVersionInput,
+    desktopVersionOverride,
+  });
 
   await syncDesktopVersionFiles({ projectRoot, version: astrbotVersion });
   if (desktopVersionOverride) {

--- a/scripts/prepare-resources.mjs
+++ b/scripts/prepare-resources.mjs
@@ -18,8 +18,10 @@ import { createPrepareResourcesContext } from './prepare-resources/context.mjs';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = path.resolve(__dirname, '..');
 
-const resolveAstrbotVersionForSync = async ({ context, needsSourceRepo }) => {
+const resolveAstrbotVersionForSync = async ({ context }) => {
   const {
+    mode,
+    projectRoot,
     sourceDir,
     sourceRepoUrl,
     sourceRepoRef,
@@ -28,6 +30,9 @@ const resolveAstrbotVersionForSync = async ({ context, needsSourceRepo }) => {
     desktopVersionInput,
     desktopVersionOverride,
   } = context;
+  const needsSourceRepo = mode !== 'version' || !desktopVersionOverride;
+
+  ensureStartupShellAssets(projectRoot);
 
   if (!needsSourceRepo) {
     console.log(
@@ -74,7 +79,6 @@ const main = async () => {
     desktopVersionInput,
     desktopVersionOverride,
   } = context;
-  const needsSourceRepo = mode !== 'version' || !desktopVersionOverride;
   await mkdir(path.join(projectRoot, 'resources'), { recursive: true });
 
   if (desktopVersionInput && desktopVersionInput !== desktopVersionOverride) {
@@ -83,9 +87,7 @@ const main = async () => {
     );
   }
 
-  ensureStartupShellAssets(projectRoot);
-
-  const astrbotVersion = await resolveAstrbotVersionForSync({ context, needsSourceRepo });
+  const astrbotVersion = await resolveAstrbotVersionForSync({ context });
 
   await syncDesktopVersionFiles({ projectRoot, version: astrbotVersion });
   if (desktopVersionOverride) {

--- a/scripts/prepare-resources.mjs
+++ b/scripts/prepare-resources.mjs
@@ -61,10 +61,12 @@ const main = async () => {
   const astrbotVersion =
     desktopVersionOverride || (await readAstrbotVersionFromPyproject({ sourceDir }));
 
-  await validateAstrbotRuntimeVersion({
-    sourceDir,
-    expectedVersion: desktopVersionOverride ? undefined : astrbotVersion,
-  });
+  if (needsSourceRepo) {
+    await validateAstrbotRuntimeVersion({
+      sourceDir,
+      expectedVersion: desktopVersionOverride ? undefined : astrbotVersion,
+    });
+  }
 
   if (desktopVersionOverride && needsSourceRepo) {
     const sourceVersion = await readAstrbotVersionFromPyproject({ sourceDir });

--- a/scripts/prepare-resources.mjs
+++ b/scripts/prepare-resources.mjs
@@ -18,16 +18,17 @@ import { createPrepareResourcesContext } from './prepare-resources/context.mjs';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = path.resolve(__dirname, '..');
 
-const resolveAstrbotVersionForSync = async ({
-  needsSourceRepo,
-  sourceDir,
-  sourceRepoUrl,
-  sourceRepoRef,
-  isSourceRepoRefCommitSha,
-  sourceDirOverrideInput,
-  desktopVersionInput,
-  desktopVersionOverride,
-}) => {
+const resolveAstrbotVersionForSync = async ({ context, needsSourceRepo }) => {
+  const {
+    sourceDir,
+    sourceRepoUrl,
+    sourceRepoRef,
+    isSourceRepoRefCommitSha,
+    sourceDirOverrideInput,
+    desktopVersionInput,
+    desktopVersionOverride,
+  } = context;
+
   if (!needsSourceRepo) {
     console.log(
       '[prepare-resources] Skip source repo sync in version-only mode because ASTRBOT_DESKTOP_VERSION is set.',
@@ -70,11 +71,6 @@ const main = async () => {
   });
   const {
     mode,
-    sourceDir,
-    sourceRepoUrl,
-    sourceRepoRef,
-    isSourceRepoRefCommitSha,
-    sourceDirOverrideInput,
     desktopVersionInput,
     desktopVersionOverride,
   } = context;
@@ -89,16 +85,7 @@ const main = async () => {
 
   ensureStartupShellAssets(projectRoot);
 
-  const astrbotVersion = await resolveAstrbotVersionForSync({
-    needsSourceRepo,
-    sourceDir,
-    sourceRepoUrl,
-    sourceRepoRef,
-    isSourceRepoRefCommitSha,
-    sourceDirOverrideInput,
-    desktopVersionInput,
-    desktopVersionOverride,
-  });
+  const astrbotVersion = await resolveAstrbotVersionForSync({ context, needsSourceRepo });
 
   await syncDesktopVersionFiles({ projectRoot, version: astrbotVersion });
   if (desktopVersionOverride) {


### PR DESCRIPTION
## Summary
- skip AstrBot runtime VERSION validation when version-only sync intentionally skips source checkout
- keep runtime VERSION validation for modes that actually require the AstrBot source repo

## Why
Scheduled Build Desktop Tauri runs fail in the Sync Repository Version job after resolving v4.26.1 because version-only mode skips vendor/AstrBot checkout but still tries to read vendor/AstrBot/astrbot/core/config/default.py.

## Validation
- ASTRBOT_DESKTOP_VERSION=4.26.1 pnpm run sync:version
- pnpm run test:prepare-resources

Co-Authored-By: Warp <agent@warp.dev>

## Summary by Sourcery

Skip AstrBot runtime version validation when version-only desktop sync runs without a checked-out source repository and reuse the resolved version for desktop asset syncing.

Bug Fixes:
- Avoid failing version-only sync runs by not requiring the AstrBot source repository or runtime version validation when a desktop version override is provided.

Enhancements:
- Refactor AstrBot version resolution into a dedicated helper used by the prepare-resources entrypoint.