### PR TITLE
fix: resolve AstrBot runtime version from package metadata

### DIFF
--- a/scripts/prepare-resources/version-sync.mjs
+++ b/scripts/prepare-resources/version-sync.mjs
@@ -52,6 +52,21 @@ export const readAstrbotVersionFromPyproject = async ({ sourceDir }) => {
 export const resolveAstrbotRuntimeVersionPath = ({ sourceDir }) =>
   path.join(sourceDir, 'astrbot', 'core', 'config', 'default.py');
 
+const readAstrbotPackageVersion = async ({ sourceDir }) => {
+  const initPath = path.join(sourceDir, 'astrbot', '__init__.py');
+  if (!existsSync(initPath)) {
+    throw new Error(`Cannot find AstrBot package version file: ${initPath}`);
+  }
+
+  const content = await readFile(initPath, 'utf8');
+  const match = /^\s*__version__\s*=\s*["']([^"']+)["']\s*(?:#.*)?$/m.exec(content);
+  if (!match) {
+    throw new Error(`Cannot resolve AstrBot package __version__ from ${initPath}`);
+  }
+
+  return match[1].trim();
+};
+
 export const readAstrbotRuntimeVersion = async ({ sourceDir }) => {
   const defaultConfigPath = resolveAstrbotRuntimeVersionPath({ sourceDir });
   if (!existsSync(defaultConfigPath)) {
@@ -61,6 +76,10 @@ export const readAstrbotRuntimeVersion = async ({ sourceDir }) => {
   const content = await readFile(defaultConfigPath, 'utf8');
   const match = /^\s*VERSION\s*=\s*["']([^"']+)["']\s*(?:#.*)?$/m.exec(content);
   if (!match) {
+    if (/^\s*VERSION\s*=\s*__version__\s*(?:#.*)?$/m.test(content)) {
+      return readAstrbotPackageVersion({ sourceDir });
+    }
+
     throw new Error(`Cannot resolve AstrBot runtime VERSION from ${defaultConfigPath}`);
   }
 

--- a/scripts/prepare-resources/version-sync.test.mjs
+++ b/scripts/prepare-resources/version-sync.test.mjs
@@ -47,11 +47,13 @@ const createTempAstrBotSource = async ({ pyprojectVersion = '1.2.3', runtimeVers
   const runtimeVersionPath = resolveAstrbotRuntimeVersionPath({ sourceDir: tempDir });
   const configDir = path.dirname(runtimeVersionPath);
   await mkdir(configDir, { recursive: true });
+  await mkdir(path.join(tempDir, 'astrbot'), { recursive: true });
   await writeFile(
     path.join(tempDir, 'pyproject.toml'),
     `[project]\nname = "AstrBot"\nversion = "${pyprojectVersion}"\n`,
     'utf8',
   );
+  await writeFile(path.join(tempDir, 'astrbot', '__init__.py'), `__version__ = "${runtimeVersion}"\n`, 'utf8');
   await writeFile(
     runtimeVersionPath,
     `import os\n\nVERSION = "${runtimeVersion}"\n`,
@@ -94,6 +96,19 @@ test('readAstrbotRuntimeVersion reads static VERSION from default.py', async () 
   try {
     const version = await readAstrbotRuntimeVersion({ sourceDir: tempDir });
     assert.equal(version, '4.26.0-beta.10');
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('readAstrbotRuntimeVersion resolves VERSION imported from package __version__', async () => {
+  const tempDir = await createTempAstrBotSource({ runtimeVersion: '4.26.1' });
+  try {
+    const runtimeVersionPath = resolveAstrbotRuntimeVersionPath({ sourceDir: tempDir });
+    await writeFile(runtimeVersionPath, `from astrbot import __version__\n\nVERSION = __version__\n`, 'utf8');
+
+    const version = await readAstrbotRuntimeVersion({ sourceDir: tempDir });
+    assert.equal(version, '4.26.1');
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- support AstrBot tags where default.py assigns VERSION from astrbot.__version__
- keep the existing static VERSION parser for tags that define VERSION directly
- add regression coverage for VERSION = __version__

## Why
The Build Desktop Tauri workflow now reaches prepare:resources for v4.26.1, but AstrBot v4.26.1 uses VERSION = __version__ in astrbot/core/config/default.py. The existing parser only accepted quoted static VERSION values and failed before resource builds.

## Validation
- pnpm run test:prepare-resources
- node --input-type=module -e "import { validateAstrbotRuntimeVersion } from './scripts/prepare-resources/version-sync.mjs'; await validateAstrbotRuntimeVersion({ sourceDir: '/var/folders/cw/k87qlccd33n262h66_dpbhl80000gn/T/opencode/astrbot-v4.26.1', expectedVersion: '4.26.1' }); console.log('runtime version ok');"

Co-Authored-By: Warp <agent@warp.dev>

## Summary by Sourcery

Improve AstrBot runtime version resolution to support both static VERSION definitions and versions sourced from the package metadata.

Bug Fixes:
- Ensure AstrBot runtime VERSION can be resolved when default.py assigns VERSION = __version__ instead of a static string.

Tests:
- Add regression test coverage for resolving VERSION from the AstrBot package __version__ alongside existing static VERSION handling.