### PR TITLE
refactor: clarify desktop-managed backend markers

### DIFF
--- a/src-tauri/src/backend/launch.rs
+++ b/src-tauri/src/backend/launch.rs
@@ -32,6 +32,7 @@ const ASTRBOT_DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV: &str =
 const DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV: &str = "DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH";
 const ASTRBOT_DESKTOP_CLIENT_ENV: &str = "ASTRBOT_DESKTOP_CLIENT";
 const ASTRBOT_DESKTOP_MANAGED_ENV: &str = "ASTRBOT_DESKTOP_MANAGED";
+const ENABLED_ENV_VALUE: &str = "1";
 const DEFAULT_DASHBOARD_HOST: &str = "127.0.0.1";
 const DEFAULT_DASHBOARD_PORT: &str = "6185";
 const CMD_CONFIG_RELATIVE_PATH: &str = "data/cmd_config.json";
@@ -134,9 +135,9 @@ where
     command.env("PYTHONNOUSERSITE", "1");
 }
 
-fn configure_desktop_managed_environment(command: &mut Command) {
-    command.env(ASTRBOT_DESKTOP_CLIENT_ENV, "1");
-    command.env(ASTRBOT_DESKTOP_MANAGED_ENV, "1");
+fn mark_as_desktop_managed(command: &mut Command) {
+    command.env(ASTRBOT_DESKTOP_CLIENT_ENV, ENABLED_ENV_VALUE);
+    command.env(ASTRBOT_DESKTOP_MANAGED_ENV, ENABLED_ENV_VALUE);
 }
 
 fn configure_desktop_dashboard_environment(
@@ -441,7 +442,7 @@ impl BackendState {
 
         if plan.packaged_mode {
             sanitize_packaged_python_environment(&mut command, append_desktop_log);
-            configure_desktop_managed_environment(&mut command);
+            mark_as_desktop_managed(&mut command);
         }
 
         if let Some(root_dir) = &plan.root_dir {
@@ -538,13 +539,13 @@ mod tests {
     use std::os::unix::ffi::OsStringExt;
 
     use super::{
-        configure_desktop_dashboard_environment, configure_desktop_managed_environment,
+        configure_desktop_dashboard_environment, mark_as_desktop_managed,
         read_cmd_config_file_with_retry_and_hook, sanitize_packaged_python_environment,
         ASTRBOT_DASHBOARD_HOST_ENV, ASTRBOT_DASHBOARD_PORT_ENV,
         ASTRBOT_DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV, ASTRBOT_DESKTOP_CLIENT_ENV,
         ASTRBOT_DESKTOP_MANAGED_ENV, CMD_CONFIG_RELATIVE_PATH, DASHBOARD_HOST_ENV,
         DASHBOARD_PORT_ENV, DASHBOARD_SKIP_DEFAULT_PASSWORD_AUTH_ENV, DEFAULT_DASHBOARD_HOST,
-        DEFAULT_DASHBOARD_PORT,
+        DEFAULT_DASHBOARD_PORT, ENABLED_ENV_VALUE,
     };
 
     static ENV_TEST_LOCK: Mutex<()> = Mutex::new(());
@@ -632,18 +633,18 @@ mod tests {
     }
 
     #[test]
-    fn configure_desktop_managed_environment_marks_backend_as_desktop_managed() {
+    fn mark_as_desktop_managed_sets_desktop_management_markers() {
         let mut command = Command::new("sh");
 
-        configure_desktop_managed_environment(&mut command);
+        mark_as_desktop_managed(&mut command);
 
         assert_eq!(
             get_command_env_value(&command, ASTRBOT_DESKTOP_CLIENT_ENV),
-            Some(Some("1".to_string()))
+            Some(Some(ENABLED_ENV_VALUE.to_string()))
         );
         assert_eq!(
             get_command_env_value(&command, ASTRBOT_DESKTOP_MANAGED_ENV),
-            Some(Some("1".to_string()))
+            Some(Some(ENABLED_ENV_VALUE.to_string()))
         );
     }
 


### PR DESCRIPTION
## Summary
- Rename the packaged backend marker helper to `mark_as_desktop_managed`.
- Extract the desktop-managed enabled marker value into a constant.
- Update the regression test name and assertions to use the shared constants.

## Why
This addresses review feedback on the desktop-managed backend startup marker code and reduces the chance of typos in the marker values.

## Verification
- cargo test mark_as_desktop_managed_sets_desktop_management_markers
- cargo test backend::launch
- cargo fmt -- --check
- cargo test

## Notes
- cargo clippy --all-targets -- -D warnings currently fails on macOS due to pre-existing dead_code warnings for Linux-only WebKit workaround symbols in src/app_runtime.rs; this PR does not touch that file.

## Summary by Sourcery

Clarify and standardize how the backend is marked as desktop-managed when running in packaged mode.

New Features:
- Introduce a `mark_as_desktop_managed` helper to apply desktop management environment markers in one place.

Enhancements:
- Extract the enabled environment marker value into a shared constant to avoid hard-coded literals.
- Align related tests and test names with the new helper and shared constant for desktop-managed markers.