### PR TITLE
fix: mark packaged backend as desktop-managed

### DIFF
--- a/src-tauri/src/backend/launch.rs
+++ b/src-tauri/src/backend/launch.rs
@@ -30,6 +30,8 @@ const ASTRBOT_DASHBOARD_PORT_ENV: &str = "ASTRBOT_DASHBOARD_PORT";
 const ASTRBOT_DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV: &str =
     "ASTRBOT_DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH";
 const DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV: &str = "DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH";
+const ASTRBOT_DESKTOP_CLIENT_ENV: &str = "ASTRBOT_DESKTOP_CLIENT";
+const ASTRBOT_DESKTOP_MANAGED_ENV: &str = "ASTRBOT_DESKTOP_MANAGED";
 const DEFAULT_DASHBOARD_HOST: &str = "127.0.0.1";
 const DEFAULT_DASHBOARD_PORT: &str = "6185";
 const CMD_CONFIG_RELATIVE_PATH: &str = "data/cmd_config.json";
@@ -133,8 +135,8 @@ where
 }
 
 fn configure_desktop_managed_environment(command: &mut Command) {
-    command.env("ASTRBOT_DESKTOP_CLIENT", "1");
-    command.env("ASTRBOT_DESKTOP_MANAGED", "1");
+    command.env(ASTRBOT_DESKTOP_CLIENT_ENV, "1");
+    command.env(ASTRBOT_DESKTOP_MANAGED_ENV, "1");
 }
 
 fn configure_desktop_dashboard_environment(
@@ -538,10 +540,11 @@ mod tests {
     use super::{
         configure_desktop_dashboard_environment, configure_desktop_managed_environment,
         read_cmd_config_file_with_retry_and_hook, sanitize_packaged_python_environment,
-        ASTRBOT_DASHBOARD_HOST_ENV,
-        ASTRBOT_DASHBOARD_PORT_ENV, ASTRBOT_DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV,
-        CMD_CONFIG_RELATIVE_PATH, DASHBOARD_HOST_ENV, DASHBOARD_PORT_ENV,
-        DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV, DEFAULT_DASHBOARD_HOST, DEFAULT_DASHBOARD_PORT,
+        ASTRBOT_DASHBOARD_HOST_ENV, ASTRBOT_DASHBOARD_PORT_ENV,
+        ASTRBOT_DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV, ASTRBOT_DESKTOP_CLIENT_ENV,
+        ASTRBOT_DESKTOP_MANAGED_ENV, CMD_CONFIG_RELATIVE_PATH, DASHBOARD_HOST_ENV,
+        DASHBOARD_PORT_ENV, DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV, DEFAULT_DASHBOARD_HOST,
+        DEFAULT_DASHBOARD_PORT,
     };
 
     static ENV_TEST_LOCK: Mutex<()> = Mutex::new(());
@@ -635,11 +638,11 @@ mod tests {
         configure_desktop_managed_environment(&mut command);
 
         assert_eq!(
-            get_command_env_value(&command, "ASTRBOT_DESKTOP_CLIENT"),
+            get_command_env_value(&command, ASTRBOT_DESKTOP_CLIENT_ENV),
             Some(Some("1".to_string()))
         );
         assert_eq!(
-            get_command_env_value(&command, "ASTRBOT_DESKTOP_MANAGED"),
+            get_command_env_value(&command, ASTRBOT_DESKTOP_MANAGED_ENV),
             Some(Some("1".to_string()))
         );
     }

--- a/src-tauri/src/backend/launch.rs
+++ b/src-tauri/src/backend/launch.rs
@@ -132,6 +132,11 @@ where
     command.env("PYTHONNOUSERSITE", "1");
 }
 
+fn configure_desktop_managed_environment(command: &mut Command) {
+    command.env("ASTRBOT_DESKTOP_CLIENT", "1");
+    command.env("ASTRBOT_DESKTOP_MANAGED", "1");
+}
+
 fn configure_desktop_dashboard_environment(
     command: &mut Command,
     root_dir: Option<&Path>,
@@ -434,7 +439,7 @@ impl BackendState {
 
         if plan.packaged_mode {
             sanitize_packaged_python_environment(&mut command, append_desktop_log);
-            command.env("ASTRBOT_DESKTOP_CLIENT", "1");
+            configure_desktop_managed_environment(&mut command);
         }
 
         if let Some(root_dir) = &plan.root_dir {
@@ -531,8 +536,9 @@ mod tests {
     use std::os::unix::ffi::OsStringExt;
 
     use super::{
-        configure_desktop_dashboard_environment, read_cmd_config_file_with_retry_and_hook,
-        sanitize_packaged_python_environment, ASTRBOT_DASHBOARD_HOST_ENV,
+        configure_desktop_dashboard_environment, configure_desktop_managed_environment,
+        read_cmd_config_file_with_retry_and_hook, sanitize_packaged_python_environment,
+        ASTRBOT_DASHBOARD_HOST_ENV,
         ASTRBOT_DASHBOARD_PORT_ENV, ASTRBOT_DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV,
         CMD_CONFIG_RELATIVE_PATH, DASHBOARD_HOST_ENV, DASHBOARD_PORT_ENV,
         DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV, DEFAULT_DASHBOARD_HOST, DEFAULT_DASHBOARD_PORT,
@@ -618,6 +624,22 @@ mod tests {
 
         assert_eq!(
             get_command_env_value(&command, "PYTHONNOUSERSITE"),
+            Some(Some("1".to_string()))
+        );
+    }
+
+    #[test]
+    fn configure_desktop_managed_environment_marks_backend_as_desktop_managed() {
+        let mut command = Command::new("sh");
+
+        configure_desktop_managed_environment(&mut command);
+
+        assert_eq!(
+            get_command_env_value(&command, "ASTRBOT_DESKTOP_CLIENT"),
+            Some(Some("1".to_string()))
+        );
+        assert_eq!(
+            get_command_env_value(&command, "ASTRBOT_DESKTOP_MANAGED"),
             Some(Some("1".to_string()))
         );
     }


### PR DESCRIPTION
## Background

AstrBot Desktop manages the packaged backend process from the Tauri shell. The same backend can also serve WebUI pages to an external browser. In that browser path, there is no Tauri desktop bridge, so the original WebUI fallback can call core restart/update APIs directly.

The paired Core-side guard needs a reliable signal that the backend is managed by the desktop shell.

## Summary

- Add `ASTRBOT_DESKTOP_MANAGED=1` to packaged backend process environment.
- Keep the existing `ASTRBOT_DESKTOP_CLIENT=1` marker.
- Centralize both desktop backend environment keys as module constants.
- Centralize environment injection in `configure_desktop_managed_environment()`.
- Add a launch test verifying both environment variables are set.

## Behavior

For packaged desktop-managed backends, the child process now receives:

```text
ASTRBOT_DESKTOP_CLIENT=1
ASTRBOT_DESKTOP_MANAGED=1
```

This lets AstrBot Core reject browser/API-triggered self-restart and self-update flows while preserving the existing desktop runtime marker.

## Related Core PR

The paired Core PR consumes `ASTRBOT_DESKTOP_MANAGED=1` to block unmanaged restart/update paths:

- https://github.com/AstrBotDevs/AstrBot/pull/9098

## Review / CI Follow-up

- Addressed Sourcery feedback by centralizing the desktop environment variable names as constants.
- Fixed the initial `cargo fmt --check` CI failure.

## Tests

```bash
rtk cargo fmt --all
rtk cargo test backend::launch::tests
```

CI status at last check: all reported checks passed, no failing checks.

## Summary by Sourcery

Mark packaged backend processes as desktop-managed via dedicated environment configuration.

Bug Fixes:
- Ensure packaged backend processes are correctly marked as desktop-managed using dedicated environment variables.

Enhancements:
- Introduce a reusable helper to configure desktop-managed environment variables for backend commands.

Tests:
- Add a unit test verifying that the desktop-managed environment configuration sets the expected environment variables.