### PR TITLE
fix: use astrbot-desktop as Linux package name

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AstrBot",
+  "mainBinaryName": "astrbot-desktop",
   "version": "4.26.4",
   "identifier": "com.astrbot.desktop.tauri",
   "build": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AstrBot",
-  "mainBinaryName": "astrbot-desktop",
   "version": "4.26.4",
   "identifier": "com.astrbot.desktop.tauri",
   "build": {

--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -1,0 +1,3 @@
+{
+  "productName": "astrbot-desktop"
+}


### PR DESCRIPTION
## Summary

Use `astrbot-desktop` as the Linux package/product name instead of the current auto-normalized `astr-bot`.

The default Linux package name was derived from `productName: "AstrBot"` and ended up as `astr-bot` in RPM metadata. This is confusing because AstrBot is a single brand name and this repository ships the desktop edition.

## Changes

- Add `src-tauri/tauri.linux.conf.json` with Linux-only `productName: "astrbot-desktop"`.
- Keep the base `productName: "AstrBot"` unchanged for non-Linux platforms and app/window branding.

## Verification

Local:

- `rtk cargo check --locked`

Fedora aarch64 build via `ssh fedora`:

- `cargo tauri build --bundles deb,rpm --config '{"build":{"beforeBuildCommand":""}}'`
- Generated Linux bundle filenames:
  - `astrbot-desktop_4.26.4_arm64.deb`
  - `astrbot-desktop-4.26.4-1.aarch64.rpm`
- Verified RPM metadata:

```text
Name        : astrbot-desktop
Version     : 4.26.4
Architecture: aarch64
```

The build ended after producing bundles with the expected signing-key warning because the Fedora test environment has the public update key but not `TAURI_SIGNING_PRIVATE_KEY`.

## Summary by Sourcery

Build:
- Add Linux-only Tauri config to override the package/product name to astrbot-desktop for generated DEB/RPM bundles.