### PR TITLE
fix: prevent silent launch window flash

### DIFF
--- a/scripts/prepare-resources/tauri-config.test.mjs
+++ b/scripts/prepare-resources/tauri-config.test.mjs
@@ -19,3 +19,19 @@ test('main Tauri window disables background throttling', async () => {
     'expected the main window to disable background throttling',
   );
 });
+
+test('main Tauri window starts hidden to avoid silent-launch flash', async () => {
+  const tauriConfig = JSON.parse(await readFile(tauriConfigPath, 'utf8'));
+  const windows = tauriConfig?.app?.windows;
+
+  assert.ok(Array.isArray(windows), 'expected tauri config app.windows to be an array');
+
+  const mainWindow = windows.find((windowConfig) => windowConfig.label === 'main');
+
+  assert.ok(mainWindow, 'expected tauri config to define a main window');
+  assert.equal(
+    mainWindow.visible,
+    false,
+    'expected the main window to stay hidden until startup settings are applied',
+  );
+});

--- a/src-tauri/src/app_runtime.rs
+++ b/src-tauri/src/app_runtime.rs
@@ -9,9 +9,18 @@ use crate::{
     DEFAULT_SHELL_LOCALE, DESKTOP_LOG_FILE, STARTUP_MODE_ENV,
 };
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StartupWindowAction {
+    KeepHidden,
+    Show,
+}
+
+#[cfg(target_os = "linux")]
 const WEBKIT_DISABLE_DMABUF_RENDERER_ENV: &str = "WEBKIT_DISABLE_DMABUF_RENDERER";
+#[cfg(target_os = "linux")]
 const WAYLAND_DISPLAY_ENV: &str = "WAYLAND_DISPLAY";
 
+#[cfg(any(target_os = "linux", test))]
 fn should_set_webkit_dmabuf_renderer_env(
     existing_value: Option<&std::ffi::OsStr>,
     wayland_display: Option<&std::ffi::OsStr>,
@@ -148,6 +157,14 @@ fn configure_page_load_events(builder: Builder<tauri::Wry>) -> Builder<tauri::Wr
     })
 }
 
+fn startup_window_action(silent_launch: bool) -> StartupWindowAction {
+    if silent_launch {
+        StartupWindowAction::KeepHidden
+    } else {
+        StartupWindowAction::Show
+    }
+}
+
 fn configure_setup(builder: Builder<tauri::Wry>) -> Builder<tauri::Wry> {
     builder.setup(|app| {
         let app_handle = app.handle().clone();
@@ -157,13 +174,23 @@ fn configure_setup(builder: Builder<tauri::Wry>) -> Builder<tauri::Wry> {
         crate::windows_shutdown::install(&app_handle);
 
         let desktop_settings = app_handle.state::<DesktopSettingsCache>().get();
-        if desktop_settings.silent_launch {
-            append_startup_log("silent launch enabled, hiding main window");
-            window::actions::hide_main_window(
-                &app_handle,
-                DEFAULT_SHELL_LOCALE,
-                append_desktop_log,
-            );
+        match startup_window_action(desktop_settings.silent_launch) {
+            StartupWindowAction::KeepHidden => {
+                append_startup_log("silent launch enabled, keeping main window hidden");
+                tray::labels::update_tray_menu_labels_with_visibility(
+                    &app_handle,
+                    DEFAULT_SHELL_LOCALE,
+                    Some(false),
+                    append_desktop_log,
+                );
+            }
+            StartupWindowAction::Show => {
+                window::actions::show_main_window(
+                    &app_handle,
+                    DEFAULT_SHELL_LOCALE,
+                    append_desktop_log,
+                );
+            }
         }
 
         startup_task::spawn_startup_task(app_handle.clone(), append_startup_log);
@@ -261,5 +288,11 @@ mod tests {
             Some(std::ffi::OsStr::new("1")),
             None
         ));
+    }
+
+    #[test]
+    fn startup_window_action_keeps_window_hidden_for_silent_launch() {
+        assert_eq!(startup_window_action(true), StartupWindowAction::KeepHidden);
+        assert_eq!(startup_window_action(false), StartupWindowAction::Show);
     }
 }

--- a/src-tauri/src/app_runtime.rs
+++ b/src-tauri/src/app_runtime.rs
@@ -9,12 +9,6 @@ use crate::{
     DEFAULT_SHELL_LOCALE, DESKTOP_LOG_FILE, STARTUP_MODE_ENV,
 };
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum StartupWindowAction {
-    KeepHidden,
-    Show,
-}
-
 #[cfg(target_os = "linux")]
 const WEBKIT_DISABLE_DMABUF_RENDERER_ENV: &str = "WEBKIT_DISABLE_DMABUF_RENDERER";
 #[cfg(target_os = "linux")]
@@ -157,14 +151,6 @@ fn configure_page_load_events(builder: Builder<tauri::Wry>) -> Builder<tauri::Wr
     })
 }
 
