### PR TITLE
fix: disable WebKit DMABuf renderer on Linux

### DIFF
--- a/src-tauri/src/app_runtime.rs
+++ b/src-tauri/src/app_runtime.rs
@@ -26,6 +26,9 @@ fn configure_linux_webkit_workarounds() {
         std::env::var_os(WAYLAND_DISPLAY_ENV).as_deref(),
     ) {
         std::env::set_var(WEBKIT_DISABLE_DMABUF_RENDERER_ENV, "1");
+        append_startup_log(&format!(
+            "applied Linux WebKit workaround: set {WEBKIT_DISABLE_DMABUF_RENDERER_ENV}=1"
+        ));
     }
 }
 

--- a/src-tauri/src/app_runtime.rs
+++ b/src-tauri/src/app_runtime.rs
@@ -10,15 +10,20 @@ use crate::{
 };
 
 const WEBKIT_DISABLE_DMABUF_RENDERER_ENV: &str = "WEBKIT_DISABLE_DMABUF_RENDERER";
+const WAYLAND_DISPLAY_ENV: &str = "WAYLAND_DISPLAY";
 
-fn should_set_webkit_dmabuf_renderer_env(existing_value: Option<&std::ffi::OsStr>) -> bool {
-    existing_value.is_none()
+fn should_set_webkit_dmabuf_renderer_env(
+    existing_value: Option<&std::ffi::OsStr>,
+    wayland_display: Option<&std::ffi::OsStr>,
+) -> bool {
+    existing_value.is_none() && wayland_display.is_some()
 }
 
 #[cfg(target_os = "linux")]
 fn configure_linux_webkit_workarounds() {
     if should_set_webkit_dmabuf_renderer_env(
         std::env::var_os(WEBKIT_DISABLE_DMABUF_RENDERER_ENV).as_deref(),
+        std::env::var_os(WAYLAND_DISPLAY_ENV).as_deref(),
     ) {
         std::env::set_var(WEBKIT_DISABLE_DMABUF_RENDERER_ENV, "1");
     }
@@ -231,13 +236,27 @@ mod tests {
     use super::*;
 
     #[test]
-    fn webkit_dmabuf_workaround_is_set_only_when_unset() {
-        assert!(should_set_webkit_dmabuf_renderer_env(None));
-        assert!(!should_set_webkit_dmabuf_renderer_env(Some(
-            std::ffi::OsStr::new("0")
-        )));
-        assert!(!should_set_webkit_dmabuf_renderer_env(Some(
-            std::ffi::OsStr::new("1")
-        )));
+    fn webkit_dmabuf_workaround_is_set_only_for_wayland_without_override() {
+        assert!(should_set_webkit_dmabuf_renderer_env(
+            None,
+            Some(std::ffi::OsStr::new("wayland-0"))
+        ));
+        assert!(!should_set_webkit_dmabuf_renderer_env(None, None));
+        assert!(!should_set_webkit_dmabuf_renderer_env(
+            Some(std::ffi::OsStr::new("0")),
+            Some(std::ffi::OsStr::new("wayland-0"))
+        ));
+        assert!(!should_set_webkit_dmabuf_renderer_env(
+            Some(std::ffi::OsStr::new("1")),
+            Some(std::ffi::OsStr::new("wayland-0"))
+        ));
+        assert!(!should_set_webkit_dmabuf_renderer_env(
+            Some(std::ffi::OsStr::new("0")),
+            None
+        ));
+        assert!(!should_set_webkit_dmabuf_renderer_env(
+            Some(std::ffi::OsStr::new("1")),
+            None
+        ));
     }
 }

--- a/src-tauri/src/app_runtime.rs
+++ b/src-tauri/src/app_runtime.rs
@@ -9,6 +9,21 @@ use crate::{
     DEFAULT_SHELL_LOCALE, DESKTOP_LOG_FILE, STARTUP_MODE_ENV,
 };
 
+const WEBKIT_DISABLE_DMABUF_RENDERER_ENV: &str = "WEBKIT_DISABLE_DMABUF_RENDERER";
+
+fn should_set_webkit_dmabuf_renderer_env(existing_value: Option<&std::ffi::OsStr>) -> bool {
+    existing_value.is_none()
+}
+
+#[cfg(target_os = "linux")]
+fn configure_linux_webkit_workarounds() {
+    if should_set_webkit_dmabuf_renderer_env(
+        std::env::var_os(WEBKIT_DISABLE_DMABUF_RENDERER_ENV).as_deref(),
+    ) {
+        std::env::set_var(WEBKIT_DISABLE_DMABUF_RENDERER_ENV, "1");
+    }
+}
+
 fn configure_plugins(builder: Builder<tauri::Wry>) -> Builder<tauri::Wry> {
     builder
         .plugin(tauri_plugin_autostart::init(
@@ -168,6 +183,9 @@ fn handle_run_event(app_handle: &tauri::AppHandle, event: RunEvent) {
 }
 
 pub(crate) fn run() {
+    #[cfg(target_os = "linux")]
+    configure_linux_webkit_workarounds();
+
     append_startup_log("desktop process starting");
     append_startup_log(&format!(
         "desktop log path: {}",
@@ -206,4 +224,20 @@ pub(crate) fn run() {
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
         .run(handle_run_event);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn webkit_dmabuf_workaround_is_set_only_when_unset() {
+        assert!(should_set_webkit_dmabuf_renderer_env(None));
+        assert!(!should_set_webkit_dmabuf_renderer_env(Some(
+            std::ffi::OsStr::new("0")
+        )));
+        assert!(!should_set_webkit_dmabuf_renderer_env(Some(
+            std::ffi::OsStr::new("1")
+        )));
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #147.

On Linux Wayland sessions, set `WEBKIT_DISABLE_DMABUF_RENDERER=1` before Tauri creates the WebKitGTK webview. This works around a known WebKitGTK/Tauri upstream issue where Wayland + NVIDIA environments can fail to start or render with:

```text
Gdk-Message: Error 71 (Protocol error) dispatching to Wayland display.
```

The variable is only set when:

- `WAYLAND_DISPLAY` is present, so X11 Linux sessions are left unchanged.
- `WEBKIT_DISABLE_DMABUF_RENDERER` is not already provided, so manual overrides such as `WEBKIT_DISABLE_DMABUF_RENDERER=0` remain possible.

## Context

The reported Fedora KDE/Wayland/NVIDIA crash matches upstream reports:

- Tauri: https://github.com/tauri-apps/tauri/issues/10702
- WebKitGTK: https://bugs.webkit.org/show_bug.cgi?id=280210

WebKitGTK itself reads `WEBKIT_DISABLE_DMABUF_RENDERER` in `AcceleratedBackingStore.cpp`, so this is an application-level startup workaround for an upstream rendering path rather than an AstrBot backend/WebUI change.

## Changes

- Add a Linux-only startup workaround before `tauri::Builder::default()`.
- Scope the default workaround to Wayland sessions via `WAYLAND_DISPLAY`.
- Preserve existing user-provided `WEBKIT_DISABLE_DMABUF_RENDERER` values.
- Add a small unit test for the Wayland + override behavior.

## Verification

- `rtk cargo fmt --all --check`
- `rtk cargo test app_runtime::tests::webkit_dmabuf_workaround_is_set_only_for_wayland_without_override`
- `rtk cargo test`

Note: one full `cargo test` run initially hit an existing-looking concurrent-state failure in `desktop_settings::tests::write_desktop_setting_preserves_unknown_fields`; that specific test passed when rerun alone, and the full suite passed on the next run.

## Notes

Disabling WebKitGTK's DMABuf renderer can reduce rendering performance on some Linux systems, so the workaround is limited to Wayland sessions and still allows users to override the variable explicitly.

## Summary by Sourcery

Apply a Linux-only startup workaround that configures WebKitGTK to avoid DMABuf rendering issues on Wayland sessions.

Bug Fixes:
- Disable WebKitGTK's DMABuf renderer by default on Linux Wayland sessions to prevent startup/rendering failures, while preserving user overrides of the related environment variable.

Tests:
- Add a unit test verifying that the WebKit DMABuf workaround is only applied when running under Wayland and no explicit override is set.