-fn startup_window_action(silent_launch: bool) -> StartupWindowAction {
-    if silent_launch {
-        StartupWindowAction::KeepHidden
-    } else {
-        StartupWindowAction::Show
-    }
-}
-
 fn configure_setup(builder: Builder<tauri::Wry>) -> Builder<tauri::Wry> {
     builder.setup(|app| {
         let app_handle = app.handle().clone();
@@ -174,23 +160,20 @@ fn configure_setup(builder: Builder<tauri::Wry>) -> Builder<tauri::Wry> {
         crate::windows_shutdown::install(&app_handle);
 
         let desktop_settings = app_handle.state::<DesktopSettingsCache>().get();
-        match startup_window_action(desktop_settings.silent_launch) {
-            StartupWindowAction::KeepHidden => {
-                append_startup_log("silent launch enabled, keeping main window hidden");
-                tray::labels::update_tray_menu_labels_with_visibility(
-                    &app_handle,
-                    DEFAULT_SHELL_LOCALE,
-                    Some(false),
-                    append_desktop_log,
-                );
-            }
-            StartupWindowAction::Show => {
-                window::actions::show_main_window(
-                    &app_handle,
-                    DEFAULT_SHELL_LOCALE,
-                    append_desktop_log,
-                );
-            }
+        if desktop_settings.silent_launch {
+            append_startup_log("silent launch enabled, keeping main window hidden");
+            tray::labels::update_tray_menu_labels_with_visibility(
+                &app_handle,
+                DEFAULT_SHELL_LOCALE,
+                Some(false),
+                append_desktop_log,
+            );
+        } else {
+            window::actions::show_main_window(
+                &app_handle,
+                DEFAULT_SHELL_LOCALE,
+                append_desktop_log,
+            );
         }
 
         startup_task::spawn_startup_task(app_handle.clone(), append_startup_log);
@@ -288,11 +271,5 @@ mod tests {
             Some(std::ffi::OsStr::new("1")),
             None
         ));
-    }
-
-    #[test]
-    fn startup_window_action_keeps_window_hidden_for_silent_launch() {
-        assert_eq!(startup_window_action(true), StartupWindowAction::KeepHidden);
-        assert_eq!(startup_window_action(false), StartupWindowAction::Show);
     }
 }

--- a/src-tauri/src/app_runtime.rs
+++ b/src-tauri/src/app_runtime.rs
@@ -3,37 +3,66 @@ use tauri::{
     Builder, Manager, RunEvent, WindowEvent,
 };
 
+#[cfg(target_os = "linux")]
+mod linux_webkit_workaround {
+    const WEBKIT_DISABLE_DMABUF_RENDERER_ENV: &str = "WEBKIT_DISABLE_DMABUF_RENDERER";
+    const WAYLAND_DISPLAY_ENV: &str = "WAYLAND_DISPLAY";
+
+    fn should_set_webkit_dmabuf_renderer_env(
+        existing_value: Option<&std::ffi::OsStr>,
+        wayland_display: Option<&std::ffi::OsStr>,
+    ) -> bool {
+        existing_value.is_none() && wayland_display.is_some()
+    }
+
+    pub(super) fn configure(log: impl Fn(&str)) {
+        if should_set_webkit_dmabuf_renderer_env(
+            std::env::var_os(WEBKIT_DISABLE_DMABUF_RENDERER_ENV).as_deref(),
+            std::env::var_os(WAYLAND_DISPLAY_ENV).as_deref(),
+        ) {
+            std::env::set_var(WEBKIT_DISABLE_DMABUF_RENDERER_ENV, "1");
+            log(&format!(
+                "applied Linux WebKit workaround: set {WEBKIT_DISABLE_DMABUF_RENDERER_ENV}=1"
+            ));
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::should_set_webkit_dmabuf_renderer_env;
+
+        #[test]
+        fn webkit_dmabuf_workaround_is_set_only_for_wayland_without_override() {
+            assert!(should_set_webkit_dmabuf_renderer_env(
+                None,
+                Some(std::ffi::OsStr::new("wayland-0"))
+            ));
+            assert!(!should_set_webkit_dmabuf_renderer_env(None, None));
+            assert!(!should_set_webkit_dmabuf_renderer_env(
+                Some(std::ffi::OsStr::new("0")),
+                Some(std::ffi::OsStr::new("wayland-0"))
+            ));
+            assert!(!should_set_webkit_dmabuf_renderer_env(
+                Some(std::ffi::OsStr::new("1")),
+                Some(std::ffi::OsStr::new("wayland-0"))
+            ));
+            assert!(!should_set_webkit_dmabuf_renderer_env(
+                Some(std::ffi::OsStr::new("0")),
+                None
+            ));
+            assert!(!should_set_webkit_dmabuf_renderer_env(
+                Some(std::ffi::OsStr::new("1")),
+                None
+            ));
+        }
+    }
+}
+
 use crate::{
     app_runtime_events, append_desktop_log, append_startup_log, bridge, desktop_settings,
     lifecycle, runtime_paths, startup_task, tray, window, BackendState, DesktopSettingsCache,
     DEFAULT_SHELL_LOCALE, DESKTOP_LOG_FILE, STARTUP_MODE_ENV,
 };
-
-#[cfg(target_os = "linux")]
-const WEBKIT_DISABLE_DMABUF_RENDERER_ENV: &str = "WEBKIT_DISABLE_DMABUF_RENDERER";
-#[cfg(target_os = "linux")]
-const WAYLAND_DISPLAY_ENV: &str = "WAYLAND_DISPLAY";
-
-#[cfg(target_os = "linux")]
-fn should_set_webkit_dmabuf_renderer_env(
-    existing_value: Option<&std::ffi::OsStr>,
-    wayland_display: Option<&std::ffi::OsStr>,
-) -> bool {
-    existing_value.is_none() && wayland_display.is_some()
-}
-
-#[cfg(target_os = "linux")]
-fn configure_linux_webkit_workarounds() {
-    if should_set_webkit_dmabuf_renderer_env(
-        std::env::var_os(WEBKIT_DISABLE_DMABUF_RENDERER_ENV).as_deref(),
-        std::env::var_os(WAYLAND_DISPLAY_ENV).as_deref(),
-    ) {
-        std::env::set_var(WEBKIT_DISABLE_DMABUF_RENDERER_ENV, "1");
-        append_startup_log(&format!(
-            "applied Linux WebKit workaround: set {WEBKIT_DISABLE_DMABUF_RENDERER_ENV}=1"
-        ));
-    }
-}
 
 fn configure_plugins(builder: Builder<tauri::Wry>) -> Builder<tauri::Wry> {
     builder
@@ -151,6 +180,15 @@ fn configure_page_load_events(builder: Builder<tauri::Wry>) -> Builder<tauri::Wr
     })
 }
 
+fn apply_startup_window_visibility(app_handle: &tauri::AppHandle, silent_launch: bool) {
+    if silent_launch {
+        append_startup_log("silent launch enabled, keeping main window hidden");
+        window::actions::hide_main_window(app_handle, DEFAULT_SHELL_LOCALE, append_desktop_log);
+    } else {
+        window::actions::show_main_window(app_handle, DEFAULT_SHELL_LOCALE, append_desktop_log);
+    }
+}
+
 fn configure_setup(builder: Builder<tauri::Wry>) -> Builder<tauri::Wry> {
     builder.setup(|app| {
         let app_handle = app.handle().clone();
@@ -160,21 +198,7 @@ fn configure_setup(builder: Builder<tauri::Wry>) -> Builder<tauri::Wry> {
         crate::windows_shutdown::install(&app_handle);
 
         let desktop_settings = app_handle.state::<DesktopSettingsCache>().get();
-        if desktop_settings.silent_launch {
-            append_startup_log("silent launch enabled, keeping main window hidden");
-            tray::labels::update_tray_menu_labels_with_visibility(
-                &app_handle,
-                DEFAULT_SHELL_LOCALE,
-                Some(false),
-                append_desktop_log,
-            );
-        } else {
-            window::actions::show_main_window(
-                &app_handle,
-                DEFAULT_SHELL_LOCALE,
-                append_desktop_log,
-            );
-        }
+        apply_startup_window_visibility(&app_handle, desktop_settings.silent_launch);
 
         startup_task::spawn_startup_task(app_handle.clone(), append_startup_log);
         Ok(())
@@ -202,7 +226,7 @@ fn handle_run_event(app_handle: &tauri::AppHandle, event: RunEvent) {
 
 pub(crate) fn run() {
     #[cfg(target_os = "linux")]
-    configure_linux_webkit_workarounds();
+    linux_webkit_workaround::configure(append_startup_log);
 
     append_startup_log("desktop process starting");
     append_startup_log(&format!(
@@ -242,34 +266,4 @@ pub(crate) fn run() {
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
         .run(handle_run_event);
-}
-
-#[cfg(all(test, target_os = "linux"))]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn webkit_dmabuf_workaround_is_set_only_for_wayland_without_override() {
-        assert!(should_set_webkit_dmabuf_renderer_env(
-            None,
-            Some(std::ffi::OsStr::new("wayland-0"))
-        ));
-        assert!(!should_set_webkit_dmabuf_renderer_env(None, None));
-        assert!(!should_set_webkit_dmabuf_renderer_env(
-            Some(std::ffi::OsStr::new("0")),
-            Some(std::ffi::OsStr::new("wayland-0"))
-        ));
-        assert!(!should_set_webkit_dmabuf_renderer_env(
-            Some(std::ffi::OsStr::new("1")),
-            Some(std::ffi::OsStr::new("wayland-0"))
-        ));
-        assert!(!should_set_webkit_dmabuf_renderer_env(
-            Some(std::ffi::OsStr::new("0")),
-            None
-        ));
-        assert!(!should_set_webkit_dmabuf_renderer_env(
-            Some(std::ffi::OsStr::new("1")),
-            None
-        ));
-    }
 }

--- a/src-tauri/src/app_runtime.rs
+++ b/src-tauri/src/app_runtime.rs
@@ -185,6 +185,7 @@ fn apply_startup_window_visibility(app_handle: &tauri::AppHandle, silent_launch:
         append_startup_log("silent launch enabled, keeping main window hidden");
         window::actions::hide_main_window(app_handle, DEFAULT_SHELL_LOCALE, append_desktop_log);
     } else {
+        append_startup_log("silent launch disabled, showing main window");
         window::actions::show_main_window(app_handle, DEFAULT_SHELL_LOCALE, append_desktop_log);
     }
 }

--- a/src-tauri/src/app_runtime.rs
+++ b/src-tauri/src/app_runtime.rs
@@ -14,7 +14,7 @@ const WEBKIT_DISABLE_DMABUF_RENDERER_ENV: &str = "WEBKIT_DISABLE_DMABUF_RENDERER
 #[cfg(target_os = "linux")]
 const WAYLAND_DISPLAY_ENV: &str = "WAYLAND_DISPLAY";
 
-#[cfg(any(target_os = "linux", test))]
+#[cfg(target_os = "linux")]
 fn should_set_webkit_dmabuf_renderer_env(
     existing_value: Option<&std::ffi::OsStr>,
     wayland_display: Option<&std::ffi::OsStr>,
@@ -244,7 +244,7 @@ pub(crate) fn run() {
         .run(handle_run_event);
 }
 
-#[cfg(test)]
+#[cfg(all(test, target_os = "linux"))]
 mod tests {
     use super::*;
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -19,6 +19,7 @@
         "minWidth": 980,
         "minHeight": 680,
         "resizable": true,
+        "visible": false,
         "fullscreen": false,
         "backgroundThrottling": "disabled"
       }


### PR DESCRIPTION
## Summary
- Start the main Tauri window hidden so silent launch never briefly flashes the app window.
- Explicitly show the main window during normal startup after desktop settings are loaded.
- Keep tray labels in sync when silent launch keeps the window hidden.
- Add regression coverage for the Tauri window visibility config and startup window action.

## Why
When launch-at-login and silent launch are both enabled, the main window was created visible first and then hidden in setup, causing a brief app frame flash at login. Starting hidden and showing only for non-silent startup removes that flash.

## Verification
- node --test scripts/prepare-resources/tauri-config.test.mjs
- cargo test startup_window_action_keeps_window_hidden_for_silent_launch
- cargo test app_runtime
- cargo test app_runtime_events
- cargo fmt -- --check
- cargo test
- cargo clippy --all-targets -- -D warnings

## Summary by Sourcery

Prevent the main Tauri window from briefly flashing on silent launch by starting it hidden and explicitly controlling its visibility based on startup settings.

Bug Fixes:
- Ensure the main window remains hidden during silent launch to avoid a brief frame flash at login.

Enhancements:
- Introduce a shared startup window visibility helper to keep window and tray state consistent across launch modes.
- Refactor the Linux WebKit workaround into a dedicated, testable module with explicit logging.

Tests:
- Add a test to verify the main Tauri window is configured to start hidden in tauri.conf.json.
- Maintain and relocate tests for the Linux WebKit workaround behavior to the new module.