### PR TITLE
Fix/dashboard react migration regressions

### DIFF
--- a/dashboard/src/components/config/ConfigSpecialEditors.tsx
+++ b/dashboard/src/components/config/ConfigSpecialEditors.tsx
@@ -19,6 +19,7 @@ import { Dialog } from '@/components/headless/Dialog';
 import { MdiIcon } from '@/components/icons/MdiIcon';
 import { Button } from '@/components/ui/Button';
 import { DialogActions } from '@/components/ui/DialogActions';
+import { SelectControl } from '@/components/ui/SelectControl';
 import { confirmAction, toast } from '@/stores/feedback';
 import { normalizeT2iPreview } from './configSpecialEditorsModel';
 import { isConfigRecord, setConfigValue, type ConfigRecord } from './configFormModel';
@@ -229,14 +230,14 @@ export function T2ITemplateEditor() {
                 value={name}
               />
             ) : (
-              <select disabled={loading} onChange={(event) => setSelected(event.target.value)} value={selected}>
+              <SelectControl disabled={loading} onChange={(event) => setSelected(event.target.value)} value={selected}>
                 {templates.map((template) => (
                   <option key={template.name} value={template.name}>
                     {template.name}
                     {template.name === active ? ` · ${label('applied')}` : ''}
                   </option>
                 ))}
-              </select>
+              </SelectControl>
             )}
             <button onClick={startNew} type="button">
               <MdiIcon name="mdi-plus" />

--- a/dashboard/src/components/config/DynamicConfigForm.tsx
+++ b/dashboard/src/components/config/DynamicConfigForm.tsx
@@ -8,6 +8,7 @@ import { MdiIcon } from '@/components/icons/MdiIcon';
 import { ExpandCollapse } from '@/components/motion/ExpandCollapse';
 import { Button } from '@/components/ui/Button';
 import { DialogActions } from '@/components/ui/DialogActions';
+import { SelectControl } from '@/components/ui/SelectControl';
 import { toast } from '@/stores/feedback';
 import { ConfigSpecialSelector, isConfigSelectorSpecial, PersonaQuickPreview } from './ConfigSpecialControls';
 import { DashboardTotpManager, T2ITemplateEditor } from './ConfigSpecialEditors';
@@ -594,7 +595,7 @@ function ConfigControl({
   if (metadata.options?.length) {
     const selectedIndex = metadata.options.findIndex((option) => Object.is(option, value));
     return (
-      <select
+      <SelectControl
         disabled={disabled}
         onChange={(event) => onChange(metadata.options?.[Number(event.target.value)])}
         value={selectedIndex < 0 ? '' : selectedIndex}
@@ -605,7 +606,7 @@ function ConfigControl({
             {String(labels[index] ?? option)}
           </option>
         ))}
-      </select>
+      </SelectControl>
     );
   }
 

--- a/dashboard/src/components/config/ObjectConfigControl.test.tsx
+++ b/dashboard/src/components/config/ObjectConfigControl.test.tsx
@@ -19,7 +19,8 @@ describe('ObjectConfigControl', () => {
     await user.clear(existingValue);
     await user.type(existingValue, 'after');
     await user.type(screen.getByPlaceholderText('core.common.objectEditor.newKeyLabel'), 'retries');
-    await user.selectOptions(screen.getByRole('combobox'), 'number');
+    await user.click(screen.getByRole('button', { name: 'string' }));
+    await user.click(screen.getByRole('option', { name: 'number' }));
     await user.click(screen.getByRole('button', { name: /core\.common\.add/ }));
 
     const numberValue = screen.getByPlaceholderText('core.common.objectEditor.placeholders.numberValue');

--- a/dashboard/src/components/config/ObjectConfigControl.tsx
+++ b/dashboard/src/components/config/ObjectConfigControl.tsx
@@ -5,6 +5,7 @@ import { Dialog } from '@/components/headless/Dialog';
 import { MdiIcon } from '@/components/icons/MdiIcon';
 import { Button } from '@/components/ui/Button';
 import { DialogActions } from '@/components/ui/DialogActions';
+import { SelectControl } from '@/components/ui/SelectControl';
 import { toast } from '@/stores/feedback';
 import { isConfigRecord, type ConfigItemMetadata, type ConfigRecord } from './configFormModel';
 
@@ -300,12 +301,12 @@ export function ObjectConfigControl({
             />
             <label>
               <span>{t('core.common.objectEditor.valueTypeLabel')}</span>
-              <select onChange={(event) => setNewType(event.target.value as ObjectValueType)} value={newType}>
+              <SelectControl onChange={(event) => setNewType(event.target.value as ObjectValueType)} value={newType}>
                 <option value="string">string</option>
                 <option value="number">number</option>
                 <option value="boolean">boolean</option>
                 <option value="json">json</option>
-              </select>
+              </SelectControl>
             </label>
             <button className="dynamic-editor-button--tonal" disabled={!newKey.trim()} onClick={addPair} type="button">
               <MdiIcon name="mdi-plus" />

--- a/dashboard/src/components/ui/FloatingActions.test.tsx
+++ b/dashboard/src/components/ui/FloatingActions.test.tsx
@@ -1,0 +1,26 @@
+// @vitest-environment jsdom
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { FloatingActionButton, FloatingActions } from './FloatingActions';
+
+describe('FloatingActions', () => {
+  it('portals actions to the document body with shared classes', () => {
+    render(
+      <main>
+        <FloatingActions aria-label="Page actions">
+          <FloatingActionButton aria-label="Refresh">Refresh</FloatingActionButton>
+        </FloatingActions>
+      </main>,
+    );
+
+    const action = screen.getByRole('button', { name: 'Refresh' });
+    const stack = screen.getByLabelText('Page actions');
+
+    expect(action).toHaveClass('ui-floating-action');
+    expect(action).toHaveAttribute('type', 'button');
+    expect(stack).toHaveClass('ui-floating-actions');
+    expect(stack.parentElement).toBe(document.body);
+  });
+});

--- a/dashboard/src/components/ui/FloatingActions.tsx
+++ b/dashboard/src/components/ui/FloatingActions.tsx
@@ -1,0 +1,25 @@
+import { forwardRef, type ButtonHTMLAttributes, type HTMLAttributes } from 'react';
+import { createPortal } from 'react-dom';
+
+export type FloatingActionsProps = HTMLAttributes<HTMLDivElement>;
+
+export function FloatingActions({ children, className = '', ...props }: FloatingActionsProps) {
+  if (typeof document === 'undefined') return null;
+
+  return createPortal(
+    <div className={`ui-floating-actions${className ? ` ${className}` : ''}`} {...props}>
+      {children}
+    </div>,
+    document.body,
+  );
+}
+
+export const FloatingActionButton = forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HTMLButtonElement>>(
+  function FloatingActionButton({ children, className = '', type = 'button', ...props }, ref) {
+    return (
+      <button className={`ui-floating-action${className ? ` ${className}` : ''}`} ref={ref} type={type} {...props}>
+        {children}
+      </button>
+    );
+  },
+);

--- a/dashboard/src/components/ui/Pagination.tsx
+++ b/dashboard/src/components/ui/Pagination.tsx
@@ -3,6 +3,7 @@ import { type ReactNode } from 'react';
 import { MdiIcon } from '@/components/icons/MdiIcon';
 import { paginationDefaults } from '@/config/defaults';
 import { IconButton } from './IconButton';
+import { SelectControl } from './SelectControl';
 
 export type PaginationLabels = {
   navigation: string;
@@ -45,13 +46,13 @@ export function Pagination({
       {onPageSizeChange ? (
         <label className="ui-pagination__size">
           <span>{labels.pageSize}</span>
-          <select onChange={(event) => onPageSizeChange(Number(event.target.value))} value={pageSize}>
+          <SelectControl onChange={(event) => onPageSizeChange(Number(event.target.value))} value={pageSize}>
             {pageSizeOptions.map((size) => (
               <option key={size} value={size}>
                 {size}
               </option>
             ))}
-          </select>
+          </SelectControl>
         </label>
       ) : null}
       {labels.range ? <span className="ui-pagination__range">{labels.range}</span> : null}

--- a/dashboard/src/components/ui/SelectControl.test.tsx
+++ b/dashboard/src/components/ui/SelectControl.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { ChangeEvent } from 'react';
 import { describe, expect, it, vi } from 'vitest';
@@ -14,7 +14,7 @@ describe('SelectControl', () => {
     const onChange = vi.fn((event: ChangeEvent<HTMLSelectElement>) => {
       changedValue = event.target.value;
     });
-    render(
+    const view = render(
       <SelectControl aria-label="Page size" onChange={onChange} value="10">
         <option value="10">10</option>
         <option value="20">20</option>
@@ -22,9 +22,39 @@ describe('SelectControl', () => {
     );
 
     await user.click(screen.getByRole('button', { name: 'Page size' }));
+    expect(view.container.querySelector('[role="listbox"]')).toBeNull();
+    expect(document.body.querySelector('[role="listbox"]')).not.toBeNull();
     await user.click(screen.getByRole('option', { name: '20' }));
 
     expect(onChange).toHaveBeenCalledOnce();
     expect(changedValue).toBe('20');
+  });
+
+  it('opens above the trigger when the viewport has no room below', async () => {
+    const user = userEvent.setup();
+    render(
+      <SelectControl aria-label="Page size" onChange={() => undefined} value="10">
+        <option value="10">10</option>
+        <option value="20">20</option>
+      </SelectControl>,
+    );
+    const trigger = screen.getByRole('button', { name: 'Page size' });
+    vi.spyOn(trigger, 'getBoundingClientRect').mockReturnValue({
+      bottom: 764,
+      height: 44,
+      left: 100,
+      right: 220,
+      top: 720,
+      width: 120,
+      x: 100,
+      y: 720,
+      toJSON: () => ({}),
+    });
+
+    await user.click(trigger);
+
+    const listbox = screen.getByRole('listbox', { name: 'Page size' });
+    await waitFor(() => expect(listbox.style.bottom).not.toBe(''));
+    expect(listbox.style.top).toBe('');
   });
 });

--- a/dashboard/src/components/ui/SelectControl.test.tsx
+++ b/dashboard/src/components/ui/SelectControl.test.tsx
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ChangeEvent } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SelectControl } from './SelectControl';
+
+describe('SelectControl', () => {
+  it('preserves native change handlers while using the shared menu', async () => {
+    const user = userEvent.setup();
+    let changedValue = '';
+    const onChange = vi.fn((event: ChangeEvent<HTMLSelectElement>) => {
+      changedValue = event.target.value;
+    });
+    render(
+      <SelectControl aria-label="Page size" onChange={onChange} value="10">
+        <option value="10">10</option>
+        <option value="20">20</option>
+      </SelectControl>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Page size' }));
+    await user.click(screen.getByRole('option', { name: '20' }));
+
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(changedValue).toBe('20');
+  });
+});

--- a/dashboard/src/components/ui/SelectControl.tsx
+++ b/dashboard/src/components/ui/SelectControl.tsx
@@ -1,0 +1,93 @@
+import {
+  Children,
+  Fragment,
+  isValidElement,
+  type ChangeEventHandler,
+  type OptionHTMLAttributes,
+  type ReactNode,
+  type SelectHTMLAttributes,
+  useMemo,
+  useRef,
+} from 'react';
+
+import { SelectMenu, type SelectMenuOption } from './SelectMenu';
+
+type SelectControlProps = Omit<SelectHTMLAttributes<HTMLSelectElement>, 'multiple' | 'size'> & {
+  children: ReactNode;
+};
+
+function optionLabel(children: ReactNode) {
+  return Children.toArray(children)
+    .map((child) => (typeof child === 'string' || typeof child === 'number' ? String(child) : ''))
+    .join('');
+}
+
+function collectOptions(children: ReactNode, options: SelectMenuOption[] = []) {
+  Children.forEach(children, (child) => {
+    if (!isValidElement(child)) return;
+    if (child.type === Fragment || child.type === 'optgroup') {
+      collectOptions((child.props as { children?: ReactNode }).children, options);
+      return;
+    }
+    if (child.type !== 'option') return;
+    const props = child.props as OptionHTMLAttributes<HTMLOptionElement>;
+    const name = optionLabel(props.children);
+    options.push({
+      disabled: props.disabled,
+      id: String(props.value ?? name),
+      name,
+    });
+  });
+  return options;
+}
+
+export function SelectControl({
+  'aria-label': ariaLabel,
+  children,
+  className = '',
+  defaultValue,
+  disabled,
+  onChange,
+  value,
+  ...props
+}: SelectControlProps) {
+  const nativeRef = useRef<HTMLSelectElement>(null);
+  const options = useMemo(() => collectOptions(children), [children]);
+  const selectedValue = String(value ?? defaultValue ?? options[0]?.id ?? '');
+  const selectedName = options.find((option) => option.id === selectedValue)?.name || '';
+
+  const selectValue = (nextValue: string) => {
+    const select = nativeRef.current;
+    if (!select) return;
+    const setter = Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, 'value')?.set;
+    setter?.call(select, nextValue);
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+  };
+
+  return (
+    <>
+      <select
+        {...props}
+        aria-hidden="true"
+        className="ui-select-control__native"
+        disabled={disabled}
+        onChange={onChange as ChangeEventHandler<HTMLSelectElement>}
+        ref={nativeRef}
+        tabIndex={-1}
+        value={value}
+        defaultValue={value === undefined ? defaultValue : undefined}
+      >
+        {children}
+      </select>
+      <SelectMenu
+        ariaLabel={ariaLabel || selectedName || 'Select'}
+        className={className}
+        disabled={disabled}
+        onChange={selectValue}
+        options={options}
+        placeholder={selectedName || options[0]?.name || ''}
+        value={selectedValue}
+      />
+    </>
+  );
+}

--- a/dashboard/src/components/ui/SelectMenu.tsx
+++ b/dashboard/src/components/ui/SelectMenu.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { type CSSProperties, useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 import { MdiIcon } from '@/components/icons/MdiIcon';
 
@@ -29,17 +30,58 @@ export function SelectMenu({
   value: string;
 }) {
   const [open, setOpen] = useState(false);
+  const [menuStyle, setMenuStyle] = useState<CSSProperties>({ visibility: 'hidden' });
+  const menu = useRef<HTMLDivElement>(null);
   const root = useRef<HTMLDivElement>(null);
   const selected = options.find((option) => option.id === value);
 
   useEffect(() => {
     if (!open) return undefined;
     const close = (event: PointerEvent) => {
-      if (!root.current?.contains(event.target as Node)) setOpen(false);
+      const target = event.target as Node;
+      if (!root.current?.contains(target) && !menu.current?.contains(target)) setOpen(false);
     };
     document.addEventListener('pointerdown', close);
     return () => document.removeEventListener('pointerdown', close);
   }, [open]);
+
+  useLayoutEffect(() => {
+    if (!open) return undefined;
+    const positionMenu = () => {
+      const trigger = root.current?.querySelector(':scope > button');
+      if (!(trigger instanceof HTMLElement)) return;
+      const rect = trigger.getBoundingClientRect();
+      const viewportWidth = document.documentElement.clientWidth || window.innerWidth;
+      const viewportHeight = document.documentElement.clientHeight || window.innerHeight;
+      const gap = 5;
+      const margin = 8;
+      const width = Math.min(Math.max(rect.width, 96), viewportWidth - margin * 2);
+      const left = Math.min(Math.max(rect.left, margin), viewportWidth - width - margin);
+      const measuredHeight = menu.current?.scrollHeight || Math.min(options.length * 42 + 10, 360);
+      const spaceBelow = viewportHeight - rect.bottom - margin;
+      const spaceAbove = rect.top - margin;
+      const openAbove = spaceBelow < Math.min(measuredHeight, 180) && spaceAbove > spaceBelow;
+      const availableHeight = Math.max(80, (openAbove ? spaceAbove : spaceBelow) - gap);
+
+      setMenuStyle({
+        bottom: openAbove ? viewportHeight - rect.top + gap : undefined,
+        left,
+        maxHeight: Math.min(360, availableHeight),
+        pointerEvents: 'auto',
+        top: openAbove ? undefined : rect.bottom + gap,
+        visibility: 'visible',
+        width,
+      });
+    };
+
+    positionMenu();
+    window.addEventListener('resize', positionMenu);
+    document.addEventListener('scroll', positionMenu, true);
+    return () => {
+      window.removeEventListener('resize', positionMenu);
+      document.removeEventListener('scroll', positionMenu, true);
+    };
+  }, [open, options.length]);
 
   useEffect(() => {
     if (disabled) setOpen(false);
@@ -53,37 +95,50 @@ export function SelectMenu({
         aria-label={ariaLabel}
         className={!selected ? 'is-placeholder' : ''}
         disabled={disabled}
-        onClick={() => setOpen((current) => !current)}
+        onClick={() => {
+          if (!open) setMenuStyle({ visibility: 'hidden' });
+          setOpen((current) => !current);
+        }}
         type="button"
       >
         <span>{selected ? selected.name : placeholder}</span>
         <MdiIcon name={open ? 'mdi-chevron-up' : 'mdi-chevron-down'} />
       </button>
-      {open && (
-        <div aria-label={ariaLabel} className="ui-select-menu__menu" role="listbox">
-          {options.map((option) => {
-            const image = option.image || imageForValue?.(option.id);
-            return (
-              <button
-                aria-selected={option.id === value}
-                className={option.id === value ? 'is-selected' : ''}
-                disabled={option.disabled}
-                key={option.id}
-                onClick={() => {
-                  onChange(option.id);
-                  setOpen(false);
-                }}
-                role="option"
-                type="button"
-              >
-                {image && <img alt="" src={image} />}
-                <span>{option.name}</span>
-                {option.id === value && <MdiIcon name="mdi-check" />}
-              </button>
-            );
-          })}
-        </div>
-      )}
+      {open &&
+        typeof document !== 'undefined' &&
+        createPortal(
+          <div
+            aria-label={ariaLabel}
+            className="ui-select-menu__menu ui-select-menu__menu--portaled"
+            ref={menu}
+            role="listbox"
+            style={menuStyle}
+            onPointerDown={(event) => event.stopPropagation()}
+          >
+            {options.map((option) => {
+              const image = option.image || imageForValue?.(option.id);
+              return (
+                <button
+                  aria-selected={option.id === value}
+                  className={option.id === value ? 'is-selected' : ''}
+                  disabled={option.disabled}
+                  key={option.id}
+                  onClick={() => {
+                    onChange(option.id);
+                    setOpen(false);
+                  }}
+                  role="option"
+                  type="button"
+                >
+                  {image && <img alt="" src={image} />}
+                  <span>{option.name}</span>
+                  {option.id === value && <MdiIcon name="mdi-check" />}
+                </button>
+              );
+            })}
+          </div>,
+          document.body,
+        )}
     </div>
   );
 }

--- a/dashboard/src/components/ui/SelectMenu.tsx
+++ b/dashboard/src/components/ui/SelectMenu.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useRef, useState } from 'react';
+
+import { MdiIcon } from '@/components/icons/MdiIcon';
+
+export type SelectMenuOption = {
+  disabled?: boolean;
+  id: string;
+  image?: string;
+  name: string;
+};
+
+export function SelectMenu({
+  ariaLabel,
+  className = '',
+  disabled = false,
+  imageForValue,
+  onChange,
+  options,
+  placeholder,
+  value,
+}: {
+  ariaLabel: string;
+  className?: string;
+  disabled?: boolean;
+  imageForValue?: (value: string) => string | undefined;
+  onChange: (value: string) => void;
+  options: SelectMenuOption[];
+  placeholder: string;
+  value: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const root = useRef<HTMLDivElement>(null);
+  const selected = options.find((option) => option.id === value);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const close = (event: PointerEvent) => {
+      if (!root.current?.contains(event.target as Node)) setOpen(false);
+    };
+    document.addEventListener('pointerdown', close);
+    return () => document.removeEventListener('pointerdown', close);
+  }, [open]);
+
+  useEffect(() => {
+    if (disabled) setOpen(false);
+  }, [disabled]);
+
+  return (
+    <div className={`ui-select-menu${className ? ` ${className}` : ''}`} ref={root}>
+      <button
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        aria-label={ariaLabel}
+        className={!selected ? 'is-placeholder' : ''}
+        disabled={disabled}
+        onClick={() => setOpen((current) => !current)}
+        type="button"
+      >
+        <span>{selected ? selected.name : placeholder}</span>
+        <MdiIcon name={open ? 'mdi-chevron-up' : 'mdi-chevron-down'} />
+      </button>
+      {open && (
+        <div aria-label={ariaLabel} className="ui-select-menu__menu" role="listbox">
+          {options.map((option) => {
+            const image = option.image || imageForValue?.(option.id);
+            return (
+              <button
+                aria-selected={option.id === value}
+                className={option.id === value ? 'is-selected' : ''}
+                disabled={option.disabled}
+                key={option.id}
+                onClick={() => {
+                  onChange(option.id);
+                  setOpen(false);
+                }}
+                role="option"
+                type="button"
+              >
+                {image && <img alt="" src={image} />}
+                <span>{option.name}</span>
+                {option.id === value && <MdiIcon name="mdi-check" />}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/components/ui/primitives.test.tsx
+++ b/dashboard/src/components/ui/primitives.test.tsx
@@ -9,6 +9,8 @@ import { DisclosureButton } from './DisclosureButton';
 import { DialogActions } from './DialogActions';
 import { Pagination } from './Pagination';
 import { SearchField } from './SearchField';
+import { SelectMenu } from './SelectMenu';
+import { SelectControl } from './SelectControl';
 import { StatusChip } from './StatusChip';
 
 const primitiveStyles = readFileSync(new URL('../../styles/components/_primitives.scss', import.meta.url), 'utf8');
@@ -44,6 +46,60 @@ describe('shared UI primitives', () => {
     expect(primitiveStyles).toContain(':where(.dialog-actions) > button');
     expect(primitiveStyles).toContain('.button--danger');
     expect(primitiveStyles).toContain('.button--warning');
+  });
+
+  it('gives native form controls a theme-aware baseline', () => {
+    expect(primitiveStyles).toContain("input[type='text']");
+    expect(primitiveStyles).toContain("input[type='checkbox']");
+    expect(primitiveStyles).toContain('select,');
+    expect(primitiveStyles).toContain('textarea');
+    expect(primitiveStyles).toContain('var(--astrbot-radius-control)');
+    expect(primitiveStyles).toContain(':focus');
+  });
+
+  it('styles expanded native select pickers with a themed fallback', () => {
+    expect(primitiveStyles).toContain(':where(select option:checked)');
+    expect(primitiveStyles).toContain('@supports (appearance: base-select)');
+    expect(primitiveStyles).toContain('::picker(select)');
+    expect(primitiveStyles).toContain('::picker-icon');
+    expect(primitiveStyles).toContain('::checkmark');
+    expect(primitiveStyles).toContain(':where(select:not(:disabled))');
+    expect(primitiveStyles).toContain(':where(select:active, select:focus, select:focus-visible, select:open)');
+    expect(primitiveStyles).toContain('border-color: transparent');
+  });
+
+  it('shares the custom select menu used by feature pages', () => {
+    const markup = renderToStaticMarkup(
+      <SelectMenu
+        ariaLabel="Computer access"
+        onChange={() => undefined}
+        options={[
+          { id: 'local', name: 'Allow' },
+          { id: 'none', name: 'Deny' },
+        ]}
+        placeholder="Choose access"
+        value="none"
+      />,
+    );
+
+    expect(markup).toContain('ui-select-menu');
+    expect(markup).toContain('aria-haspopup="listbox"');
+    expect(markup).toContain('Deny');
+    expect(markup).not.toContain('Choose access');
+  });
+
+  it('adapts native option markup to the shared select menu', () => {
+    const markup = renderToStaticMarkup(
+      <SelectControl aria-label="Page size" value={20} onChange={() => undefined}>
+        <option value={10}>10</option>
+        <option value={20}>20</option>
+      </SelectControl>,
+    );
+
+    expect(markup).toContain('ui-select-control__native');
+    expect(markup).toContain('aria-label="Page size"');
+    expect(markup).toContain('aria-haspopup="listbox"');
+    expect(markup).toContain('>20<');
   });
 
   it('gives search and status controls consistent accessible markup', () => {

--- a/dashboard/src/routes/chat/ChatComposer.test.tsx
+++ b/dashboard/src/routes/chat/ChatComposer.test.tsx
@@ -32,7 +32,9 @@ describe('ChatComposer', () => {
       />,
     );
 
-    expect(markup).toContain('<select aria-label="Configuration" disabled=""');
+    expect(markup).toContain('aria-haspopup="listbox"');
+    expect(markup).toContain('aria-label="Configuration"');
+    expect(markup).toContain('disabled=""');
     expect(markup).toContain('<textarea aria-label=""');
     expect(markup).not.toContain('<textarea aria-label="" disabled=""');
   });

--- a/dashboard/src/routes/chat/ChatComposer.tsx
+++ b/dashboard/src/routes/chat/ChatComposer.tsx
@@ -14,6 +14,7 @@ import {
 import { useTranslation } from 'react-i18next';
 
 import { MdiIcon } from '@/components/icons/MdiIcon';
+import { SelectControl } from '@/components/ui/SelectControl';
 
 import './ChatComposer.scss';
 
@@ -445,7 +446,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
                 <label className="chat-composer-v2__config">
                   <MdiIcon name="mdi-tune" />
                   <span>{labels.config}</span>
-                  <select
+                  <SelectControl
                     aria-label={labels.config}
                     disabled={actionsDisabled}
                     onChange={(event) => onConfigChange(event.target.value)}
@@ -456,7 +457,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
                         {config.name}
                       </option>
                     ))}
-                  </select>
+                  </SelectControl>
                   {configs.find((config) => config.id === configId)?.description && (
                     <small>{configs.find((config) => config.id === configId)?.description}</small>
                   )}

--- a/dashboard/src/routes/chat/ChatMessageList.test.tsx
+++ b/dashboard/src/routes/chat/ChatMessageList.test.tsx
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { renderStatic } from '@/test/render';
+import { ChatMessageList } from './ChatMessageList';
+
+describe('ChatMessageList', () => {
+  it('renders one lightweight thinking indicator while a reply is starting', () => {
+    const markup = renderStatic(
+      <ChatMessageList
+        labels={{ loading: 'Thinking...', running: 'Running' }}
+        messages={[
+          {
+            id: 'pending-reply',
+            content: { type: 'bot', message: [], isLoading: true },
+          },
+        ]}
+        streaming
+      />,
+    );
+
+    expect(markup.match(/ab-chat-message-spinner/g)).toHaveLength(1);
+    expect(markup).toContain('<span class="ab-chat-message-loading">Thinking...</span>');
+    expect(markup).not.toContain('>Running<');
+  });
+});

--- a/dashboard/src/routes/chat/ChatMessageList.tsx
+++ b/dashboard/src/routes/chat/ChatMessageList.tsx
@@ -44,6 +44,7 @@ export type ChatMessageLabels = {
   replyTo: string;
   cachedTokens: string;
   inputTokens: string;
+  loading: string;
   outputTokens: string;
   ttft: string;
   duration: string;
@@ -127,6 +128,7 @@ export function ChatMessageList({
       duration: t('features.chat.stats.duration'),
       edit: t('core.common.edit'),
       inputTokens: t('features.chat.stats.inputTokens'),
+      loading: t('features.chat.message.loading'),
       outputTokens: t('features.chat.stats.outputTokens'),
       reasoning: t('features.chat.reasoning.thinking'),
       references: t('features.chat.refs.title'),
@@ -251,9 +253,7 @@ export function ChatMessageList({
                       </div>
                     </div>
                   ) : message.content.isLoading && bubbleParts.length === 0 ? (
-                    <span className="ab-chat-message-loading">
-                      <span className="ab-chat-message-spinner" /> {labels.running}
-                    </span>
+                    <span className="ab-chat-message-loading">{labels.loading}</span>
                   ) : (
                     bubbleParts.map((part, partIndex) => (
                       <MessagePart

--- a/dashboard/src/routes/chat/ChatPage.test.tsx
+++ b/dashboard/src/routes/chat/ChatPage.test.tsx
@@ -6,6 +6,7 @@ import { Link, Route, Routes, useLocation } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ApiError } from '@/api/http';
+import { selectedModelPreference, selectedProviderPreference } from '@/config/preferences';
 import {
   createChatSession,
   getChatSession,
@@ -36,6 +37,7 @@ describe('ChatPage', () => {
   beforeEach(() => {
     resetChatStreamRegistry();
     vi.resetAllMocks();
+    localStorage.clear();
     vi.mocked(listChatSessions).mockResolvedValue(mockApiResponse({ sessions: [] }));
     vi.mocked(listChatProjects).mockResolvedValue(mockApiResponse({ projects: [] }));
     vi.mocked(listProviders).mockResolvedValue(mockApiResponse({ model_metadata: {}, providers: [] }));
@@ -99,6 +101,37 @@ describe('ChatPage', () => {
         kind: 'send',
         message: [{ text: 'Hello AstrBot', type: 'plain' }],
         sessionId: 'session-new',
+      }),
+      expect.any(AbortSignal),
+      expect.any(Object),
+    );
+  });
+
+  it('replaces a removed persisted provider before sending the first message', async () => {
+    const user = userEvent.setup();
+    localStorage.setItem('selectedProvider', 'removed-provider');
+    localStorage.setItem('selectedProviderModel', 'removed-model');
+    vi.mocked(listProviders).mockResolvedValue(
+      mockApiResponse({
+        model_metadata: {},
+        providers: [{ enable: true, id: 'available-provider', model: 'available-model' }],
+      }),
+    );
+    vi.mocked(createChatSession).mockResolvedValue(mockApiResponse({ session_id: 'session-new' }));
+
+    renderRoute(<ChatPage />, { route: '/chat' });
+
+    const composer = await screen.findByPlaceholderText('features.chat.input.placeholder');
+    await waitFor(() => expect(selectedProviderPreference.read()).toBe('available-provider'));
+    expect(selectedModelPreference.read()).toBe('available-model');
+    await user.type(composer, 'Use the available provider');
+    await user.click(screen.getByRole('button', { name: 'features.chat.input.send' }));
+
+    await waitFor(() => expect(runChatStream).toHaveBeenCalled());
+    expect(runChatStream).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selectedModel: 'available-model',
+        selectedProvider: 'available-provider',
       }),
       expect.any(AbortSignal),
       expect.any(Object),

--- a/dashboard/src/routes/chat/ChatPage.test.tsx
+++ b/dashboard/src/routes/chat/ChatPage.test.tsx
@@ -21,6 +21,7 @@ import {
 import { deferred } from '@/test/async';
 import { mockApiResponse, renderRoute } from '@/test/render';
 import { runChatStream } from './chatTransport';
+import { chatStreamRegistry, resetChatStreamRegistry } from './chatStreamRegistry';
 import ChatPage from './ChatPage';
 
 vi.mock('@/api/openapi');
@@ -33,6 +34,7 @@ function CurrentPath() {
 
 describe('ChatPage', () => {
   beforeEach(() => {
+    resetChatStreamRegistry();
     vi.resetAllMocks();
     vi.mocked(listChatSessions).mockResolvedValue(mockApiResponse({ sessions: [] }));
     vi.mocked(listChatProjects).mockResolvedValue(mockApiResponse({ projects: [] }));
@@ -133,5 +135,53 @@ describe('ChatPage', () => {
 
     await waitFor(() => expect(screen.queryByText('stale response')).not.toBeInTheDocument());
     expect(screen.getByText('newest response')).toBeInTheDocument();
+  });
+
+  it('keeps an active chat stream alive while navigating to another dashboard page', async () => {
+    const user = userEvent.setup();
+    const stream = deferred<void>();
+    let streamSignal: AbortSignal | undefined;
+    let deliverPayload: ((payload: unknown) => void) | undefined;
+    vi.mocked(getChatSession).mockResolvedValue(mockApiResponse({ history: [] }));
+    vi.mocked(runChatStream).mockImplementation(async (_action, signal, callbacks) => {
+      streamSignal = signal;
+      deliverPayload = callbacks.onPayload;
+      await stream.promise;
+    });
+
+    renderRoute(
+      <>
+        <Link to="/logs">Open logs</Link>
+        <Link to="/chat/session-1">Return to chat</Link>
+        <Routes>
+          <Route element={<ChatPage />} path="/chat/:conversationId" />
+          <Route element={<div>Logs page</div>} path="/logs" />
+        </Routes>
+      </>,
+      { route: '/chat/session-1' },
+    );
+
+    const composer = await screen.findByPlaceholderText('features.chat.input.placeholder');
+    await user.type(composer, 'Keep generating');
+    await user.click(screen.getByRole('button', { name: 'features.chat.input.send' }));
+    await waitFor(() => expect(runChatStream).toHaveBeenCalled());
+    expect(deliverPayload).toEqual(expect.any(Function));
+    expect(chatStreamRegistry.messageCache['session-1']).toHaveLength(2);
+
+    await user.click(screen.getByRole('link', { name: 'Open logs' }));
+    expect(await screen.findByText('Logs page')).toBeInTheDocument();
+    expect(streamSignal?.aborted).toBe(false);
+
+    await user.click(screen.getByRole('link', { name: 'Return to chat' }));
+    await screen.findByPlaceholderText('features.chat.input.placeholder');
+    expect(chatStreamRegistry.messageCache['session-1']).toHaveLength(2);
+    expect(await screen.findByText('Keep generating')).toBeInTheDocument();
+    deliverPayload?.({ type: 'plain', data: 'Still connected', streaming: true });
+    expect(chatStreamRegistry.messageCache['session-1'][1].content.message).toContainEqual({
+      text: 'Still connected',
+      type: 'plain',
+    });
+
+    stream.resolve();
   });
 });

--- a/dashboard/src/routes/chat/ChatPage.tsx
+++ b/dashboard/src/routes/chat/ChatPage.tsx
@@ -429,14 +429,17 @@ export default function ChatPage({ chatbox = false }: ChatPageProps) {
       setProviderMetadata(
         isObject(envelope.model_metadata) ? (envelope.model_metadata as Record<string, JsonObject>) : {},
       );
-      const selected = items.find((item) => item.id === provider);
-      if (selected?.model) setModel(selected.model);
+      const selected = items.find((item) => item.id === provider) || items[0];
+      const selectedProvider = selected?.id || '';
+      const selectedModel = selected?.model || '';
+      if (provider !== selectedProvider) setProvider(selectedProvider);
+      setModel(selectedModel);
     } catch (cause) {
       toast.error(errorMessage(cause, 'Failed to load models.'));
     } finally {
       setProvidersLoading(false);
     }
-  }, [provider]);
+  }, [provider, setModel, setProvider]);
 
   const loadMessages = useCallback(async () => {
     const requestId = ++messageLoadRequestRef.current;
@@ -994,8 +997,8 @@ export default function ChatPage({ chatbox = false }: ChatPageProps) {
           enableStreaming: streaming,
           message: messagePayload,
           messageId,
-          selectedModel: providerOverrideEnabled ? model : '',
-          selectedProvider: providerOverrideEnabled ? provider : '',
+          selectedModel: providerOverrideEnabled ? currentProvider?.model || '' : '',
+          selectedProvider: providerOverrideEnabled ? currentProvider?.id || '' : '',
           sessionId,
           transport: transportMode,
         },
@@ -1034,7 +1037,11 @@ export default function ChatPage({ chatbox = false }: ChatPageProps) {
     }
   };
 
-  const regenerate = async (target: ChatRecord, selectedProvider = provider, selectedModel = model) => {
+  const regenerate = async (
+    target: ChatRecord,
+    selectedProvider = currentProvider?.id || '',
+    selectedModel = currentProvider?.model || '',
+  ) => {
     if (!conversationId || target.id == null || sending) return;
     const targetId = String(target.id);
     const index = messages.findIndex((item) => item === target || String(item.id) === targetId);
@@ -1133,8 +1140,8 @@ export default function ChatPage({ chatbox = false }: ChatPageProps) {
           enableStreaming: streaming,
           llmCheckpointId: String(source.llm_checkpoint_id || ''),
           message: serializeChatParts(source.content.message),
-          selectedModel: providerOverrideEnabled ? model : '',
-          selectedProvider: providerOverrideEnabled ? provider : '',
+          selectedModel: providerOverrideEnabled ? currentProvider?.model || '' : '',
+          selectedProvider: providerOverrideEnabled ? currentProvider?.id || '' : '',
           sessionId: conversationId,
         },
         abort.signal,
@@ -1284,8 +1291,8 @@ export default function ChatPage({ chatbox = false }: ChatPageProps) {
           kind: 'thread',
           enableStreaming: streaming,
           message: [{ type: 'plain', text }],
-          selectedModel: providerOverrideEnabled ? model : '',
-          selectedProvider: providerOverrideEnabled ? provider : '',
+          selectedModel: providerOverrideEnabled ? currentProvider?.model || '' : '',
+          selectedProvider: providerOverrideEnabled ? currentProvider?.id || '' : '',
           threadId,
         },
         abort.signal,

--- a/dashboard/src/routes/chat/ChatPage.tsx
+++ b/dashboard/src/routes/chat/ChatPage.tsx
@@ -67,6 +67,7 @@ import {
 } from './configBinding';
 import { createStreamRenderScheduler } from './streamRenderScheduler';
 import { runChatStream } from './chatTransport';
+import { chatStreamRegistry } from './chatStreamRegistry';
 import { useChatPreferences } from './useChatPreferences';
 import {
   agentRunnerTypeFromProfile,
@@ -187,8 +188,8 @@ export default function ChatPage({ chatbox = false }: ChatPageProps) {
   const agentRunnerCacheRef = useRef(new Map<string, string>());
   const agentRunnerRequestsRef = useRef(new Map<string, Promise<string>>());
   const agentRunnerRequestIdRef = useRef(0);
-  const activeStreamsRef = useRef<Map<string, AbortController>>(new Map());
-  const messageCacheRef = useRef<Record<string, ChatRecord[]>>({});
+  const activeStreamsRef = useRef(chatStreamRegistry.activeStreams);
+  const messageCacheRef = useRef(chatStreamRegistry.messageCache);
   const activeConversationRef = useRef(conversationId);
   const audioRecorderRef = useRef(new AudioRecorder());
   const activeSessionRef = useRef('');
@@ -554,10 +555,17 @@ export default function ChatPage({ chatbox = false }: ChatPageProps) {
     void loadMessages();
   }, [conversationId, loadMessages]);
 
+  useEffect(() => {
+    if (!conversationId) return;
+    return chatStreamRegistry.subscribe(conversationId, () => {
+      const cached = messageCacheRef.current[conversationId];
+      if (cached) setMessages([...cached]);
+      markSessionRunning(conversationId, activeStreamsRef.current.has(conversationId));
+    });
+  }, [conversationId, markSessionRunning]);
+
   useEffect(
     () => () => {
-      activeStreamsRef.current.forEach((controller) => controller.abort());
-      activeStreamsRef.current.clear();
       audioRecorderRef.current.cancel();
       if (settingsSubmenuTimer.current != null) window.clearTimeout(settingsSubmenuTimer.current);
       if (messageScrollFrame.current != null) window.cancelAnimationFrame(messageScrollFrame.current);
@@ -965,6 +973,7 @@ export default function ChatPage({ chatbox = false }: ChatPageProps) {
       abort = new AbortController();
       abortRef.current = abort;
       activeStreamsRef.current.set(sessionId, abort);
+      chatStreamRegistry.notify(sessionId);
       activeSessionRef.current = sessionId;
       const messagePayload = serializeChatParts(outgoing);
       const applyPayloads = (payloads: unknown[]) => {
@@ -976,8 +985,7 @@ export default function ChatPage({ chatbox = false }: ChatPageProps) {
         if (changed) streamRender?.schedule();
       };
       streamRender = createStreamRenderScheduler(() => {
-        const cached = messageCacheRef.current[sessionId];
-        if (activeConversationRef.current === sessionId && cached?.includes(bot!)) setMessages([...cached]);
+        chatStreamRegistry.notify(sessionId);
       });
       await runChatStream(
         {
@@ -1012,12 +1020,12 @@ export default function ChatPage({ chatbox = false }: ChatPageProps) {
           streamRender.schedule();
           streamRender.flush();
         } else {
-          const cached = messageCacheRef.current[sessionId];
-          if (activeConversationRef.current === sessionId && cached?.includes(bot)) setMessages([...cached]);
+          chatStreamRegistry.notify(sessionId);
         }
       }
       if (!abort || abortRef.current === abort) abortRef.current = null;
       if (sessionId) activeStreamsRef.current.delete(sessionId);
+      if (sessionId) chatStreamRegistry.notify(sessionId);
       if (!sessionId || activeSessionRef.current === sessionId) activeSessionRef.current = '';
       if (sessionId) markSessionRunning(sessionId, false);
       setPendingSessionSending(false);
@@ -1046,11 +1054,11 @@ export default function ChatPage({ chatbox = false }: ChatPageProps) {
     setError('');
     const abort = new AbortController();
     const streamRender = createStreamRenderScheduler(() => {
-      const cached = messageCacheRef.current[conversationId];
-      if (activeConversationRef.current === conversationId && cached?.includes(regenerated)) setMessages([...cached]);
+      chatStreamRegistry.notify(conversationId);
     });
     abortRef.current = abort;
     activeStreamsRef.current.set(conversationId, abort);
+    chatStreamRegistry.notify(conversationId);
     activeSessionRef.current = conversationId;
     try {
       await runChatStream(
@@ -1083,6 +1091,7 @@ export default function ChatPage({ chatbox = false }: ChatPageProps) {
       streamRender.flush();
       if (abortRef.current === abort) abortRef.current = null;
       activeStreamsRef.current.delete(conversationId);
+      chatStreamRegistry.notify(conversationId);
       if (activeSessionRef.current === conversationId) activeSessionRef.current = '';
       markSessionRunning(conversationId, false);
     }
@@ -1112,8 +1121,9 @@ export default function ChatPage({ chatbox = false }: ChatPageProps) {
     markSessionRunning(conversationId, true);
     const abort = new AbortController();
     activeStreamsRef.current.set(conversationId, abort);
+    chatStreamRegistry.notify(conversationId);
     const scheduler = createStreamRenderScheduler(() => {
-      if (activeConversationRef.current === conversationId) setMessages([...messageCacheRef.current[conversationId]]);
+      chatStreamRegistry.notify(conversationId);
     });
     try {
       await runChatStream(
@@ -1145,6 +1155,7 @@ export default function ChatPage({ chatbox = false }: ChatPageProps) {
       scheduler.schedule();
       scheduler.flush();
       activeStreamsRef.current.delete(conversationId);
+      chatStreamRegistry.notify(conversationId);
       markSessionRunning(conversationId, false);
     }
   };
@@ -1353,6 +1364,7 @@ export default function ChatPage({ chatbox = false }: ChatPageProps) {
     if (sessionId) await stopChatSession({ path: { session_id: sessionId } }).catch(() => undefined);
     if (sessionId) {
       activeStreamsRef.current.delete(sessionId);
+      chatStreamRegistry.notify(sessionId);
       markSessionRunning(sessionId, false);
     }
     setPendingSessionSending(false);

--- a/dashboard/src/routes/chat/ChatPage.tsx
+++ b/dashboard/src/routes/chat/ChatPage.tsx
@@ -1609,7 +1609,7 @@ export default function ChatPage({ chatbox = false }: ChatPageProps) {
                               </button>
                             </span>
                             {runningSessionIds.has(session.session_id) && (
-                              <MdiIcon className="chat-project-session-progress" name="mdi-loading" />
+                              <span aria-hidden="true" className="chat-project-session-progress" />
                             )}
                           </div>
                         ))
@@ -1629,7 +1629,7 @@ export default function ChatPage({ chatbox = false }: ChatPageProps) {
                 <button onClick={() => selectSession(session.session_id)} type="button">
                   <span>{session.display_name || session.session_id}</span>
                   {runningSessionIds.has(session.session_id) && (
-                    <MdiIcon className="chat-session-progress" name="mdi-loading" />
+                    <span aria-hidden="true" className="chat-session-progress" />
                   )}
                 </button>
                 <div>

--- a/dashboard/src/routes/chat/ChatProjectDialog.tsx
+++ b/dashboard/src/routes/chat/ChatProjectDialog.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { Dialog } from '@/components/headless/Dialog';
 import { Button } from '@/components/ui/Button';
 import { DialogActions } from '@/components/ui/DialogActions';
+import { SelectControl } from '@/components/ui/SelectControl';
 
 export type ChatProjectForm = {
   description: string;
@@ -109,7 +110,7 @@ export function ChatProjectDialog({
         <div className="chat-project-dialog__divider" />
         <label className="chat-project-field">
           <span>{t('features.chat.project.workspace.type')}</span>
-          <select
+          <SelectControl
             aria-label={t('features.chat.project.workspace.type')}
             onChange={(event) => set('workspace_type', event.target.value as ChatProjectForm['workspace_type'])}
             value={form.workspace_type}
@@ -117,7 +118,7 @@ export function ChatProjectDialog({
             <option value="project">{t('features.chat.project.workspace.project')}</option>
             <option value="session">{t('features.chat.project.workspace.session')}</option>
             <option value="custom">{t('features.chat.project.workspace.custom')}</option>
-          </select>
+          </SelectControl>
         </label>
         {form.workspace_type === 'custom' && (
           <label className="chat-project-field">

--- a/dashboard/src/routes/chat/chatStreamRegistry.ts
+++ b/dashboard/src/routes/chat/chatStreamRegistry.ts
@@ -1,0 +1,34 @@
+import type { ChatRecord } from './model';
+
+type StreamListener = () => void;
+
+const activeStreams = new Map<string, AbortController>();
+const messageCache: Record<string, ChatRecord[]> = {};
+const listeners = new Map<string, Set<StreamListener>>();
+
+export const chatStreamRegistry = {
+  activeStreams,
+  messageCache,
+
+  notify(sessionId: string) {
+    listeners.get(sessionId)?.forEach((listener) => listener());
+  },
+
+  subscribe(sessionId: string, listener: StreamListener) {
+    const sessionListeners = listeners.get(sessionId) ?? new Set<StreamListener>();
+    sessionListeners.add(listener);
+    listeners.set(sessionId, sessionListeners);
+    listener();
+    return () => {
+      sessionListeners.delete(listener);
+      if (!sessionListeners.size) listeners.delete(sessionId);
+    };
+  },
+};
+
+export function resetChatStreamRegistry() {
+  activeStreams.forEach((controller) => controller.abort());
+  activeStreams.clear();
+  Object.keys(messageCache).forEach((sessionId) => delete messageCache[sessionId]);
+  listeners.clear();
+}

--- a/dashboard/src/routes/configuration/ApiKeySettingsSection.tsx
+++ b/dashboard/src/routes/configuration/ApiKeySettingsSection.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 
 import { createApiKey, deleteApiKey, listApiKeys, revokeApiKey } from '@/api/openapi';
 import { MdiIcon } from '@/components/icons/MdiIcon';
+import { SelectControl } from '@/components/ui/SelectControl';
 import { externalLinks } from '@/config/links';
 import { useBrowserCapabilities } from '@/platform/BrowserCapabilitiesProvider';
 import { confirmAction, toast } from '@/stores/feedback';
@@ -152,7 +153,7 @@ export function ApiKeySettingsSection() {
           placeholder={t(`${prefix}.name`)}
           value={name}
         />
-        <select
+        <SelectControl
           aria-label={t(`${prefix}.expiresInDays`)}
           disabled={creating}
           onChange={(event) => setExpiry(event.target.value === 'permanent' ? 'permanent' : Number(event.target.value))}
@@ -163,7 +164,7 @@ export function ApiKeySettingsSection() {
           <option value={30}>{t(`${prefix}.expiryOptions.day30`)}</option>
           <option value={90}>{t(`${prefix}.expiryOptions.day90`)}</option>
           <option value="permanent">{t(`${prefix}.expiryOptions.permanent`)}</option>
-        </select>
+        </SelectControl>
         <button disabled={creating || !name.trim() || !scopes.length} onClick={() => void create()} type="button">
           <MdiIcon className={creating ? 'mdi-spin' : ''} name={creating ? 'mdi-loading' : 'mdi-key-plus'} />
           {t(`${prefix}.create`)}

--- a/dashboard/src/routes/configuration/ConfigPage.tsx
+++ b/dashboard/src/routes/configuration/ConfigPage.tsx
@@ -17,6 +17,7 @@ import { DEFAULT_CONFIG_ID } from '@/config/defaults';
 import { MetadataConfigEditor } from '@/components/config/DynamicConfigForm';
 import { isConfigRecord, type ConfigRecord } from '@/components/config/configFormModel';
 import { MdiIcon } from '@/components/icons/MdiIcon';
+import { SelectControl } from '@/components/ui/SelectControl';
 import { Dialog, DialogClose } from '@/components/headless/Dialog';
 import { confirmAction, toast } from '@/stores/feedback';
 import { JsonConfigDialog, LoadingState } from './ConfigurationUi';
@@ -295,7 +296,7 @@ export default function ConfigPage() {
         <div className="visual-config-toolbar">
           <label className="visual-config-profile">
             <span>{t('features.config.configSelection.selectConfig')}</span>
-            <select
+            <SelectControl
               aria-label={t('features.config.configSelection.selectConfig')}
               onChange={(event) => void chooseProfile(event.target.value)}
               value={selected}
@@ -306,7 +307,7 @@ export default function ConfigPage() {
                 </option>
               ))}
               <option value="__manage__">{t('features.config.configManagement.manageConfigs')}</option>
-            </select>
+            </SelectControl>
           </label>
           <label className="visual-config-search">
             <MdiIcon name="mdi-magnify" />

--- a/dashboard/src/routes/configuration/CronPage.tsx
+++ b/dashboard/src/routes/configuration/CronPage.tsx
@@ -15,6 +15,7 @@ import { MdiIcon } from '@/components/icons/MdiIcon';
 import { Menu, MenuItem } from '@/components/headless/Menu';
 import { Button, DialogCancel } from '@/components/ui/Button';
 import { DialogActions } from '@/components/ui/DialogActions';
+import { SelectControl } from '@/components/ui/SelectControl';
 import { toast } from '@/stores/feedback';
 import {
   buildCronExpression,
@@ -453,7 +454,7 @@ export default function CronPage() {
               </label>
               <label>
                 <MdiIcon name="mdi-send-outline" />
-                <select onChange={(event) => setTargetFilter(event.target.value)} value={targetFilter}>
+                <SelectControl onChange={(event) => setTargetFilter(event.target.value)} value={targetFilter}>
                   <option value="">{k('filters.umo')}</option>
                   {jobs.some((job) => !jobSession(job)) && (
                     <option value={NO_DELIVERY_TARGET}>{k('filters.noDeliveryTarget')}</option>
@@ -463,7 +464,7 @@ export default function CronPage() {
                       {target}
                     </option>
                   ))}
-                </select>
+                </SelectControl>
               </label>
             </div>
           )}
@@ -617,7 +618,7 @@ export default function CronPage() {
           <div className="cron-form__schedule">
             <label>
               <span>{k('form.scheduleMode')}</span>
-              <select
+              <SelectControl
                 onChange={(event) => updateForm('scheduleMode', event.target.value as ScheduleMode)}
                 value={form.scheduleMode}
               >
@@ -626,7 +627,7 @@ export default function CronPage() {
                     {k(`form.scheduleModes.${mode}`)}
                   </option>
                 ))}
-              </select>
+              </SelectControl>
             </label>
             <ScheduleFields form={form} k={k} updateForm={updateForm} />
           </div>
@@ -680,7 +681,7 @@ function ScheduleFields({ form, k, updateForm }: ScheduleFieldsProps) {
         </label>
         <label>
           <span>{k('form.intervalUnit')}</span>
-          <select
+          <SelectControl
             onChange={(event) => updateForm('intervalUnit', event.target.value as IntervalUnit)}
             value={form.intervalUnit}
           >
@@ -689,7 +690,7 @@ function ScheduleFields({ form, k, updateForm }: ScheduleFieldsProps) {
                 {k(`form.intervalUnits.${unit}`)}
               </option>
             ))}
-          </select>
+          </SelectControl>
         </label>
       </div>
     );
@@ -705,13 +706,16 @@ function ScheduleFields({ form, k, updateForm }: ScheduleFieldsProps) {
       <div className="cron-form__inline">
         <label>
           <span>{k('form.weeklyDay')}</span>
-          <select onChange={(event) => updateForm('weeklyDay', Number(event.target.value))} value={form.weeklyDay}>
+          <SelectControl
+            onChange={(event) => updateForm('weeklyDay', Number(event.target.value))}
+            value={form.weeklyDay}
+          >
             {['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'].map((day, index) => (
               <option key={day} value={index}>
                 {k(`form.weekdays.${day}`)}
               </option>
             ))}
-          </select>
+          </SelectControl>
         </label>
         <label>
           <span>{k('form.weeklyTime')}</span>

--- a/dashboard/src/routes/configuration/PlatformPage.tsx
+++ b/dashboard/src/routes/configuration/PlatformPage.tsx
@@ -21,6 +21,8 @@ import type { ConfigGroupMetadata, ConfigRecord } from '@/components/config/conf
 import { Dialog, DialogClose } from '@/components/headless/Dialog';
 import { MdiIcon } from '@/components/icons/MdiIcon';
 import { DisclosureButton } from '@/components/ui/DisclosureButton';
+import { SelectMenu } from '@/components/ui/SelectMenu';
+import { SelectControl } from '@/components/ui/SelectControl';
 import { DEFAULT_CONFIG_ID } from '@/config/defaults';
 import { useBrowserCapabilities } from '@/platform/BrowserCapabilitiesProvider';
 import { i18n } from '@/i18n';
@@ -499,73 +501,6 @@ function PlatformCard({
   );
 }
 
-function PlatformSelect({
-  ariaLabel,
-  imageForValue,
-  onChange,
-  options,
-  placeholder,
-  value,
-}: {
-  ariaLabel: string;
-  imageForValue?: (value: string) => string | undefined;
-  onChange: (value: string) => void;
-  options: ConfigProfileOption[];
-  placeholder: string;
-  value: string;
-}) {
-  const [open, setOpen] = useState(false);
-  const root = useRef<HTMLDivElement>(null);
-  const selected = options.find((option) => option.id === value);
-  useEffect(() => {
-    if (!open) return undefined;
-    const close = (event: PointerEvent) => {
-      if (!root.current?.contains(event.target as Node)) setOpen(false);
-    };
-    document.addEventListener('pointerdown', close);
-    return () => document.removeEventListener('pointerdown', close);
-  }, [open]);
-  return (
-    <div className="platform-select" ref={root}>
-      <button
-        aria-expanded={open}
-        aria-haspopup="listbox"
-        aria-label={ariaLabel}
-        className={!selected ? 'is-placeholder' : ''}
-        onClick={() => setOpen((current) => !current)}
-        type="button"
-      >
-        <span>{selected ? selected.name : placeholder}</span>
-        <MdiIcon name={open ? 'mdi-chevron-up' : 'mdi-chevron-down'} />
-      </button>
-      {open && (
-        <div className="platform-select__menu" role="listbox">
-          {options.map((option) => {
-            const image = imageForValue?.(option.id);
-            return (
-              <button
-                aria-selected={option.id === value}
-                className={option.id === value ? 'is-selected' : ''}
-                key={option.id}
-                onClick={() => {
-                  onChange(option.id);
-                  setOpen(false);
-                }}
-                role="option"
-                type="button"
-              >
-                {image && <img alt="" src={image} />}
-                <span>{option.name}</span>
-                {option.id === value && <MdiIcon name="mdi-check" />}
-              </button>
-            );
-          })}
-        </div>
-      )}
-    </div>
-  );
-}
-
 function PlatformEditor({
   configMode,
   configProfiles,
@@ -662,7 +597,7 @@ function PlatformEditor({
                 <p>{t('createDialog.step1Hint')}</p>
                 {!editing && (
                   <div className="platform-editor__type">
-                    <PlatformSelect
+                    <SelectMenu
                       ariaLabel={t('createDialog.platformTypeLabel')}
                       imageForValue={(key) => platformLogo(String(templates[key]?.type || key), templates[key])}
                       onChange={onTypeChange}
@@ -776,7 +711,7 @@ function PlatformEditor({
                         <div className="platform-editor__profile-select">
                           <label>
                             <span>{t('createDialog.selectConfigLabel')}</span>
-                            <PlatformSelect
+                            <SelectMenu
                               ariaLabel={t('createDialog.selectConfigLabel')}
                               onChange={onSelectedConfigChange}
                               options={configProfiles}
@@ -894,7 +829,7 @@ function PlatformRoutesEditor({
       ) : (
         routes.map((route, index) => (
           <div className="platform-route-row" key={`${index}-${route.messageType}-${route.sessionId}`}>
-            <select
+            <SelectControl
               aria-label={t('createDialog.routeSource.selectPlaceholder')}
               onChange={(event) => {
                 const parsed = parsePlatformUmo(event.target.value);
@@ -913,8 +848,8 @@ function PlatformRoutesEditor({
                   {umo}
                 </option>
               ))}
-            </select>
-            <select
+            </SelectControl>
+            <SelectControl
               aria-label={t('createDialog.routeTableHeaders.source')}
               onChange={(event) => update(index, { messageType: event.target.value, sourceUmo: '' })}
               value={route.messageType}
@@ -922,14 +857,14 @@ function PlatformRoutesEditor({
               <option value="*">{t('createDialog.messageTypeOptions.all')}</option>
               <option value="GroupMessage">{t('createDialog.messageTypeOptions.group')}</option>
               <option value="FriendMessage">{t('createDialog.messageTypeOptions.friend')}</option>
-            </select>
+            </SelectControl>
             <input
               aria-label={t('createDialog.sessionIdPlaceholder')}
               onChange={(event) => update(index, { sessionId: event.target.value || '*', sourceUmo: '' })}
               placeholder={t('createDialog.sessionIdPlaceholder')}
               value={route.sessionId}
             />
-            <select
+            <SelectControl
               aria-label={t('createDialog.routeTableHeaders.config')}
               onChange={(event) => update(index, { configId: event.target.value })}
               value={route.configId}
@@ -939,7 +874,7 @@ function PlatformRoutesEditor({
                   {profile.name}
                 </option>
               ))}
-            </select>
+            </SelectControl>
             <div className="platform-route-row__actions">
               <button disabled={index === 0} onClick={() => move(index, -1)} type="button">
                 <MdiIcon name="mdi-arrow-up" />

--- a/dashboard/src/routes/extensions/ExtensionPage.tsx
+++ b/dashboard/src/routes/extensions/ExtensionPage.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
 import {
@@ -28,6 +27,7 @@ import { Markdown } from '@/components/content/Markdown';
 import { ConfigGroup } from '@/components/config/DynamicConfigForm';
 import type { ConfigGroupMetadata } from '@/components/config/configFormModel';
 import { Dialog } from '@/components/headless/Dialog';
+import { FloatingActionButton, FloatingActions } from '@/components/ui/FloatingActions';
 import { MdiIcon } from '@/components/icons/MdiIcon';
 import { AsyncState } from '@/components/ui/AsyncState';
 import { FormDialog } from '@/components/ui/FormDialog';
@@ -750,33 +750,24 @@ function InstalledPlugins() {
           <p>{e('empty.noPluginsDesc')}</p>
         </div>
       )}
-      {typeof document !== 'undefined' &&
-        createPortal(
-          <div className="extension-installed__fabs">
-            <button
-              aria-label={e('buttons.updateAll')}
-              disabled={loading || updatingAll}
-              onClick={() => void updateAll()}
-              title={e('buttons.updateAll')}
-              type="button"
-            >
-              <MdiIcon
-                className={updatingAll ? 'mdi-spin' : undefined}
-                name={updatingAll ? 'mdi-loading' : 'mdi-update'}
-              />
-            </button>
-            <button
-              aria-label={e('market.installPlugin')}
-              disabled={updatingAll}
-              onClick={() => setInstallOpen(true)}
-              title={e('market.installPlugin')}
-              type="button"
-            >
-              <MdiIcon name="mdi-plus" />
-            </button>
-          </div>,
-          document.body,
-        )}
+      <FloatingActions>
+        <FloatingActionButton
+          aria-label={e('buttons.updateAll')}
+          disabled={loading || updatingAll}
+          onClick={() => void updateAll()}
+          title={e('buttons.updateAll')}
+        >
+          <MdiIcon className={updatingAll ? 'mdi-spin' : undefined} name={updatingAll ? 'mdi-loading' : 'mdi-update'} />
+        </FloatingActionButton>
+        <FloatingActionButton
+          aria-label={e('market.installPlugin')}
+          disabled={updatingAll}
+          onClick={() => setInstallOpen(true)}
+          title={e('market.installPlugin')}
+        >
+          <MdiIcon name="mdi-plus" />
+        </FloatingActionButton>
+      </FloatingActions>
       <Dialog
         onOpenChange={(open) => !open && setConfigPlugin(null)}
         open={configPlugin !== null}
@@ -1237,15 +1228,15 @@ function PluginMarket() {
           value={keyword}
         />
       </header>
-      <button
-        aria-label={e('market.installPlugin')}
-        className="extension-market__fab"
-        onClick={() => setInstalling({})}
-        title={e('market.installPlugin')}
-        type="button"
-      >
-        <MdiIcon name="mdi-plus" />
-      </button>
+      <FloatingActions>
+        <FloatingActionButton
+          aria-label={e('market.installPlugin')}
+          onClick={() => setInstalling({})}
+          title={e('market.installPlugin')}
+        >
+          <MdiIcon name="mdi-plus" />
+        </FloatingActionButton>
+      </FloatingActions>
       <div className="extension-market__section-title">
         <div>
           <h2>{e('market.allPlugins')}</h2>

--- a/dashboard/src/routes/extensions/ExtensionPage.tsx
+++ b/dashboard/src/routes/extensions/ExtensionPage.tsx
@@ -33,6 +33,7 @@ import { AsyncState } from '@/components/ui/AsyncState';
 import { FormDialog } from '@/components/ui/FormDialog';
 import { Pagination } from '@/components/ui/Pagination';
 import { SearchField } from '@/components/ui/SearchField';
+import { SelectControl } from '@/components/ui/SelectControl';
 import { confirmDestructiveAction } from '@/components/ui/confirm';
 import { confirmAction, toast } from '@/stores/feedback';
 import { errorMessage, isObject, type JsonObject, recordId, responseData } from '@/routes/configuration/model';
@@ -1261,7 +1262,7 @@ function PluginMarket() {
         <div>
           <label>
             <span>{e('market.category')}</span>
-            <select
+            <SelectControl
               onChange={(event) => {
                 setCategory(event.target.value);
                 setPage(1);
@@ -1273,12 +1274,12 @@ function PluginMarket() {
                   {item.label} ({item.count})
                 </option>
               ))}
-            </select>
+            </SelectControl>
           </label>
           <label>
             <MdiIcon name="mdi-sort" />
             <span>{e('sort.by')}</span>
-            <select
+            <SelectControl
               onChange={(event) => {
                 setSort(event.target.value as typeof sort);
                 setPage(1);
@@ -1289,7 +1290,7 @@ function PluginMarket() {
               <option value="stars">{e('sort.stars')}</option>
               <option value="author">{e('sort.author')}</option>
               <option value="updated">{e('sort.updated')}</option>
-            </select>
+            </SelectControl>
           </label>
           {sort !== 'default' && (
             <button

--- a/dashboard/src/routes/extensions/ExtensionSections.tsx
+++ b/dashboard/src/routes/extensions/ExtensionSections.tsx
@@ -512,7 +512,12 @@ function ComponentPagination({
     <footer>
       <label>
         {t('core.common.itemsPerPage')}:{' '}
-        <SelectControl onChange={(event) => onPageSizeChange(Number(event.target.value))} value={pageSize}>
+        <SelectControl
+          aria-label={t('core.common.itemsPerPage')}
+          className="component-panel__page-size"
+          onChange={(event) => onPageSizeChange(Number(event.target.value))}
+          value={pageSize}
+        >
           <option>10</option>
           <option>25</option>
           <option>50</option>

--- a/dashboard/src/routes/extensions/ExtensionSections.tsx
+++ b/dashboard/src/routes/extensions/ExtensionSections.tsx
@@ -44,6 +44,8 @@ import { MdiIcon } from '@/components/icons/MdiIcon';
 import { Dialog } from '@/components/headless/Dialog';
 import { MonacoEditor } from '@/components/editor/MonacoEditor';
 import { DisclosureButton } from '@/components/ui/DisclosureButton';
+import { SelectMenu } from '@/components/ui/SelectMenu';
+import { SelectControl } from '@/components/ui/SelectControl';
 import { useUnsavedChangesGuard } from '@/components/ui/useUnsavedChangesGuard';
 import { confirmAction, toast } from '@/stores/feedback';
 import { useBrowserCapabilities } from '@/platform/BrowserCapabilitiesProvider';
@@ -510,11 +512,11 @@ function ComponentPagination({
     <footer>
       <label>
         {t('core.common.itemsPerPage')}:{' '}
-        <select onChange={(event) => onPageSizeChange(Number(event.target.value))} value={pageSize}>
+        <SelectControl onChange={(event) => onPageSizeChange(Number(event.target.value))} value={pageSize}>
           <option>10</option>
           <option>25</option>
           <option>50</option>
-        </select>
+        </SelectControl>
       </label>
       <span>
         {t('core.common.paginationRange', {
@@ -580,41 +582,60 @@ function CommandFilters({
 }) {
   return (
     <div className="component-panel__filters">
-      <label>
+      <div className="component-panel__filter">
         <span>{t('filters.byPlugin')}</span>
-        <select onChange={(event) => onPluginChange(event.target.value)} value={plugin}>
-          <option value="all">{t('filters.all')}</option>
-          {plugins.map((item) => (
-            <option key={item}>{item}</option>
-          ))}
-        </select>
-      </label>
-      <label>
+        <SelectMenu
+          ariaLabel={t('filters.byPlugin')}
+          onChange={onPluginChange}
+          options={[{ id: 'all', name: t('filters.all') }, ...plugins.map((item) => ({ id: item, name: item }))]}
+          placeholder={t('filters.all')}
+          value={plugin}
+        />
+      </div>
+      <div className="component-panel__filter">
         <span>{t('filters.byType')}</span>
-        <select onChange={(event) => onTypeChange(event.target.value)} value={type}>
-          <option value="all">{t('filters.all')}</option>
-          <option value="group">{t('type.group')}</option>
-          <option value="command">{t('type.command')}</option>
-          <option value="sub_command">{t('type.subCommand')}</option>
-        </select>
-      </label>
-      <label>
+        <SelectMenu
+          ariaLabel={t('filters.byType')}
+          onChange={onTypeChange}
+          options={[
+            { id: 'all', name: t('filters.all') },
+            { id: 'group', name: t('type.group') },
+            { id: 'command', name: t('type.command') },
+            { id: 'sub_command', name: t('type.subCommand') },
+          ]}
+          placeholder={t('filters.all')}
+          value={type}
+        />
+      </div>
+      <div className="component-panel__filter">
         <span>{t('filters.byPermission')}</span>
-        <select onChange={(event) => onPermissionChange(event.target.value)} value={permission}>
-          <option value="all">{t('filters.all')}</option>
-          <option value="everyone">{t('permission.everyone')}</option>
-          <option value="admin">{t('permission.admin')}</option>
-        </select>
-      </label>
-      <label>
+        <SelectMenu
+          ariaLabel={t('filters.byPermission')}
+          onChange={onPermissionChange}
+          options={[
+            { id: 'all', name: t('filters.all') },
+            { id: 'everyone', name: t('permission.everyone') },
+            { id: 'admin', name: t('permission.admin') },
+          ]}
+          placeholder={t('filters.all')}
+          value={permission}
+        />
+      </div>
+      <div className="component-panel__filter">
         <span>{t('filters.byStatus')}</span>
-        <select onChange={(event) => onStatusChange(event.target.value)} value={status}>
-          <option value="all">{t('filters.all')}</option>
-          <option value="enabled">{t('filters.enabled')}</option>
-          <option value="disabled">{t('filters.disabled')}</option>
-          <option value="conflict">{t('filters.conflict')}</option>
-        </select>
-      </label>
+        <SelectMenu
+          ariaLabel={t('filters.byStatus')}
+          onChange={onStatusChange}
+          options={[
+            { id: 'all', name: t('filters.all') },
+            { id: 'enabled', name: t('filters.enabled') },
+            { id: 'disabled', name: t('filters.disabled') },
+            { id: 'conflict', name: t('filters.conflict') },
+          ]}
+          placeholder={t('filters.all')}
+          value={status}
+        />
+      </div>
     </div>
   );
 }
@@ -688,14 +709,14 @@ function CommandRow({
         </span>
       </td>
       <td>
-        <select
+        <SelectControl
           className={`component-permission is-${item.permission === 'admin' ? 'admin' : 'member'}`}
           onChange={(event) => void onPermission(item, event.target.value as 'admin' | 'member')}
           value={item.permission === 'admin' ? 'admin' : 'member'}
         >
           <option value="member">{t('permission.everyone')}</option>
           <option value="admin">{t('permission.admin')}</option>
-        </select>
+        </SelectControl>
       </td>
       <td>
         <span className={`component-status is-${status}`}>{t(`status.${status}`)}</span>
@@ -802,14 +823,14 @@ function ToolRow({
           {item.origin === 'builtin' ? (
             <span className="component-permission-builtin">{t('functionTools.table.permissionBuiltin')}</span>
           ) : (
-            <select
+            <SelectControl
               className={`component-permission is-${item.permission === 'admin' ? 'admin' : 'member'}`}
               onChange={(event) => void onPermission(item, event.target.value as 'admin' | 'member')}
               value={item.permission === 'admin' ? 'admin' : 'member'}
             >
               <option value="member">{t('functionTools.table.permissionEveryone')}</option>
               <option value="admin">{t('functionTools.table.permissionAdmin')}</option>
-            </select>
+            </SelectControl>
           )}
         </td>
         <td>
@@ -1435,9 +1456,9 @@ export function McpSection() {
         <div className="mcp-sync">
           <label>
             {m('dialogs.syncProvider.fields.provider')}
-            <select value="modelscope">
+            <SelectControl value="modelscope">
               <option value="modelscope">{m('dialogs.syncProvider.providers.modelscope')}</option>
-            </select>
+            </SelectControl>
           </label>
           <ol>
             <li>
@@ -2528,7 +2549,7 @@ function NeoSkills({
         </label>
         <label>
           {t('skills.neoStatus')}
-          <select
+          <SelectControl
             onChange={(event) => onFilters((current) => ({ ...current, status: event.target.value }))}
             value={filters.status}
           >
@@ -2538,18 +2559,18 @@ function NeoSkills({
                 <option key={value}>{value}</option>
               ),
             )}
-          </select>
+          </SelectControl>
         </label>
         <label>
           {t('skills.neoStage')}
-          <select
+          <SelectControl
             onChange={(event) => onFilters((current) => ({ ...current, stage: event.target.value }))}
             value={filters.stage}
           >
             <option value="">{t('skills.neoAll')}</option>
             <option>canary</option>
             <option>stable</option>
-          </select>
+          </SelectControl>
         </label>
       </section>
       {loading && <SectionState error="" loading />}

--- a/dashboard/src/routes/extensions/ExtensionSections.tsx
+++ b/dashboard/src/routes/extensions/ExtensionSections.tsx
@@ -44,6 +44,7 @@ import { MdiIcon } from '@/components/icons/MdiIcon';
 import { Dialog } from '@/components/headless/Dialog';
 import { MonacoEditor } from '@/components/editor/MonacoEditor';
 import { DisclosureButton } from '@/components/ui/DisclosureButton';
+import { FloatingActionButton, FloatingActions } from '@/components/ui/FloatingActions';
 import { SelectMenu } from '@/components/ui/SelectMenu';
 import { SelectControl } from '@/components/ui/SelectControl';
 import { useUnsavedChangesGuard } from '@/components/ui/useUnsavedChangesGuard';
@@ -1510,24 +1511,22 @@ export function McpSection() {
 
 function McpFloatingActions({ onAdd, onSync, t }: { onAdd: () => void; onSync: () => void; t: ModuleText }) {
   return (
-    <div className="resource-fab-stack">
-      <button
+    <FloatingActions>
+      <FloatingActionButton
         aria-label={t('mcpServers.buttons.sync')}
         onClick={onSync}
         title={t('mcpServers.buttons.sync')}
-        type="button"
       >
         <MdiIcon name="mdi-sync" />
-      </button>
-      <button
+      </FloatingActionButton>
+      <FloatingActionButton
         aria-label={t('mcpServers.buttons.add')}
         onClick={onAdd}
         title={t('mcpServers.buttons.add')}
-        type="button"
       >
         <MdiIcon name="mdi-plus" />
-      </button>
-    </div>
+      </FloatingActionButton>
+    </FloatingActions>
   );
 }
 
@@ -1965,21 +1964,20 @@ function SkillsFloatingActions({
   t: ModuleText;
 }) {
   return (
-    <div className="resource-fab-stack">
-      <button
+    <FloatingActions>
+      <FloatingActionButton
         aria-label={t('skills.refresh')}
         onClick={() => void onRefresh()}
         title={t('skills.refresh')}
-        type="button"
       >
         <MdiIcon name="mdi-refresh" />
-      </button>
+      </FloatingActionButton>
       {mode === 'local' && (
-        <button aria-label={t('skills.upload')} onClick={onUpload} title={t('skills.upload')} type="button">
+        <FloatingActionButton aria-label={t('skills.upload')} onClick={onUpload} title={t('skills.upload')}>
           <MdiIcon name="mdi-upload" />
-        </button>
+        </FloatingActionButton>
       )}
-    </div>
+    </FloatingActions>
   );
 }
 

--- a/dashboard/src/routes/knowledge/DocumentDetailPage.tsx
+++ b/dashboard/src/routes/knowledge/DocumentDetailPage.tsx
@@ -15,6 +15,7 @@ import { Dialog } from '@/components/headless/Dialog';
 import { MdiIcon } from '@/components/icons/MdiIcon';
 import { DialogCancel } from '@/components/ui/Button';
 import { DialogActions } from '@/components/ui/DialogActions';
+import { SelectControl } from '@/components/ui/SelectControl';
 import { confirmAction, toast } from '@/stores/feedback';
 import { errorMessage, recordId } from '@/routes/configuration/model';
 import { chunkCount, documentName, formatFileSize, formatKnowledgeDate } from './knowledgeModel';
@@ -218,7 +219,7 @@ export default function DocumentDetailPage() {
               {k('chunks.showing')} {(page - 1) * pageSize + 1}–{Math.min(page * pageSize, total)} / {total}
             </span>
             <div>
-              <select
+              <SelectControl
                 onChange={(event) => {
                   setPageSize(Number(event.target.value));
                   setPage(1);
@@ -228,7 +229,7 @@ export default function DocumentDetailPage() {
                 {[10, 25, 50, 100].map((size) => (
                   <option key={size}>{size}</option>
                 ))}
-              </select>
+              </SelectControl>
               <button disabled={page <= 1} onClick={() => setPage((value) => value - 1)} type="button">
                 ‹
               </button>

--- a/dashboard/src/routes/knowledge/KnowledgeBaseDetailPage.tsx
+++ b/dashboard/src/routes/knowledge/KnowledgeBaseDetailPage.tsx
@@ -31,6 +31,7 @@ import { Dialog } from '@/components/headless/Dialog';
 import { MdiIcon } from '@/components/icons/MdiIcon';
 import { Button, DialogCancel } from '@/components/ui/Button';
 import { DialogActions } from '@/components/ui/DialogActions';
+import { SelectControl } from '@/components/ui/SelectControl';
 import { confirmAction, toast } from '@/stores/feedback';
 import { errorMessage, isObject, JsonObject, responseData } from '@/routes/configuration/model';
 import {
@@ -540,7 +541,7 @@ function Documents({
                 </label>
                 <label>
                   {t('upload.cleaningProvider')}
-                  <select
+                  <SelectControl
                     disabled={!uploadSettings.enable_cleaning}
                     onChange={(event) =>
                       setUploadSettings({ ...uploadSettings, cleaning_provider_id: event.target.value })
@@ -553,7 +554,7 @@ function Documents({
                         {String(provider.id)}
                       </option>
                     ))}
-                  </select>
+                  </SelectControl>
                   <small>{t('upload.cleaningProviderHint')}</small>
                 </label>
               </div>
@@ -802,7 +803,7 @@ function KnowledgeDocumentList({
       </div>
       {total > pageSize && (
         <div className="pagination">
-          <select
+          <SelectControl
             onChange={(event) => {
               onPageSizeChange(Number(event.target.value));
               onPageChange(1);
@@ -812,7 +813,7 @@ function KnowledgeDocumentList({
             {[10, 20, 50].map((size) => (
               <option key={size}>{size}</option>
             ))}
-          </select>
+          </SelectControl>
           <button disabled={page <= 1} onClick={() => onPageChange((value) => value - 1)} type="button">
             ‹
           </button>
@@ -1015,7 +1016,7 @@ function KnowledgeSettings({
           <NumberField field="top_m_final" form={form} label={t('settings.topMFinal')} setForm={setForm} />
           <label>
             {t('settings.rerankProvider')}
-            <select
+            <SelectControl
               onChange={(event) => setForm({ ...form, rerank_provider_id: event.target.value })}
               value={form.rerank_provider_id}
             >
@@ -1025,7 +1026,7 @@ function KnowledgeSettings({
                   {String(provider.rerank_model || provider.model || provider.id)}
                 </option>
               ))}
-            </select>
+            </SelectControl>
           </label>
         </div>
       </div>

--- a/dashboard/src/routes/knowledge/KnowledgeBaseListPage.tsx
+++ b/dashboard/src/routes/knowledge/KnowledgeBaseListPage.tsx
@@ -17,6 +17,7 @@ import { MdiIcon } from '@/components/icons/MdiIcon';
 import { AsyncState } from '@/components/ui/AsyncState';
 import { Button, DialogCancel } from '@/components/ui/Button';
 import { DialogActions } from '@/components/ui/DialogActions';
+import { FloatingActionButton, FloatingActions } from '@/components/ui/FloatingActions';
 import { IconButton } from '@/components/ui/IconButton';
 import { PageHeader } from '@/components/ui/PageHeader';
 import { Pagination } from '@/components/ui/Pagination';
@@ -407,31 +408,19 @@ export default function KnowledgeBaseListPage() {
           totalItems={total}
         />
       )}
-      {typeof document !== 'undefined' &&
-        createPortal(
-          <div className="knowledge-fab-stack">
-            <button
-              aria-label={k('list.refresh')}
-              className="knowledge-fab"
-              disabled={loading}
-              onClick={() => void load()}
-              title={k('list.refresh')}
-              type="button"
-            >
-              <MdiIcon className={loading ? 'mdi-spin' : ''} name="mdi-refresh" />
-            </button>
-            <button
-              aria-label={k('list.create')}
-              className="knowledge-fab"
-              onClick={() => open()}
-              title={k('list.create')}
-              type="button"
-            >
-              <MdiIcon name="mdi-plus" />
-            </button>
-          </div>,
-          document.body,
-        )}
+      <FloatingActions>
+        <FloatingActionButton
+          aria-label={k('list.refresh')}
+          disabled={loading}
+          onClick={() => void load()}
+          title={k('list.refresh')}
+        >
+          <MdiIcon className={loading ? 'mdi-spin' : ''} name="mdi-refresh" />
+        </FloatingActionButton>
+        <FloatingActionButton aria-label={k('list.create')} onClick={() => open()} title={k('list.create')}>
+          <MdiIcon name="mdi-plus" />
+        </FloatingActionButton>
+      </FloatingActions>
       <Dialog
         onOpenChange={(openValue) => !openValue && close()}
         open={editing !== null}

--- a/dashboard/src/routes/monitoring/ConversationPage.tsx
+++ b/dashboard/src/routes/monitoring/ConversationPage.tsx
@@ -21,6 +21,7 @@ import { DataTable, type DataTableColumn } from '@/components/ui/DataTable';
 import { DialogActions } from '@/components/ui/DialogActions';
 import { Pagination } from '@/components/ui/Pagination';
 import { SearchField } from '@/components/ui/SearchField';
+import { SelectControl } from '@/components/ui/SelectControl';
 import { confirmDestructiveAction } from '@/components/ui/confirm';
 import { toast } from '@/stores/feedback';
 import {
@@ -305,7 +306,7 @@ export default function ConversationPage() {
               placeholder={t(`${prefix}.filters.platform`)}
               value={platform}
             />
-            <select
+            <SelectControl
               onChange={(event) => {
                 setMessageType(event.target.value);
                 setPage(1);
@@ -315,7 +316,7 @@ export default function ConversationPage() {
               <option value="">{t(`${prefix}.filters.type`)}</option>
               <option value="GroupMessage">{t(`${prefix}.messageTypes.group`)}</option>
               <option value="FriendMessage">{t(`${prefix}.messageTypes.friend`)}</option>
-            </select>
+            </SelectControl>
             <SearchField
               label={t(`${prefix}.filters.search`)}
               onChange={(value) => {

--- a/dashboard/src/routes/monitoring/SessionManagementControls.tsx
+++ b/dashboard/src/routes/monitoring/SessionManagementControls.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { MdiIcon } from '@/components/icons/MdiIcon';
+import { SelectControl } from '@/components/ui/SelectControl';
 import { FOLLOW_CONFIG_VALUE, sessionDisplayName, type ProviderOption, type UmoInfo } from './sessionManagementModel';
 
 export function UmoDisplay({
@@ -82,14 +83,14 @@ export function ProviderSelect({
   return (
     <label>
       <span>{label}</span>
-      <select disabled={disabled} onChange={(event) => onChange(event.target.value)} value={value}>
+      <SelectControl disabled={disabled} onChange={(event) => onChange(event.target.value)} value={value}>
         <option value={FOLLOW_CONFIG_VALUE}>{followText}</option>
         {options.map((provider) => (
           <option key={provider.id} value={provider.id}>
             {provider.model ? `${provider.name || provider.id} (${provider.model})` : provider.name || provider.id}
           </option>
         ))}
-      </select>
+      </SelectControl>
     </label>
   );
 }

--- a/dashboard/src/routes/monitoring/SessionManagementPage.test.tsx
+++ b/dashboard/src/routes/monitoring/SessionManagementPage.test.tsx
@@ -71,9 +71,7 @@ describe('SessionManagementPage', () => {
     await screen.findByText('user-1');
     const checkboxes = screen.getAllByRole('checkbox');
     await user.click(checkboxes[1]);
-    await user.click(
-      screen.getByRole('button', { name: 'features.session-management.batchOperations.llmStatus' }),
-    );
+    await user.click(screen.getByRole('button', { name: 'features.session-management.batchOperations.llmStatus' }));
     await user.click(screen.getByRole('option', { name: 'features.session-management.status.enabled' }));
     await user.click(screen.getByRole('button', { name: 'features.session-management.batchOperations.apply' }));
 

--- a/dashboard/src/routes/monitoring/SessionManagementPage.test.tsx
+++ b/dashboard/src/routes/monitoring/SessionManagementPage.test.tsx
@@ -71,10 +71,10 @@ describe('SessionManagementPage', () => {
     await screen.findByText('user-1');
     const checkboxes = screen.getAllByRole('checkbox');
     await user.click(checkboxes[1]);
-    await user.selectOptions(
-      screen.getByRole('combobox', { name: 'features.session-management.batchOperations.llmStatus' }),
-      'true',
+    await user.click(
+      screen.getByRole('button', { name: 'features.session-management.batchOperations.llmStatus' }),
     );
+    await user.click(screen.getByRole('option', { name: 'features.session-management.status.enabled' }));
     await user.click(screen.getByRole('button', { name: 'features.session-management.batchOperations.apply' }));
 
     await waitFor(() =>

--- a/dashboard/src/routes/monitoring/SessionManagementPage.tsx
+++ b/dashboard/src/routes/monitoring/SessionManagementPage.tsx
@@ -18,6 +18,7 @@ import { externalLinks } from '@/config/links';
 import { paginationDefaults } from '@/config/defaults';
 import { Dialog, DialogClose } from '@/components/headless/Dialog';
 import { MdiIcon } from '@/components/icons/MdiIcon';
+import { SelectControl } from '@/components/ui/SelectControl';
 import { confirmAction, toast } from '@/stores/feedback';
 import { EditorSection, MultiSelect, ProviderSelect, TransferList, UmoDisplay } from './SessionManagementControls';
 import {
@@ -626,7 +627,7 @@ export default function SessionManagementPage() {
         <footer className="session-rules-pagination">
           <label>
             {t('core.common.itemsPerPage')}:{' '}
-            <select
+            <SelectControl
               onChange={(event) => {
                 setPageSize(Number(event.target.value));
                 setPage(1);
@@ -636,7 +637,7 @@ export default function SessionManagementPage() {
               {[10, 20, 50].map((size) => (
                 <option key={size}>{size}</option>
               ))}
-            </select>
+            </SelectControl>
           </label>
           <span>
             {t('core.common.paginationRange', {
@@ -668,7 +669,7 @@ export default function SessionManagementPage() {
         <div className="session-batch-grid">
           <label>
             <span>{text('batchOperations.scope')}</span>
-            <select onChange={(event) => setBatchScope(event.target.value as BatchScope)} value={batchScope}>
+            <SelectControl onChange={(event) => setBatchScope(event.target.value as BatchScope)} value={batchScope}>
               <option value="selected">{text('batchOperations.scopeSelected')}</option>
               <option value="all">{text('batchOperations.scopeAll')}</option>
               <option value="group">{text('batchOperations.scopeGroup')}</option>
@@ -681,27 +682,27 @@ export default function SessionManagementPage() {
                   })}
                 </option>
               ))}
-            </select>
+            </SelectControl>
           </label>
           <label>
             <span>{text('batchOperations.llmStatus')}</span>
-            <select onChange={(event) => setBatchLlm(event.target.value)} value={batchLlm}>
+            <SelectControl onChange={(event) => setBatchLlm(event.target.value)} value={batchLlm}>
               <option value="">{text('batchOperations.llmStatus')}</option>
               <option value="true">{text('status.enabled')}</option>
               <option value="false">{text('status.disabled')}</option>
-            </select>
+            </SelectControl>
           </label>
           <label>
             <span>{text('batchOperations.ttsStatus')}</span>
-            <select onChange={(event) => setBatchTts(event.target.value)} value={batchTts}>
+            <SelectControl onChange={(event) => setBatchTts(event.target.value)} value={batchTts}>
               <option value="">{text('batchOperations.ttsStatus')}</option>
               <option value="true">{text('status.enabled')}</option>
               <option value="false">{text('status.disabled')}</option>
-            </select>
+            </SelectControl>
           </label>
           <label>
             <span>{text('batchOperations.chatProvider')}</span>
-            <select onChange={(event) => setBatchChatProvider(event.target.value)} value={batchChatProvider}>
+            <SelectControl onChange={(event) => setBatchChatProvider(event.target.value)} value={batchChatProvider}>
               <option value="">{text('batchOperations.chatProvider')}</option>
               <option value={FOLLOW_CONFIG_VALUE}>{text('provider.followConfig')}</option>
               {chatProviders.map((provider) => (
@@ -709,7 +710,7 @@ export default function SessionManagementPage() {
                   {providerLabel(provider)}
                 </option>
               ))}
-            </select>
+            </SelectControl>
           </label>
         </div>
         <div className="session-batch-actions">
@@ -734,7 +735,7 @@ export default function SessionManagementPage() {
             {selected.size > 0 && groups.length > 0 && (
               <label className="session-group-add">
                 <MdiIcon name="mdi-folder-plus" />
-                <select
+                <SelectControl
                   onChange={(event) => {
                     if (event.target.value) void addSelectedToGroup(event.target.value);
                     event.target.value = '';
@@ -750,7 +751,7 @@ export default function SessionManagementPage() {
                       })}
                     </option>
                   ))}
-                </select>
+                </SelectControl>
               </label>
             )}
             <button onClick={() => void openGroupEditor()} type="button">
@@ -801,14 +802,14 @@ export default function SessionManagementPage() {
           </div>
           <label>
             <span>{text('addRule.selectUmo')}</span>
-            <select disabled={loadingUmos} onChange={(event) => setNewUmo(event.target.value)} value={newUmo}>
+            <SelectControl disabled={loadingUmos} onChange={(event) => setNewUmo(event.target.value)} value={newUmo}>
               <option value="">{loadingUmos ? '…' : text('addRule.noUmos')}</option>
               {availableNewUmos.map((umo) => (
                 <option key={umo} value={umo}>
                   {displayName(infoFor(umo))} · {umo}
                 </option>
               ))}
-            </select>
+            </SelectControl>
           </label>
           <div className="dialog-actions">
             <DialogClose asChild>
@@ -932,7 +933,7 @@ export default function SessionManagementPage() {
             >
               <label>
                 <span>{text('ruleEditor.personaConfig.selectPersona')}</span>
-                <select
+                <SelectControl
                   onChange={(event) =>
                     updateEditor('service', { ...editor.service, persona_id: event.target.value || null })
                   }
@@ -944,7 +945,7 @@ export default function SessionManagementPage() {
                       {persona.name}
                     </option>
                   ))}
-                </select>
+                </SelectControl>
               </label>
               <div className="session-rule-alert">
                 <MdiIcon name="mdi-information-outline" />

--- a/dashboard/src/routes/welcome/WelcomePage.tsx
+++ b/dashboard/src/routes/welcome/WelcomePage.tsx
@@ -7,6 +7,7 @@ import { decodeApiData, expectRecord, isRecord } from '@/api/response';
 import { Markdown } from '@/components/content/Markdown';
 import { Dialog } from '@/components/headless/Dialog';
 import { MdiIcon } from '@/components/icons/MdiIcon';
+import { SelectMenu } from '@/components/ui/SelectMenu';
 import { toast } from '@/stores/feedback';
 import { loadWelcomeAnnouncement } from '@/services/announcementService';
 import PlatformPage from '@/routes/configuration/PlatformPage';
@@ -158,14 +159,17 @@ export default function WelcomePage() {
             <div className="onboarding-list__content">
               <h3>{t(`${prefix}.onboard.step3Title`)}</h3>
               <p>{t(`${prefix}.onboard.step3Desc`)}</p>
-              <select
+              <SelectMenu
+                ariaLabel={t(`${prefix}.onboard.step3Title`)}
                 disabled={savingRuntime}
-                onChange={(event) => void saveRuntime(event.target.value as ComputerAccessRuntime)}
+                onChange={(value) => void saveRuntime(value as ComputerAccessRuntime)}
+                options={[
+                  { id: 'local', name: t(`${prefix}.onboard.step3Allow`) },
+                  { id: 'none', name: t(`${prefix}.onboard.step3Deny`) },
+                ]}
+                placeholder={t(`${prefix}.onboard.step3Title`)}
                 value={runtime}
-              >
-                <option value="local">{t(`${prefix}.onboard.step3Allow`)}</option>
-                <option value="none">{t(`${prefix}.onboard.step3Deny`)}</option>
-              </select>
+              />
               <details className="onboarding-help">
                 <summary>{t(`${prefix}.onboard.step3HelpTitle`)}</summary>
                 <ol>

--- a/dashboard/src/styles/components/_motion-transitions.scss
+++ b/dashboard/src/styles/components/_motion-transitions.scss
@@ -1,5 +1,5 @@
 /* Shared motion tokens for page and component transitions. */
-.full-layout__page > :not(.chat-shell) { animation: motion-page-in 0.26s ease-out both; }
+.full-layout__page > :not(.chat-shell) { animation: motion-page-in 0.26s ease-out backwards; }
 .headless-menu__content,
 .headless-popover__content,
 .provider-source-add[open] > .provider-source-add__menu,
@@ -24,7 +24,7 @@
 .provider-type-panel,
 .extension-detail__info,
 .extension-config-editor--detail,
-.extension-markdown { animation: motion-content-in 0.22s ease-out both; }
+.extension-markdown { animation: motion-content-in 0.22s ease-out backwards; }
 
 @keyframes motion-fade-in { from { opacity: 0; } to { opacity: 1; } }
 @keyframes motion-fade-out { from { opacity: 1; } to { opacity: 0; } }

--- a/dashboard/src/styles/components/_primitives.scss
+++ b/dashboard/src/styles/components/_primitives.scss
@@ -277,6 +277,51 @@
   opacity: .5;
 }
 
+.ui-floating-actions {
+  position: fixed;
+  z-index: 50;
+  right: 52px;
+  bottom: 52px;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.ui-floating-action {
+  display: grid;
+  width: 56px;
+  height: 56px;
+  padding: 0;
+  place-items: center;
+  border: 0;
+  border-radius: 16px;
+  background: color-mix(in srgb, var(--astrbot-primary) 72%, #17202a);
+  box-shadow: 0 4px 6px rgb(0 0 0 / 10%);
+  color: #fff;
+  cursor: pointer;
+  font-size: 24px;
+  transition: box-shadow .3s ease, transform .3s ease;
+}
+
+.ui-floating-action:hover {
+  box-shadow: 0 12px 20px color-mix(in srgb, var(--astrbot-primary) 40%, transparent);
+  transform: translateY(-4px) scale(1.05);
+}
+
+.ui-floating-action:disabled {
+  cursor: wait;
+  opacity: .6;
+  transform: none;
+}
+
+@media (max-width: 760px) {
+  .ui-floating-actions {
+    right: 20px;
+    bottom: 20px;
+  }
+}
+
 .ui-select-menu__menu > button.is-selected {
   color: var(--astrbot-primary);
   font-weight: 650;

--- a/dashboard/src/styles/components/_primitives.scss
+++ b/dashboard/src/styles/components/_primitives.scss
@@ -1,3 +1,290 @@
+:where(
+  input:not([type]),
+  input[type='date'],
+  input[type='datetime-local'],
+  input[type='email'],
+  input[type='month'],
+  input[type='number'],
+  input[type='password'],
+  input[type='search'],
+  input[type='tel'],
+  input[type='text'],
+  input[type='time'],
+  input[type='url'],
+  input[type='week'],
+  select,
+  textarea
+) {
+  min-height: 40px;
+  padding: 8px 11px;
+  border: 1px solid var(--astrbot-border);
+  border-radius: var(--astrbot-radius-control);
+  outline: 0;
+  background-color: var(--astrbot-surface);
+  color: var(--astrbot-text);
+  font: inherit;
+  transition: border-color .15s ease, outline-color .15s ease, background-color .15s ease;
+}
+
+:where(
+  input:not([type]),
+  input[type='date'],
+  input[type='datetime-local'],
+  input[type='email'],
+  input[type='month'],
+  input[type='number'],
+  input[type='password'],
+  input[type='search'],
+  input[type='tel'],
+  input[type='text'],
+  input[type='time'],
+  input[type='url'],
+  input[type='week'],
+  select,
+  textarea
+):focus {
+  border-color: var(--astrbot-primary);
+  outline: 2px solid color-mix(in srgb, var(--astrbot-primary) 24%, transparent);
+  outline-offset: 1px;
+}
+
+:where(input, select, textarea):disabled {
+  cursor: not-allowed;
+  opacity: .55;
+}
+
+:where(input, textarea)::placeholder {
+  color: color-mix(in srgb, var(--astrbot-text) 46%, transparent);
+}
+
+:where(input[aria-invalid='true'], select[aria-invalid='true'], textarea[aria-invalid='true']) {
+  border-color: var(--astrbot-error);
+}
+
+:where(input[type='checkbox'], input[type='radio']) {
+  width: 18px;
+  height: 18px;
+  margin: 0;
+  accent-color: var(--astrbot-primary);
+  cursor: pointer;
+}
+
+:where(input[type='range']) {
+  accent-color: var(--astrbot-primary);
+}
+
+:where(select) {
+  cursor: pointer;
+}
+
+:where(select option, select optgroup) {
+  background-color: var(--astrbot-surface);
+  color: var(--astrbot-text);
+}
+
+:where(select option:checked) {
+  background-color: color-mix(in srgb, var(--astrbot-primary) 16%, var(--astrbot-surface));
+  color: var(--astrbot-primary);
+}
+
+@supports (appearance: base-select) {
+  :where(select),
+  ::picker(select) {
+    appearance: base-select;
+  }
+
+  :where(select:not(:disabled)) {
+    color: var(--astrbot-primary);
+    font-weight: 650;
+  }
+
+  :where(select)::picker-icon {
+    color: color-mix(in srgb, var(--astrbot-text) 62%, transparent);
+    transition: transform .16s ease;
+  }
+
+  :where(select):open::picker-icon {
+    transform: rotate(180deg);
+  }
+
+  :where(select:active, select:focus, select:focus-visible, select:open) {
+    border-color: transparent;
+    outline: 2px solid color-mix(in srgb, var(--astrbot-primary) 28%, transparent);
+    outline-offset: 1px;
+    background-color: var(--astrbot-surface);
+    color: var(--astrbot-primary);
+    box-shadow: none;
+    filter: none;
+  }
+
+  ::picker(select) {
+    max-height: min(360px, 55vh);
+    margin-block-start: 5px;
+    padding: 6px;
+    border: 1px solid var(--astrbot-border);
+    border-radius: 10px;
+    background: var(--astrbot-surface);
+    box-shadow: 0 12px 30px rgb(0 0 0 / 16%);
+    color: var(--astrbot-text);
+  }
+
+  :where(select option) {
+    min-height: 38px;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 10px;
+    border-radius: 7px;
+    background: transparent;
+    color: var(--astrbot-text);
+    cursor: pointer;
+  }
+
+  :where(select option:hover, select option:focus) {
+    background: var(--astrbot-hover);
+  }
+
+  :where(select option:checked) {
+    background: color-mix(in srgb, var(--astrbot-primary) 13%, var(--astrbot-surface));
+    color: var(--astrbot-primary);
+    font-weight: 650;
+  }
+
+  :where(select option)::checkmark {
+    order: 1;
+    margin-left: auto;
+    color: var(--astrbot-primary);
+  }
+}
+
+:where(textarea) {
+  resize: vertical;
+}
+
+.ui-select-menu {
+  position: relative;
+  width: 100%;
+}
+
+.ui-select-control__native {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  border: 0 !important;
+  overflow: hidden !important;
+  clip-path: inset(50%) !important;
+  white-space: nowrap !important;
+}
+
+.ui-select-menu > button {
+  display: flex;
+  width: 100%;
+  min-height: 44px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 9px 12px;
+  border: 1px solid var(--astrbot-border);
+  border-radius: var(--astrbot-radius-control);
+  outline: 0;
+  background: var(--astrbot-surface);
+  color: var(--astrbot-text);
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+}
+
+.ui-select-menu > button:hover {
+  border-color: color-mix(in srgb, var(--astrbot-primary) 32%, var(--astrbot-border));
+}
+
+.ui-select-menu > button:focus-visible,
+.ui-select-menu > button[aria-expanded='true'] {
+  border-color: transparent;
+  outline: 2px solid color-mix(in srgb, var(--astrbot-primary) 28%, transparent);
+  outline-offset: 1px;
+  color: var(--astrbot-primary);
+}
+
+.ui-select-menu > button:active {
+  background: var(--astrbot-surface);
+  filter: none;
+}
+
+.ui-select-menu > button:disabled {
+  cursor: not-allowed;
+  opacity: .55;
+}
+
+.ui-select-menu > button.is-placeholder {
+  color: color-mix(in srgb, var(--astrbot-text) 52%, transparent);
+}
+
+.ui-select-menu > button > .mdi {
+  flex: 0 0 auto;
+  color: color-mix(in srgb, var(--astrbot-text) 58%, transparent);
+  font-size: 20px;
+}
+
+.ui-select-menu__menu {
+  position: absolute;
+  z-index: 200;
+  top: calc(100% + 5px);
+  right: 0;
+  left: 0;
+  max-height: min(360px, 55vh);
+  overflow-y: auto;
+  padding: 5px;
+  border: 1px solid var(--astrbot-border);
+  border-radius: 9px;
+  background: var(--astrbot-surface);
+  box-shadow: 0 10px 28px rgb(0 0 0 / 16%);
+}
+
+.ui-select-menu__menu > button {
+  display: grid;
+  width: 100%;
+  min-height: 42px;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 10px;
+  border: 0;
+  border-radius: 7px;
+  outline: 0;
+  background: transparent;
+  color: var(--astrbot-text);
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+}
+
+.ui-select-menu__menu > button:hover,
+.ui-select-menu__menu > button:focus-visible,
+.ui-select-menu__menu > button.is-selected {
+  background: var(--astrbot-hover);
+}
+
+.ui-select-menu__menu > button:disabled {
+  cursor: not-allowed;
+  opacity: .5;
+}
+
+.ui-select-menu__menu > button.is-selected {
+  color: var(--astrbot-primary);
+  font-weight: 650;
+}
+
+.ui-select-menu__menu > button > .mdi:last-child {
+  color: var(--astrbot-primary);
+}
+
+.ui-select-menu__menu > button > img {
+  width: 30px;
+  height: 30px;
+  object-fit: contain;
+}
+
 .ui-button,
 .button--primary,
 .button--danger,
@@ -210,8 +497,10 @@
 }
 
 .ui-search-field > input {
+  min-height: 0;
   min-width: 0;
   flex: 1;
+  padding: 0;
   border: 0;
   outline: 0;
   background: transparent;
@@ -352,13 +641,14 @@
   gap: var(--astrbot-space-2);
 }
 
-.ui-pagination__size select {
+.ui-pagination__size .ui-select-menu {
+  width: auto;
+  min-width: 76px;
+}
+
+.ui-pagination__size .ui-select-menu > button {
   min-height: 34px;
   padding: var(--astrbot-space-1) var(--astrbot-space-2);
-  border: 1px solid var(--astrbot-border);
-  border-radius: var(--astrbot-radius-control);
-  background: var(--astrbot-surface);
-  color: var(--astrbot-text);
 }
 
 .ui-pagination__page {

--- a/dashboard/src/styles/components/_primitives.scss
+++ b/dashboard/src/styles/components/_primitives.scss
@@ -241,6 +241,13 @@
   box-shadow: 0 10px 28px rgb(0 0 0 / 16%);
 }
 
+.ui-select-menu__menu--portaled {
+  position: fixed;
+  z-index: 1300;
+  right: auto;
+  pointer-events: auto;
+}
+
 .ui-select-menu__menu > button {
   display: grid;
   width: 100%;

--- a/dashboard/src/styles/components/motion-transitions.test.ts
+++ b/dashboard/src/styles/components/motion-transitions.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+const styles = readFileSync(new URL('./_motion-transitions.scss', import.meta.url), 'utf8');
+
+describe('shared motion transitions', () => {
+  it('releases layout transforms after entrance animations finish', () => {
+    expect(styles).toContain('animation: motion-page-in 0.26s ease-out backwards');
+    expect(styles).toContain('animation: motion-content-in 0.22s ease-out backwards');
+    expect(styles).not.toMatch(/motion-(?:page|content)-in[^;]*\bboth\b/);
+  });
+});

--- a/dashboard/src/styles/features/_chat-workspaces.scss
+++ b/dashboard/src/styles/features/_chat-workspaces.scss
@@ -41,9 +41,3 @@
   padding: 20px;
 }
 
-.chat-session-progress {
-  flex: 0 0 auto;
-  color: var(--astrbot-primary);
-  animation: chat-spin .8s linear infinite;
-}
-

--- a/dashboard/src/styles/features/_chat.scss
+++ b/dashboard/src/styles/features/_chat.scss
@@ -142,11 +142,11 @@ html[data-theme='dark'] .chat-shell {
 .chat-project-field { position: relative; display: grid; }
 .chat-project-field > span { position: absolute; z-index: 1; top: -8px; left: 12px; max-width: calc(100% - 24px); overflow: hidden; padding: 0 5px; background: var(--astrbot-surface); color: color-mix(in srgb, var(--astrbot-text) 58%, transparent); font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }
 .chat-project-field > input,
-.chat-project-field > select,
+.chat-project-field > .ui-select-menu > button,
 .chat-project-field > textarea { width: 100%; min-height: 46px; padding: 10px 13px; border: 1px solid var(--astrbot-border); border-radius: 8px; outline: 0; background: var(--astrbot-surface); color: inherit; font: inherit; }
 .chat-project-field > textarea { min-height: 92px; resize: vertical; }
 .chat-project-field > input:focus,
-.chat-project-field > select:focus,
+.chat-project-field > .ui-select-menu > button:focus-visible,
 .chat-project-field > textarea:focus { border-color: var(--astrbot-text); box-shadow: 0 0 0 1px var(--astrbot-text); }
 .chat-project-dialog__divider { height: 1px; margin: 3px 0 1px; background: var(--astrbot-border); }
 .chat-project-dialog__error { padding: 9px 11px; border-radius: 8px; background: color-mix(in srgb, var(--astrbot-error) 10%, var(--astrbot-surface)); color: var(--astrbot-error); font-size: 13px; }
@@ -431,7 +431,8 @@ html[data-theme='dark'] .chat-composer { border-color: rgb(255 255 255 / 12%); b
 .chat-composer-menu__upload { position: relative; cursor: pointer; }
 .chat-composer-menu__upload input { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0 0 0 0); }
 .chat-composer-menu__config { display: grid; grid-template-columns: 1fr auto; align-items: center; gap: 4px 8px; padding: 7px 8px; color: var(--chat-muted); font-size: 12px; }
-.chat-composer-menu__config select { grid-column: 1 / -1; width: 100%; min-width: 0; padding: 7px 8px; border: 1px solid var(--astrbot-border); border-radius: 7px; background: var(--astrbot-surface); color: inherit; }
+.chat-composer-menu__config .ui-select-menu { grid-column: 1 / -1; min-width: 0; }
+.chat-composer-menu__config .ui-select-menu > button { min-height: 38px; padding: 7px 8px; border-radius: 7px; color: inherit; }
 .chat-composer-menu__config small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .chat-record { display: grid; width: 36px; height: 36px; place-items: center; border-radius: 50% !important; color: var(--astrbot-text); font-size: 20px; }
 .chat-record:hover { background: color-mix(in srgb, var(--astrbot-text) 5%, transparent) !important; }

--- a/dashboard/src/styles/features/_chat.scss
+++ b/dashboard/src/styles/features/_chat.scss
@@ -131,7 +131,24 @@ html[data-theme='dark'] .chat-shell {
 .chat-project-session-row > span button { display: grid; width: 26px; height: 26px; place-items: center; border-radius: 6px; color: var(--chat-muted); }
 .chat-project-session-row > span button:hover { background: color-mix(in srgb, var(--astrbot-text) 7%, transparent); color: var(--astrbot-text); }
 .chat-project-session-row > span button:last-child:hover { color: var(--astrbot-error); }
-.chat-project-session-progress { position: absolute; right: 8px; color: var(--astrbot-primary); animation: chat-spin .8s linear infinite; }
+.chat-project-session-row > .chat-project-session-progress {
+  position: absolute;
+  top: 50%;
+  right: 8px;
+  display: block;
+  width: 16px;
+  height: 16px;
+  margin-top: -8px;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  color: var(--astrbot-primary);
+  opacity: 1;
+  pointer-events: none;
+  transform: none;
+  visibility: visible;
+  animation: chat-spin .8s linear infinite;
+}
 .chat-project-session-row:hover > .chat-project-session-progress,
 .chat-project-session-row:focus-within > .chat-project-session-progress { display: none; }
 .chat-project-session-empty { padding: 5px 10px; color: var(--chat-muted); font-size: 13px; }
@@ -167,6 +184,24 @@ html[data-theme='dark'] .chat-shell {
 .chat-session-list > div > div button { display: grid; width: 27px; height: 27px; place-items: center; border-radius: 6px; color: var(--chat-muted); }
 .chat-session-list > div > div .chat-sidebar-icon { width: 15px; height: 15px; }
 .chat-session-list > div > div button:hover { background: color-mix(in srgb, var(--astrbot-text) 7%, transparent); color: var(--astrbot-text); }
+.chat-session-list > div > button > .chat-session-progress {
+  position: absolute;
+  top: 50%;
+  right: 10px;
+  display: block;
+  width: 16px;
+  height: 16px;
+  margin-top: -8px;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  color: var(--astrbot-primary);
+  font-size: 0;
+  pointer-events: none;
+  animation: chat-spin .8s linear infinite;
+}
+.chat-session-list > div:hover .chat-session-progress,
+.chat-session-list > div:focus-within .chat-session-progress { display: none; }
 .chat-sessions__footer { position: relative; margin-top: auto; padding: 10px 16px 14px; }
 .chat-settings-menu { position: relative; }
 .chat-settings-menu > summary::-webkit-details-marker { display: none; }

--- a/dashboard/src/styles/features/_config-editor.scss
+++ b/dashboard/src/styles/features/_config-editor.scss
@@ -14,7 +14,8 @@
 .visual-config-search { min-height: 40px; border: 1px solid var(--astrbot-border); border-radius: 8px; background: var(--astrbot-surface); color: inherit; }
 .visual-config-profile { position: relative; width: 170px; flex: 0 0 auto; }
 .visual-config-profile > span { position: absolute; z-index: 1; top: -8px; left: 10px; padding: 0 4px; background: var(--astrbot-surface); color: color-mix(in srgb, var(--astrbot-text) 58%, transparent); font-size: 10px; }
-.visual-config-profile > select { width: 100%; height: 100%; min-height: 40px; padding: 7px 32px 7px 11px; border: 0; outline: 0; background: transparent; color: inherit; }
+.visual-config-profile > .ui-select-menu { height: 100%; }
+.visual-config-profile > .ui-select-menu > button { height: 100%; min-height: 40px; border: 0; background: transparent; }
 .visual-config-search { display: flex; width: min(360px, 100%); align-items: center; gap: 8px; padding: 0 11px; }
 .visual-config-search .mdi { flex: 0 0 auto; color: color-mix(in srgb, var(--astrbot-text) 62%, transparent); font-size: 19px; }
 .visual-config-search input { width: 100%; min-width: 0; padding: 8px 0; border: 0; outline: 0; background: transparent; color: inherit; }
@@ -109,7 +110,7 @@
 .plugin-file-config__drop { display: grid; justify-items: center; gap: 4px; margin-top: 10px; padding: 24px; border: 1px dashed var(--astrbot-primary); border-radius: 10px; background: transparent; color: var(--astrbot-primary); cursor: pointer; }
 .dynamic-config__control { min-width: 0; }
 .dynamic-config__control > input,
-.dynamic-config__control > select,
+.dynamic-config__control > .ui-select-menu > button,
 .dynamic-config__control > textarea { width: 100%; min-height: 40px; padding: 8px 10px; border: 1px solid var(--astrbot-border); border-radius: 8px; background: var(--astrbot-surface); color: inherit; }
 .dynamic-config__control select[multiple] { min-height: 110px; }
 .dynamic-config__control textarea { resize: vertical; }
@@ -390,13 +391,13 @@
 .dynamic-list-dialog__add > input,
 .dynamic-list-dialog__items input,
 .dynamic-object-dialog input,
-.dynamic-object-dialog select,
+.dynamic-object-dialog .ui-select-menu > button,
 .dynamic-batch-dialog textarea { min-width: 0; min-height: 40px; padding: 8px 10px; border: 1px solid var(--astrbot-border); border-radius: 8px; outline: 0; background: var(--astrbot-surface); color: inherit; }
 .dynamic-list-dialog__add > input { flex: 1; }
 .dynamic-list-dialog__add > input:focus,
 .dynamic-list-dialog__items input:focus,
 .dynamic-object-dialog input:focus,
-.dynamic-object-dialog select:focus,
+.dynamic-object-dialog .ui-select-menu > button:focus-visible,
 .dynamic-batch-dialog textarea:focus { border-color: var(--astrbot-text); box-shadow: 0 0 0 1px var(--astrbot-text); }
 .dynamic-list-dialog__items { display: grid; max-height: 400px; min-height: 180px; gap: 2px; overflow: auto; }
 .dynamic-list-dialog__item { display: flex; min-height: 44px; align-items: center; gap: 6px; padding: 4px 5px 4px 10px; border-radius: 8px; cursor: pointer; transition: background .18s ease; }
@@ -429,7 +430,7 @@
 .dynamic-object-dialog__add { display: grid; grid-template-columns: minmax(0, 1fr) 125px auto; align-items: center; gap: 8px; padding-top: 12px; border-top: 1px solid var(--astrbot-border); }
 .dynamic-object-dialog__add > label { position: relative; }
 .dynamic-object-dialog__add > label > span { position: absolute; z-index: 1; top: -7px; left: 10px; padding: 0 4px; background: var(--astrbot-surface); color: color-mix(in srgb, var(--astrbot-text) 58%, transparent); font-size: 10px; }
-.dynamic-object-dialog__add select { width: 100%; }
+.dynamic-object-dialog__add .ui-select-menu { width: 100%; }
 @media (max-width: 600px) {
   .dynamic-list-dialog__add { align-items: stretch; flex-wrap: wrap; }
   .dynamic-list-dialog__add > input { flex-basis: 100%; }

--- a/dashboard/src/styles/features/_conversations.scss
+++ b/dashboard/src/styles/features/_conversations.scss
@@ -6,10 +6,10 @@
 .conversation-panel__title > span { display: inline-grid; min-width: 26px; height: 26px; padding: 0 8px; place-items: center; border-radius: 999px; background: color-mix(in srgb, var(--astrbot-primary) 13%, transparent); color: var(--astrbot-primary); font-size: 12px; font-weight: 700; }
 .conversation-filters { display: flex; min-width: 420px; flex: 1 1 520px; align-items: center; gap: 8px; }
 .conversation-filters > input,
-.conversation-filters > select,
+.conversation-filters > .ui-select-menu > button,
 .conversation-filters > label { min-height: 38px; border: 1px solid var(--astrbot-border); border-radius: 8px; background: color-mix(in srgb, var(--astrbot-text) 2%, var(--astrbot-surface)); color: inherit; }
 .conversation-filters > input,
-.conversation-filters > select { width: 132px; padding: 0 10px; }
+.conversation-filters > .ui-select-menu { width: 132px; }
 .conversation-filters > label { display: flex; min-width: 210px; flex: 1; align-items: center; gap: 7px; padding: 0 10px; }
 .conversation-filters > label .mdi { color: color-mix(in srgb, var(--astrbot-text) 55%, transparent); }
 .conversation-filters > label input { width: 100%; min-width: 0; border: 0; outline: 0; background: transparent; color: inherit; }
@@ -55,9 +55,10 @@
 .conversation-pagination { display: flex; min-height: 56px; align-items: center; justify-content: space-between; gap: 16px; padding: 10px 16px; border-top: 1px solid var(--astrbot-border); color: color-mix(in srgb, var(--astrbot-text) 65%, transparent); font-size: 12px; }
 .conversation-pagination label,
 .conversation-pagination > div { display: flex; align-items: center; gap: 7px; }
-.conversation-pagination select,
+.conversation-pagination .ui-select-menu > button,
 .conversation-pagination button { height: 32px; border: 1px solid var(--astrbot-border); border-radius: 7px; background: var(--astrbot-surface); color: inherit; }
-.conversation-pagination select { padding: 0 24px 0 8px; }
+.conversation-pagination .ui-select-menu { width: auto; min-width: 72px; }
+.conversation-pagination .ui-select-menu > button { min-height: 32px; padding: 0 8px; }
 .conversation-pagination button { width: 32px; padding: 0; font-size: 18px; }
 .conversation-history { display: flex; max-height: 65vh; flex-direction: column; gap: 10px; overflow: auto; margin: 16px 0; padding: 16px; border-radius: 12px; background: color-mix(in srgb, var(--astrbot-text) 3%, var(--astrbot-surface)); }
 .conversation-history__message { width: min(78%, 720px); padding: 10px 12px; border: 1px solid var(--astrbot-border); border-radius: 12px; background: var(--astrbot-surface); }

--- a/dashboard/src/styles/features/_cron.scss
+++ b/dashboard/src/styles/features/_cron.scss
@@ -15,7 +15,8 @@
 .cron-filters label:first-child { width: 280px; }
 .cron-filters label:last-child { width: 320px; }
 .cron-filters input,
-.cron-filters select { width: 100%; min-width: 0; height: 42px; padding: 0 10px 0 0; border: 0; outline: 0; background: transparent; color: var(--astrbot-text); }
+.cron-filters .ui-select-menu { min-width: 0; }
+.cron-filters .ui-select-menu > button { height: 42px; padding: 0 10px 0 0; border: 0; background: transparent; }
 .cron-filters label > .mdi { margin-left: 11px; font-size: 19px; }
 .cron-task-list { display: flex; flex-direction: column; gap: 12px; padding-bottom: 12px; }
 .cron-task { display: flex; min-width: 0; min-height: 104px; align-items: center; gap: 12px; padding: 15px 16px; border: 1px solid var(--astrbot-border); border-radius: 11px; background: var(--astrbot-surface); cursor: pointer; transition: border-color .15s ease, background-color .15s ease, transform .15s ease; }
@@ -60,10 +61,10 @@
 .cron-form label,
 .cron-form__field { display: grid; gap: 7px; color: color-mix(in srgb, var(--astrbot-text) 78%, transparent); font-size: 12px; font-weight: 600; }
 .cron-form input,
-.cron-form select,
+.cron-form .ui-select-menu > button,
 .cron-form textarea { width: 100%; min-height: 42px; padding: 9px 11px; border: 1px solid var(--astrbot-border); border-radius: 8px; outline: 0; background: var(--astrbot-surface); color: var(--astrbot-text); font: inherit; font-size: 14px; font-weight: 400; }
 .cron-form input:focus,
-.cron-form select:focus,
+.cron-form .ui-select-menu > button:focus-visible,
 .cron-form textarea:focus { border-color: var(--astrbot-primary); box-shadow: 0 0 0 2px color-mix(in srgb, var(--astrbot-primary) 12%, transparent); }
 .cron-form textarea { resize: vertical; }
 .cron-form__schedule { display: grid; grid-template-columns: minmax(150px, 180px) minmax(0, 1fr); gap: 12px; align-items: end; }

--- a/dashboard/src/styles/features/_extensions.scss
+++ b/dashboard/src/styles/features/_extensions.scss
@@ -34,9 +34,9 @@
 .extension-controls > input { width: min(360px, 100%); margin-right: auto; }
 .extension-controls input,
 .extension-market-controls input,
-.extension-market-controls select,
+.extension-market-controls .ui-select-menu > button,
 .extension-table input,
-.extension-table select,
+.extension-table .ui-select-menu > button,
 .extension-install-form input,
 .extension-source-manager input { min-height: 39px; padding: 8px 11px; border: 1px solid var(--astrbot-border); border-radius: 9px; background: var(--astrbot-surface); color: inherit; }
 .extension-state { display: grid; min-height: 300px; place-items: center; color: var(--astrbot-primary); font-size: 34px; }
@@ -87,9 +87,9 @@
 .component-panel__tabs button { display: inline-flex; min-height: 42px; align-items: center; gap: 7px; padding: 8px 18px; border: 0; background: transparent; color: var(--astrbot-muted); cursor: pointer; font: inherit; }
 .component-panel__tabs button[aria-pressed='true'] { background: color-mix(in srgb, var(--astrbot-primary) 12%, transparent); color: var(--astrbot-primary); font-weight: 700; }
 .component-panel__filters { display: grid; grid-template-columns: 1.5fr 1fr 1fr 1fr; gap: 16px; margin-bottom: 18px; }
-.component-panel__filters label { position: relative; display: block; min-width: 0; }
-.component-panel__filters label > span { position: absolute; z-index: 1; top: -8px; left: 11px; padding: 0 5px; background: var(--astrbot-surface); color: var(--astrbot-muted); font-size: 12px; line-height: 16px; pointer-events: none; }
-.component-panel__filters select { width: 100%; min-width: 0; height: 46px; padding: 0 13px; border: 1px solid var(--astrbot-border); border-radius: 8px; background: var(--astrbot-surface); color: var(--astrbot-text); font: inherit; }
+.component-panel__filter { position: relative; min-width: 0; }
+.component-panel__filter > span { position: absolute; z-index: 201; top: -8px; left: 11px; padding: 0 5px; background: var(--astrbot-surface); color: var(--astrbot-muted); font-size: 12px; line-height: 16px; pointer-events: none; }
+.component-panel__filter .ui-select-menu > button { min-height: 46px; padding: 8px 13px; }
 .component-panel__toolbar { display: flex; align-items: center; justify-content: space-between; gap: 18px; margin-bottom: 18px; }
 .component-panel__toolbar > label { display: flex; width: min(350px, 100%); min-height: 42px; align-items: center; gap: 9px; padding: 0 13px; border: 1px solid var(--astrbot-border); border-radius: 14px; background: color-mix(in srgb, var(--astrbot-text) 4%, transparent); }
 .component-panel__toolbar > label input { width: 100%; border: 0; outline: 0; background: transparent; color: var(--astrbot-text); font: inherit; }
@@ -117,7 +117,8 @@
 .component-panel__table tr.is-subcommand { background: color-mix(in srgb, var(--astrbot-primary) 5%, transparent); }
 .component-panel__table > footer { display: flex; min-height: 54px; align-items: center; justify-content: flex-end; gap: 12px; padding: 8px 14px; }
 .component-panel__table > footer label { display: flex; align-items: center; gap: 8px; }
-.component-panel__table > footer select { height: 36px; padding: 0 24px 0 10px; border: 1px solid var(--astrbot-border); border-radius: 7px; background: var(--astrbot-surface); color: var(--astrbot-text); }
+.component-panel__table > footer .ui-select-menu { width: auto; min-width: 76px; }
+.component-panel__table > footer .ui-select-menu > button { min-height: 36px; padding: 0 10px; border-radius: 7px; }
 .component-panel__table > footer button { display: grid; width: 32px; height: 32px; place-items: center; border: 0; border-radius: 6px; background: transparent; color: var(--astrbot-text); cursor: pointer; }
 .component-panel__table > footer button:disabled { opacity: .3; }
 .component-command-name { display: flex; align-items: center; }
@@ -203,7 +204,7 @@
 .extension-market__random header button { background: color-mix(in srgb, var(--astrbot-primary) 12%, transparent); color: var(--astrbot-primary); }
 .extension-market__section-title label { position: relative; display: flex; min-width: 190px; height: 42px; align-items: center; gap: 5px; padding: 0 8px; border: 1px solid var(--astrbot-border); border-radius: 8px; }
 .extension-market__section-title label > span { position: absolute; top: -8px; left: 10px; padding: 0 4px; background: var(--astrbot-surface); color: var(--astrbot-muted); font-size: 12px; }
-.extension-market__section-title select { width: 100%; border: 0; outline: 0; background: transparent; color: var(--astrbot-text); font: inherit; font-size: 14px; }
+.extension-market__section-title .ui-select-menu > button { min-height: 40px; border: 0; background: transparent; font-size: 14px; }
 .extension-market-card { display: flex; min-width: 0; min-height: 176px; flex-direction: column; overflow: hidden; border: 1px solid var(--astrbot-border); border-radius: 12px; background: var(--astrbot-surface); cursor: pointer; transition: background .16s; }
 .extension-market-card:hover { background: var(--astrbot-hover); }
 .extension-market-card__body { display: grid; min-height: 0; flex: 1; grid-template-columns: 76px minmax(0, 1fr); gap: 12px; padding: 12px 12px 8px; }
@@ -257,7 +258,7 @@
 .headless-dialog__content:has(.mcp-editor) { width: min(750px, calc(100vw - 32px)); }
 .mcp-editor { display: grid; gap: 12px; margin-top: 12px; }
 .mcp-editor > label, .mcp-sync > label { display: grid; gap: 6px; font-size: 13px; font-weight: 600; }
-.mcp-editor input, .mcp-sync input, .mcp-sync select { width: 100%; min-height: 42px; padding: 8px 10px; border: 1px solid var(--astrbot-border); border-radius: 8px; background: var(--astrbot-surface); color: inherit; font: inherit; }
+.mcp-editor input, .mcp-sync input, .mcp-sync .ui-select-menu > button { width: 100%; min-height: 42px; padding: 8px 10px; border: 1px solid var(--astrbot-border); border-radius: 8px; background: var(--astrbot-surface); color: inherit; font: inherit; }
 .mcp-editor > header { display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between; gap: 8px; }
 .mcp-editor > header > div { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 5px; }
 .mcp-editor > header button { padding: 5px 8px; border: 0; border-radius: 6px; background: color-mix(in srgb, var(--astrbot-primary) 10%, transparent); color: var(--astrbot-primary); cursor: pointer; }
@@ -326,7 +327,7 @@
 .neo-skills__filters header { display: grid; gap: 4px; }
 .neo-skills__filters small { color: var(--astrbot-muted); }
 .neo-skills__filters label { display: grid; gap: 5px; font-size: 12px; font-weight: 600; }
-.neo-skills__filters input, .neo-skills__filters select { min-height: 40px; padding: 7px 9px; border: 1px solid var(--astrbot-border); border-radius: 7px; background: var(--astrbot-surface); color: inherit; }
+.neo-skills__filters input, .neo-skills__filters .ui-select-menu > button { min-height: 40px; padding: 7px 9px; border: 1px solid var(--astrbot-border); border-radius: 7px; background: var(--astrbot-surface); color: inherit; }
 .neo-skills__stats { display: flex; flex-wrap: wrap; gap: 7px; }
 .neo-skills__stats span { padding: 4px 9px; border-radius: 999px; background: color-mix(in srgb, var(--astrbot-primary) 10%, transparent); color: var(--astrbot-primary); font-size: 11px; }
 .neo-skills__table { overflow: hidden; border: 1px solid var(--astrbot-border); border-radius: 10px; }

--- a/dashboard/src/styles/features/_extensions.scss
+++ b/dashboard/src/styles/features/_extensions.scss
@@ -115,12 +115,14 @@
 .component-panel__table tr.is-conflict { border-left: 3px solid var(--astrbot-warning); background: color-mix(in srgb, var(--astrbot-warning) 10%, transparent); }
 .component-panel__table tr.is-group,
 .component-panel__table tr.is-subcommand { background: color-mix(in srgb, var(--astrbot-primary) 5%, transparent); }
-.component-panel__table > footer { display: flex; min-height: 54px; align-items: center; justify-content: flex-end; gap: 12px; padding: 8px 14px; }
-.component-panel__table > footer label { display: flex; align-items: center; gap: 8px; }
-.component-panel__table > footer .ui-select-menu { width: auto; min-width: 76px; }
-.component-panel__table > footer .ui-select-menu > button { min-height: 36px; padding: 0 10px; border-radius: 7px; }
-.component-panel__table > footer button { display: grid; width: 32px; height: 32px; place-items: center; border: 0; border-radius: 6px; background: transparent; color: var(--astrbot-text); cursor: pointer; }
-.component-panel__table > footer button:disabled { opacity: .3; }
+.component-panel__table > footer { display: flex; min-height: 58px; align-items: center; justify-content: flex-end; gap: 10px; padding: 10px 14px; border-top: 1px solid var(--astrbot-border); background: color-mix(in srgb, var(--astrbot-text) 1.5%, var(--astrbot-surface)); }
+.component-panel__table > footer label { display: flex; align-items: center; gap: 8px; color: var(--astrbot-muted); font-size: 13px; white-space: nowrap; }
+.component-panel__table > footer .component-panel__page-size { width: 68px; min-width: 68px; }
+.component-panel__table > footer .component-panel__page-size > button { width: 100%; height: 36px; min-height: 36px; padding: 0 9px; border-radius: 8px; background: var(--astrbot-surface); }
+.component-panel__table > footer > span { min-width: 104px; text-align: center; white-space: nowrap; }
+.component-panel__table > footer > button { display: grid; width: 32px; height: 32px; place-items: center; border: 0; border-radius: 50%; background: transparent; color: var(--astrbot-text); cursor: pointer; }
+.component-panel__table > footer > button:hover:not(:disabled) { background: var(--astrbot-hover); color: var(--astrbot-primary); }
+.component-panel__table > footer > button:disabled { opacity: .3; }
 .component-command-name { display: flex; align-items: center; }
 .component-command-name .ui-disclosure-button,
 .component-expand { margin: -2px 0; }

--- a/dashboard/src/styles/features/_extensions.scss
+++ b/dashboard/src/styles/features/_extensions.scss
@@ -195,7 +195,6 @@
 .extension-market__header > label { display: flex; width: min(340px, 100%); min-height: 42px; align-items: center; gap: 8px; padding: 0 12px; border-radius: 8px; background: color-mix(in srgb, var(--astrbot-text) 5%, transparent); }
 .extension-market__header > label input { min-width: 0; flex: 1; border: 0; outline: 0; background: transparent; color: var(--astrbot-text); font: inherit; }
 .extension-market__header > label button { display: grid; width: 28px; height: 28px; place-items: center; border: 0; background: transparent; color: var(--astrbot-muted); cursor: pointer; }
-.extension-market__fab { position: fixed; z-index: 20; right: 52px; bottom: 52px; display: grid; width: 64px; height: 64px; place-items: center; border: 0; border-radius: 16px; background: var(--astrbot-primary); color: #fff; box-shadow: 0 7px 18px rgb(0 0 0 / 24%); cursor: pointer; font-size: 30px; }
 .extension-market__section-title,
 .extension-market__random > header { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 12px; }
 .extension-market__section-title > div,
@@ -254,9 +253,6 @@
 .resource-empty { display: grid; min-height: 300px; place-items: center; align-content: center; gap: 10px; color: color-mix(in srgb, var(--astrbot-text) 42%, transparent); text-align: center; }
 .resource-empty > .mdi { font-size: 64px; }
 .resource-empty p, .resource-empty small { margin: 0; }
-.resource-fab-stack { position: fixed; right: 52px; bottom: 52px; z-index: 50; display: flex; flex-direction: column; gap: 16px; }
-.resource-fab-stack button { display: grid; width: 58px; height: 58px; padding: 0; place-items: center; border: 0; border-radius: 16px; background: var(--astrbot-dark-primary, #2578a5); box-shadow: 0 4px 7px rgba(0,0,0,.16); color: #fff; cursor: pointer; font-size: 25px; transition: transform .2s, box-shadow .2s; }
-.resource-fab-stack button:hover { transform: translateY(-3px) scale(1.04); box-shadow: 0 10px 20px color-mix(in srgb, var(--astrbot-primary) 35%, transparent); }
 .headless-dialog__content:has(.mcp-editor) { width: min(750px, calc(100vw - 32px)); }
 .mcp-editor { display: grid; gap: 12px; margin-top: 12px; }
 .mcp-editor > label, .mcp-sync > label { display: grid; gap: 6px; font-size: 13px; font-weight: 600; }
@@ -344,7 +340,6 @@
 .neo-skills__actions .button--danger { background: color-mix(in srgb, var(--astrbot-error) 10%, transparent); color: var(--astrbot-error); }
 
 @media (max-width: 900px) {
-  .resource-fab-stack { right: 24px; bottom: 24px; }
   .resource-list-item { align-items: stretch; flex-direction: column; }
   .resource-list-item__actions { justify-content: flex-end; margin-left: 0; }
   .skills-upload__abilities, .neo-skills__filters { grid-template-columns: 1fr; }
@@ -481,10 +476,6 @@
 .extension-installed__empty > .mdi { color: color-mix(in srgb, #1687c4 72%, var(--astrbot-text)); font-size: 64px; }
 .extension-installed__empty h3 { margin: 13px 0 5px; color: var(--astrbot-text); font-size: 20px; }
 .extension-installed__empty p { margin: 0; }
-.extension-installed__fabs { position: fixed; z-index: 30; right: 52px; bottom: 52px; display: flex; align-items: center; flex-direction: column; gap: 16px; }
-.extension-installed__fabs button { display: grid; width: 56px; height: 56px; place-items: center; padding: 0; border: 0; border-radius: 16px; background: color-mix(in srgb, var(--astrbot-primary) 72%, #17202a); color: #fff; cursor: pointer; font-size: 26px; box-shadow: 0 4px 6px rgb(0 0 0 / 10%); transition: box-shadow .3s ease, transform .3s ease; }
-.extension-installed__fabs button:hover { box-shadow: 0 12px 20px color-mix(in srgb, var(--astrbot-primary) 40%, transparent); transform: translateY(-4px) scale(1.05); }
-.extension-installed__fabs button:disabled { cursor: wait; opacity: .6; transform: none; }
 .extension-update-result { display: grid; min-height: 190px; place-items: center; align-content: center; gap: 18px; padding: 24px; text-align: center; }
 .extension-update-result > i { font-size: 82px; color: var(--astrbot-primary); }
 .extension-update-result.is-success > i { color: var(--astrbot-success); }
@@ -536,7 +527,6 @@
   .extension-market__section-title { align-items: flex-start; flex-direction: column; }
   .extension-market__section-title > div:last-child { width: 100%; justify-content: flex-start; }
   .extension-market__section-title label { min-width: min(190px, 100%); }
-  .extension-market__fab { right: 22px; bottom: 22px; width: 56px; height: 56px; }
   .extension-detail__info dl { grid-template-columns: 1fr; }
   .extension-detail__info dt { padding-bottom: 3px; border-bottom: 0; }
   .extension-detail__info dd { padding-top: 3px; }
@@ -544,7 +534,6 @@
   .extension-installed__search { width: 100%; }
   .extension-installed .extension-failed article { grid-template-columns: 1fr; }
   .extension-installed .extension-failed article > span { justify-content: flex-end; }
-  .extension-installed__fabs { right: 20px; bottom: 20px; }
   .extension-detail__components > div { grid-template-columns: 1fr; }
 }
 .knowledge-card__title { display: flex; align-items: flex-start; gap: 12px; }

--- a/dashboard/src/styles/features/_knowledge.scss
+++ b/dashboard/src/styles/features/_knowledge.scss
@@ -190,8 +190,6 @@
 .knowledge-tavily.is-configured { color: var(--astrbot-success); }
 .knowledge-tavily > span { flex: 1; }
 .knowledge-tavily > button { border: 0; background: transparent; color: var(--astrbot-primary); cursor: pointer; font-weight: 650; }
-.welcome-onboarding-dialog { width: min(1120px, 86vw); max-height: 74vh; overflow: auto; }
-.welcome-onboarding-dialog .route-page__heading { display: none; }
 .knowledge-upload__settings h3 { width: 100%; margin: 0; font-size: 13px; }
 .knowledge-upload__settings span { font-size: 11px; }
 

--- a/dashboard/src/styles/features/_knowledge.scss
+++ b/dashboard/src/styles/features/_knowledge.scss
@@ -95,10 +95,6 @@
 .knowledge-form .dialog-actions > .button--primary-soft { background: color-mix(in srgb, var(--astrbot-primary) 12%, var(--astrbot-surface)); color: var(--astrbot-primary); }
 .knowledge-form .dialog-actions > .button--primary-soft:hover { background: color-mix(in srgb, var(--astrbot-primary) 18%, var(--astrbot-surface)); }
 .knowledge-form .dialog-actions > button:disabled { cursor: not-allowed; opacity: .55; }
-.knowledge-fab-stack { position: fixed; z-index: 30; right: 52px; bottom: 52px; display: flex; align-items: center; flex-direction: column; gap: 16px; }
-.knowledge-fab { display: grid; width: 56px; height: 56px; place-items: center; border: 0; border-radius: 16px; background: color-mix(in srgb, var(--astrbot-primary) 72%, #17202a); color: #fff; cursor: pointer; font-size: 24px; box-shadow: 0 4px 6px rgb(0 0 0 / 10%); transition: box-shadow .3s ease, transform .3s ease; }
-.knowledge-fab:hover { box-shadow: 0 12px 20px color-mix(in srgb, var(--astrbot-primary) 40%, transparent); transform: translateY(-4px) scale(1.05); }
-.knowledge-fab:disabled { cursor: wait; opacity: .6; transform: none; }
 .knowledge-emoji-picker { display: grid; gap: 14px; margin-top: 14px; }
 .knowledge-emoji-picker h3 { margin: 0 0 7px; font-size: 13px; }
 .knowledge-emoji-picker section > div { display: grid; grid-template-columns: repeat(8, 1fr); gap: 5px; }

--- a/dashboard/src/styles/features/_knowledge.scss
+++ b/dashboard/src/styles/features/_knowledge.scss
@@ -70,7 +70,7 @@
 .knowledge-form textarea,
 .knowledge-url-field input,
 .knowledge-settings input,
-.knowledge-settings select { width: 100%; min-height: 40px; padding: 8px 10px; border: 1px solid var(--astrbot-border); border-radius: 8px; background: var(--astrbot-surface); color: var(--astrbot-text); }
+.knowledge-settings .ui-select-menu > button { width: 100%; min-height: 40px; padding: 8px 10px; border: 1px solid var(--astrbot-border); border-radius: 8px; background: var(--astrbot-surface); color: var(--astrbot-text); }
 .knowledge-provider-select__trigger { display: flex; width: 100%; min-height: 48px; align-items: center; justify-content: space-between; gap: 12px; padding: 8px 12px; border: 1px solid var(--astrbot-border); border-radius: 8px; background: var(--astrbot-surface); color: var(--astrbot-text); cursor: pointer; text-align: left; }
 .knowledge-provider-select__trigger > span { display: grid; min-width: 0; flex: 1; gap: 2px; }
 .knowledge-provider-select__trigger strong { overflow-wrap: anywhere; font-size: 13px; }
@@ -180,7 +180,7 @@
 .knowledge-upload__settings { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; padding: 10px; border-radius: 8px; background: var(--astrbot-hover); }
 .knowledge-upload__settings > h3 { width: 100%; margin: 4px 0; }
 .knowledge-upload__settings > label { display: grid; min-width: 145px; flex: 1; gap: 5px; font-size: 12px; font-weight: 650; }
-.knowledge-upload__settings input, .knowledge-upload__cleaning select { min-width: 0; padding: 8px 9px; border: 1px solid var(--astrbot-border); border-radius: 7px; background: var(--astrbot-surface); color: inherit; }
+.knowledge-upload__settings input, .knowledge-upload__cleaning .ui-select-menu > button { min-width: 0; padding: 8px 9px; border: 1px solid var(--astrbot-border); border-radius: 7px; background: var(--astrbot-surface); color: inherit; }
 .knowledge-upload__cleaning { display: grid; gap: 10px; padding: 11px; border: 1px solid var(--astrbot-border); border-radius: 9px; }
 .knowledge-upload__cleaning h3 { margin: 0; }
 .knowledge-upload__cleaning > label { display: grid; gap: 5px; }
@@ -243,7 +243,8 @@
 .knowledge-pagination { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding-top: 13px; color: color-mix(in srgb, var(--astrbot-text) 55%, transparent); font-size: 11px; }
 .knowledge-pagination > div { display: flex; align-items: center; gap: 5px; }
 .knowledge-pagination button,
-.knowledge-pagination select { min-height: 32px; padding: 4px 8px; border: 1px solid var(--astrbot-border); border-radius: 7px; background: var(--astrbot-surface); color: inherit; }
+.knowledge-pagination .ui-select-menu { width: auto; min-width: 72px; }
+.knowledge-pagination .ui-select-menu > button { min-height: 32px; padding: 4px 8px; border: 1px solid var(--astrbot-border); border-radius: 7px; background: var(--astrbot-surface); color: inherit; }
 .knowledge-chunk-dialog { margin-top: 14px; }
 .knowledge-chunk-dialog dl { display: grid; grid-template-columns: repeat(3, 1fr); gap: 7px; }
 .knowledge-chunk-dialog dl div { padding: 8px; border-radius: 7px; background: var(--astrbot-hover); }

--- a/dashboard/src/styles/features/_monitoring-pages.scss
+++ b/dashboard/src/styles/features/_monitoring-pages.scss
@@ -144,11 +144,11 @@
 
 .dialog-form { margin-top: 18px; }
 .dialog-form input,
-.dialog-form select,
+.dialog-form .ui-select-menu > button,
 .dialog-form textarea,
 .data-filters input,
-.data-filters select,
-.pagination select {
+.data-filters .ui-select-menu > button,
+.pagination .ui-select-menu > button {
   min-height: 38px;
   padding: 7px 9px;
   border: 1px solid var(--astrbot-border);

--- a/dashboard/src/styles/features/_platforms.scss
+++ b/dashboard/src/styles/features/_platforms.scss
@@ -52,16 +52,7 @@
 .platform-editor__step h3 { margin: 0; font-size: 18px; }
 .platform-editor__step p { margin: 5px 0 0; color: color-mix(in srgb, var(--astrbot-text) 52%, transparent); font-size: 12px; }
 .platform-editor__type { display: block; width: min(300px, 100%); margin-top: 24px; }
-.platform-select { position: relative; width: 100%; }
-.platform-select > button { display: flex; width: 100%; min-height: 56px; align-items: center; justify-content: space-between; gap: 12px; padding: 10px 14px; border: 1px solid var(--astrbot-border); border-radius: 10px; background: var(--astrbot-surface); color: var(--astrbot-text); cursor: pointer; font-size: 16px; text-align: left; }
-.platform-select > button.is-placeholder { color: color-mix(in srgb, var(--astrbot-text) 52%, transparent); }
-.platform-select > button > .mdi { flex: 0 0 auto; color: color-mix(in srgb, var(--astrbot-text) 58%, transparent); font-size: 20px; }
-.platform-select__menu { position: absolute; z-index: 20; top: calc(100% + 5px); right: 0; left: 0; max-height: 260px; overflow-y: auto; padding: 5px; border: 1px solid var(--astrbot-border); border-radius: 9px; background: var(--astrbot-surface); box-shadow: 0 10px 28px rgb(0 0 0 / 16%); }
-.platform-select__menu > button { display: grid; width: 100%; min-height: 42px; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; gap: 10px; padding: 7px 10px; border: 0; border-radius: 7px; background: transparent; color: var(--astrbot-text); cursor: pointer; font-size: 14px; text-align: left; }
-.platform-select__menu > button:hover,
-.platform-select__menu > button.is-selected { background: var(--astrbot-hover); }
-.platform-select__menu > button > .mdi:last-child { color: var(--astrbot-primary); }
-.platform-select__menu > button > img { width: 30px; height: 30px; object-fit: contain; }
+.platform-editor__type .ui-select-menu > button { min-height: 56px; padding: 10px 14px; font-size: 16px; }
 .platform-tutorial { width: max-content; gap: 6px; margin-top: 12px; padding: 7px 11px; border-radius: 8px; background: color-mix(in srgb, var(--astrbot-primary) 10%, transparent); color: var(--astrbot-primary); font-size: 13px; text-decoration: none; }
 .platform-creation-mode { display: grid; gap: 11px; margin-top: 18px; }
 .platform-creation-mode > strong { font-size: 14px; }
@@ -98,8 +89,8 @@
 .platform-editor__profile-select label,
 .platform-editor__new-profile { display: grid; width: min(310px, 100%); gap: 5px; color: color-mix(in srgb, var(--astrbot-text) 58%, transparent); font-size: 12px; }
 .platform-editor__new-profile input { min-height: 54px; padding: 9px 14px; border: 1px solid var(--astrbot-border); border-radius: 9px; background: var(--astrbot-surface); color: var(--astrbot-text); font-size: 15px; }
-.platform-editor__profile-select .platform-select { width: 100%; }
-.platform-editor__profile-select .platform-select > button { min-height: 54px; font-size: 15px; }
+.platform-editor__profile-select .ui-select-menu { width: 100%; }
+.platform-editor__profile-select .ui-select-menu > button { min-height: 54px; font-size: 15px; }
 .platform-editor__profile-select a { display: grid; width: 42px; height: 42px; place-items: center; border-radius: 50%; color: var(--astrbot-text); text-decoration: none; }
 .platform-editor__profile-select a:hover { background: var(--astrbot-hover); }
 .platform-editor__new-profile { margin-left: 30px; }
@@ -111,7 +102,7 @@
 .platform-routes-editor > header p { margin: 4px 0 0; }
 .platform-routes-editor > header button { display: inline-flex; min-height: 36px; align-items: center; gap: 5px; padding: 7px 12px; border: 1px solid var(--astrbot-border); border-radius: 8px; background: var(--astrbot-surface); color: var(--astrbot-primary); cursor: pointer; }
 .platform-route-row { display: grid; grid-template-columns: minmax(120px, 1.3fr) minmax(110px, .8fr) minmax(120px, 1fr) minmax(120px, 1fr) auto; align-items: center; gap: 8px; }
-.platform-route-row select,
+.platform-route-row .ui-select-menu > button,
 .platform-route-row input { width: 100%; min-height: 38px; padding: 7px 10px; border: 1px solid var(--astrbot-border); border-radius: 8px; background: var(--astrbot-surface); color: var(--astrbot-text); }
 .platform-route-row__actions { display: flex; gap: 3px; }
 .platform-route-row__actions button { display: grid; width: 34px; height: 34px; place-items: center; border: 0; border-radius: 50%; background: transparent; color: var(--astrbot-text); cursor: pointer; }

--- a/dashboard/src/styles/features/_sessions.scss
+++ b/dashboard/src/styles/features/_sessions.scss
@@ -135,7 +135,8 @@
 .session-rules-empty button { display: inline-flex; align-items: center; gap: 5px; margin-top: 8px; padding: 7px 12px; border: 0; border-radius: 7px; background: color-mix(in srgb, var(--astrbot-primary) 12%, var(--astrbot-surface)); color: var(--astrbot-primary); cursor: pointer; }
 .session-rules-pagination { display: flex; min-height: 54px; align-items: center; justify-content: flex-end; gap: 9px; padding: 8px 16px; color: color-mix(in srgb, var(--astrbot-text) 65%, transparent); font-size: 12px; }
 .session-rules-pagination label { display: flex; align-items: center; gap: 6px; margin-right: 10px; }
-.session-rules-pagination select { height: 32px; padding: 0 24px 0 8px; border: 1px solid var(--astrbot-border); border-radius: 7px; background: var(--astrbot-surface); color: inherit; }
+.session-rules-pagination .ui-select-menu { width: auto; min-width: 72px; }
+.session-rules-pagination .ui-select-menu > button { min-height: 32px; padding: 0 8px; border-radius: 7px; }
 .session-rules-pagination button { display: grid; width: 30px; height: 30px; place-items: center; padding: 0; border: 0; border-radius: 50%; background: transparent; color: inherit; cursor: pointer; }
 .session-rules-pagination button:hover:not(:disabled) { background: var(--astrbot-hover); color: var(--astrbot-primary); }
 .session-rules-pagination button:disabled { cursor: not-allowed; opacity: .35; }
@@ -144,7 +145,7 @@
 .session-rules-section-title h2 { margin: 0; font-size: 17px; }
 .session-rules-section-title--actions { justify-content: space-between; }
 .session-rules-section-title--actions > div { gap: 8px; }
-.session-group-add select { height: 30px; border: 0; outline: 0; background: transparent; color: inherit; cursor: pointer; }
+.session-group-add .ui-select-menu > button { min-height: 30px; border: 0; background: transparent; color: inherit; }
 
 .session-batch-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 10px; padding: 8px 16px 4px; }
 .session-batch-grid label,
@@ -152,10 +153,10 @@
 .session-rule-editor label:not(.session-check),
 .session-quick-name label,
 .session-group-editor > label { display: grid; gap: 5px; color: color-mix(in srgb, var(--astrbot-text) 68%, transparent); font-size: 12px; }
-.session-batch-grid select,
-.session-add-rule select,
+.session-batch-grid .ui-select-menu > button,
+.session-add-rule .ui-select-menu > button,
 .session-rule-editor input:not([type='checkbox']),
-.session-rule-editor select,
+.session-rule-editor .ui-select-menu > button,
 .session-quick-name input,
 .session-group-editor > label input,
 .session-transfer-list__search {
@@ -343,7 +344,7 @@
   .conversation-page-react { padding: 10px; }
   .conversation-filters { flex-wrap: wrap; }
   .conversation-filters > input,
-  .conversation-filters > select { min-width: 120px; flex: 1; }
+  .conversation-filters > .ui-select-menu { min-width: 120px; flex: 1; }
   .conversation-filters > label { min-width: 100%; }
   .conversation-panel__actions { width: 100%; margin-left: 0; }
   .conversation-pagination { flex-wrap: wrap; justify-content: center; }

--- a/dashboard/src/styles/features/_settings.scss
+++ b/dashboard/src/styles/features/_settings.scss
@@ -181,7 +181,7 @@
 .settings-two-factor .settings-alert { margin: 0; }
 .api-key-create { padding: 16px 20px; }
 .api-key-create input,
-.api-key-create select { min-height: 40px; padding: 8px 10px; border: 1px solid var(--astrbot-border); border-radius: 8px; background: var(--astrbot-surface); color: inherit; }
+.api-key-create .ui-select-menu > button { min-height: 40px; padding: 8px 10px; border: 1px solid var(--astrbot-border); border-radius: 8px; background: var(--astrbot-surface); color: inherit; }
 .api-key-create input { flex: 1; min-width: 220px; }
 .api-key-scopes { display: flex; flex-wrap: wrap; align-items: center; gap: 7px; padding: 0 20px 16px; }
 .api-key-scopes > span { margin-right: 4px; font-weight: 600; }
@@ -197,7 +197,7 @@
 .settings-list-card:has(> .api-key-create) > header p { font-size: 14px; }
 .settings-list-card:has(> .api-key-create) > .api-key-create { display: grid; grid-template-columns: minmax(260px, 1fr) 112px 190px; padding: 24px 0 14px; }
 .settings-list-card:has(> .api-key-create) > .api-key-create input,
-.settings-list-card:has(> .api-key-create) > .api-key-create select,
+.settings-list-card:has(> .api-key-create) > .api-key-create .ui-select-menu > button,
 .settings-list-card:has(> .api-key-create) > .api-key-create button { min-height: 48px; border-radius: 10px; }
 .settings-list-card:has(> .api-key-create) > .api-key-scopes { padding: 0 0 20px; }
 .settings-list-card:has(> .api-key-create) > .api-key-scopes label { padding: 6px 12px; font-size: 13px; }
@@ -210,7 +210,8 @@
 .t2i-editor { display: flex; min-height: 0; flex: 1; flex-direction: column; margin: 0 -24px -24px; }
 .t2i-editor__toolbar { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; padding: 12px 18px; border-bottom: 1px solid var(--astrbot-border); background: color-mix(in srgb, var(--astrbot-text) 4%, var(--astrbot-surface)); }
 .t2i-editor__toolbar input,
-.t2i-editor__toolbar select { min-width: 260px; min-height: 38px; flex: 1; padding: 7px 10px; border: 1px solid var(--astrbot-border); border-radius: 8px; background: var(--astrbot-surface); color: inherit; }
+.t2i-editor__toolbar .ui-select-menu { min-width: 260px; flex: 1; }
+.t2i-editor__toolbar .ui-select-menu > button { min-height: 38px; padding: 7px 10px; border: 1px solid var(--astrbot-border); border-radius: 8px; background: var(--astrbot-surface); color: inherit; }
 .t2i-editor__toolbar button { display: inline-flex; min-height: 34px; align-items: center; gap: 5px; padding: 6px 9px; border: 0; border-radius: 7px; background: transparent; color: inherit; cursor: pointer; }
 .t2i-editor__toolbar button:hover { background: var(--astrbot-hover); }
 .t2i-editor__workspace { display: grid; min-height: 0; flex: 1; grid-template-columns: repeat(2, minmax(0, 1fr)); }

--- a/dashboard/src/styles/features/_welcome.scss
+++ b/dashboard/src/styles/features/_welcome.scss
@@ -137,9 +137,8 @@
   cursor: pointer;
 }
 
-.onboarding-list select {
+.onboarding-list .ui-select-menu {
   width: min(240px, 100%);
-  min-height: 44px;
 }
 
 .headless-dialog__content:has(.welcome-onboarding-dialog) {

--- a/dashboard/src/styles/features/_welcome.scss
+++ b/dashboard/src/styles/features/_welcome.scss
@@ -142,3 +142,37 @@
   min-height: 44px;
 }
 
+.headless-dialog__content:has(.welcome-onboarding-dialog) {
+  display: flex;
+  width: min(1440px, calc(100vw - 48px));
+  height: min(900px, calc(100vh - 48px));
+  max-height: calc(100vh - 48px);
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.welcome-onboarding-dialog {
+  min-width: 0;
+  min-height: 0;
+  flex: 1;
+  overflow: auto;
+}
+
+.welcome-onboarding-dialog > .provider-page,
+.welcome-onboarding-dialog > .platform-page-react {
+  min-height: 100%;
+}
+
+.welcome-onboarding-dialog .route-page__heading {
+  display: none;
+}
+
+@media (max-width: 700px) {
+  .headless-dialog__content:has(.welcome-onboarding-dialog) {
+    width: calc(100vw - 16px);
+    height: calc(100vh - 16px);
+    max-height: calc(100vh - 16px);
+    padding: 16px;
+  }
+}
+

--- a/src-tauri/src/app_runtime.rs
+++ b/src-tauri/src/app_runtime.rs
@@ -81,24 +81,10 @@ fn configure_plugins(builder: Builder<tauri::Wry>) -> Builder<tauri::Wry> {
 fn configure_window_events(builder: Builder<tauri::Wry>) -> Builder<tauri::Wry> {
     builder.on_window_event(|window, event| {
         let is_quitting = window.app_handle().state::<BackendState>().is_quitting();
-        let desktop_settings = window.app_handle().state::<DesktopSettingsCache>().get();
         let action = match &event {
-            WindowEvent::CloseRequested { .. } => app_runtime_events::main_window_action(
-                window.label(),
-                is_quitting,
-                false,
-                true,
-                false,
-                desktop_settings.close_to_tray,
-            ),
-            WindowEvent::Focused(false) => app_runtime_events::main_window_action(
-                window.label(),
-                is_quitting,
-                matches!(window.is_minimized(), Ok(true)),
-                false,
-                true,
-                desktop_settings.close_to_tray,
-            ),
+            WindowEvent::CloseRequested { .. } => {
+                app_runtime_events::main_window_action(window.label(), is_quitting, true)
+            }
             _ => app_runtime_events::MainWindowAction::None,
         };
 
@@ -107,19 +93,6 @@ fn configure_window_events(builder: Builder<tauri::Wry>) -> Builder<tauri::Wry> 
                 if let WindowEvent::CloseRequested { api, .. } = event {
                     api.prevent_close();
                 }
-                window::actions::hide_main_window(
-                    window.app_handle(),
-                    DEFAULT_SHELL_LOCALE,
-                    append_desktop_log,
-                );
-            }
-            app_runtime_events::MainWindowAction::PreventCloseAndExit => {
-                if let WindowEvent::CloseRequested { api, .. } = event {
-                    api.prevent_close();
-                }
-                lifecycle::events::handle_tray_quit(window.app_handle());
-            }
-            app_runtime_events::MainWindowAction::HideIfMinimized => {
                 window::actions::hide_main_window(
                     window.app_handle(),
                     DEFAULT_SHELL_LOCALE,

--- a/src-tauri/src/app_runtime_events.rs
+++ b/src-tauri/src/app_runtime_events.rs
@@ -4,8 +4,6 @@ use tauri::{webview::PageLoadEvent, RunEvent};
 pub(crate) enum MainWindowAction {
     None,
     PreventCloseAndHide,
-    PreventCloseAndExit,
-    HideIfMinimized,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -27,10 +25,7 @@ pub(crate) enum RunEventAction {
 pub(crate) fn main_window_action(
     window_label: &str,
     is_quitting: bool,
-    minimized_on_focus_lost: bool,
     is_close_requested: bool,
-    is_focus_lost: bool,
-    close_to_tray: bool,
 ) -> MainWindowAction {
     if window_label != "main" {
         return MainWindowAction::None;
@@ -39,15 +34,9 @@ pub(crate) fn main_window_action(
     if is_close_requested {
         return if is_quitting {
             MainWindowAction::None
-        } else if close_to_tray {
-            MainWindowAction::PreventCloseAndHide
         } else {
-            MainWindowAction::PreventCloseAndExit
+            MainWindowAction::PreventCloseAndHide
         };
-    }
-
-    if is_focus_lost && minimized_on_focus_lost && !is_quitting {
-        return MainWindowAction::HideIfMinimized;
     }
 
     MainWindowAction::None
@@ -105,7 +94,7 @@ mod tests {
     #[test]
     fn main_window_action_ignores_non_main_windows() {
         assert_eq!(
-            main_window_action("settings", false, false, true, false, true),
+            main_window_action("settings", false, true),
             MainWindowAction::None
         );
     }
@@ -113,24 +102,24 @@ mod tests {
     #[test]
     fn main_window_action_hides_on_close_when_not_quitting() {
         assert_eq!(
-            main_window_action("main", false, false, true, false, true),
+            main_window_action("main", false, true),
             MainWindowAction::PreventCloseAndHide
         );
     }
 
     #[test]
-    fn main_window_action_allows_close_when_close_to_tray_is_disabled() {
+    fn main_window_action_allows_close_while_quitting_from_tray() {
         assert_eq!(
-            main_window_action("main", false, false, true, false, false),
-            MainWindowAction::PreventCloseAndExit
+            main_window_action("main", true, true),
+            MainWindowAction::None
         );
     }
 
     #[test]
-    fn main_window_action_hides_on_minimized_focus_loss() {
+    fn main_window_action_leaves_minimize_to_the_window_manager() {
         assert_eq!(
-            main_window_action("main", false, true, false, true, true),
-            MainWindowAction::HideIfMinimized
+            main_window_action("main", false, false),
+            MainWindowAction::None
         );
     }
 

--- a/src-tauri/src/app_types.rs
+++ b/src-tauri/src/app_types.rs
@@ -19,7 +19,6 @@ pub(crate) struct TrayMenuState {
     pub(crate) restart_backend_item: MenuItem<tauri::Wry>,
     pub(crate) launch_at_login_item: CheckMenuItem<tauri::Wry>,
     pub(crate) silent_launch_item: CheckMenuItem<tauri::Wry>,
-    pub(crate) close_to_tray_item: CheckMenuItem<tauri::Wry>,
     pub(crate) quit_item: MenuItem<tauri::Wry>,
 }
 

--- a/src-tauri/src/desktop_settings.rs
+++ b/src-tauri/src/desktop_settings.rs
@@ -31,7 +31,6 @@ impl DesktopSettingsCache {
 pub(crate) enum DesktopSettingKey {
     LaunchAtLogin,
     SilentLaunch,
-    CloseToTray,
 }
 
 fn default_launch_at_login() -> bool {
@@ -42,18 +41,12 @@ fn default_silent_launch() -> bool {
     false
 }
 
-fn default_close_to_tray() -> bool {
-    true
-}
-
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub(crate) struct DesktopSettings {
     #[serde(rename = "launchAtLogin", default = "default_launch_at_login")]
     pub(crate) launch_at_login: bool,
     #[serde(rename = "silentLaunch", default = "default_silent_launch")]
     pub(crate) silent_launch: bool,
-    #[serde(rename = "closeToTray", default = "default_close_to_tray")]
-    pub(crate) close_to_tray: bool,
     #[serde(flatten)]
     other: Map<String, Value>,
 }
@@ -63,7 +56,6 @@ impl Default for DesktopSettings {
         Self {
             launch_at_login: default_launch_at_login(),
             silent_launch: default_silent_launch(),
-            close_to_tray: default_close_to_tray(),
             other: Map::new(),
         }
     }
@@ -74,7 +66,6 @@ impl DesktopSettings {
         match key {
             DesktopSettingKey::LaunchAtLogin => self.launch_at_login = value,
             DesktopSettingKey::SilentLaunch => self.silent_launch = value,
-            DesktopSettingKey::CloseToTray => self.close_to_tray = value,
         }
     }
 }
@@ -246,22 +237,17 @@ mod tests {
         }
     }
 
-    fn settings(
-        launch_at_login: bool,
-        silent_launch: bool,
-        close_to_tray: bool,
-    ) -> DesktopSettings {
+    fn settings(launch_at_login: bool, silent_launch: bool) -> DesktopSettings {
         DesktopSettings {
             launch_at_login,
             silent_launch,
-            close_to_tray,
             ..DesktopSettings::default()
         }
     }
 
     #[test]
-    fn desktop_settings_default_preserves_existing_close_to_tray_behavior() {
-        assert_eq!(DesktopSettings::default(), settings(false, false, true));
+    fn desktop_settings_defaults_to_manual_launch() {
+        assert_eq!(DesktopSettings::default(), settings(false, false));
     }
 
     #[test]
@@ -276,10 +262,9 @@ mod tests {
         )
         .expect("write state");
 
-        assert_eq!(
-            read_desktop_settings(Some(&root)),
-            settings(true, true, false)
-        );
+        let settings = read_desktop_settings(Some(&root));
+        assert!(settings.launch_at_login);
+        assert!(settings.silent_launch);
     }
 
     #[test]
@@ -290,16 +275,13 @@ mod tests {
         fs::create_dir_all(path.parent().expect("state parent")).expect("create state parent");
         fs::write(&path, r#"{"silentLaunch":true}"#).expect("write state");
 
-        assert_eq!(
-            read_desktop_settings(Some(&root)),
-            settings(false, true, true)
-        );
+        assert_eq!(read_desktop_settings(Some(&root)), settings(false, true));
     }
 
     #[test]
     fn desktop_settings_cache_returns_updated_value_without_reloading_file() {
         let cache = DesktopSettingsCache::new(DesktopSettings::default());
-        let updated = settings(true, true, false);
+        let updated = settings(true, true);
 
         cache.set(updated.clone());
 
@@ -351,15 +333,15 @@ mod tests {
             DesktopSettings::default()
         );
 
-        let updated = write_desktop_setting(Some(&root), DesktopSettingKey::CloseToTray, false)
+        let updated = write_desktop_setting(Some(&root), DesktopSettingKey::SilentLaunch, true)
             .expect("write setting");
 
-        assert!(!updated.close_to_tray);
+        assert!(updated.silent_launch);
         let raw = fs::read_to_string(&path).expect("read state");
         let parsed: serde_json::Value = serde_json::from_str(&raw).expect("parse reset state");
         assert_eq!(
-            parsed.get("closeToTray").and_then(|value| value.as_bool()),
-            Some(false)
+            parsed.get("silentLaunch").and_then(|value| value.as_bool()),
+            Some(true)
         );
     }
 
@@ -388,9 +370,6 @@ mod tests {
             parsed.get("silentLaunch").and_then(|value| value.as_bool()),
             Some(false)
         );
-        assert_eq!(
-            parsed.get("closeToTray").and_then(|value| value.as_bool()),
-            Some(true)
-        );
+        assert!(parsed.get("closeToTray").is_none());
     }
 }

--- a/src-tauri/src/shell_locale.rs
+++ b/src-tauri/src/shell_locale.rs
@@ -19,7 +19,6 @@ pub struct ShellTexts {
     pub tray_restart_backend: &'static str,
     pub tray_launch_at_login: &'static str,
     pub tray_silent_launch: &'static str,
-    pub tray_close_to_tray: &'static str,
     pub tray_quit: &'static str,
 }
 
@@ -32,7 +31,6 @@ pub fn shell_texts_for_locale(locale: &str) -> ShellTexts {
             tray_restart_backend: "Restart Backend",
             tray_launch_at_login: "Launch at Login",
             tray_silent_launch: "Silent Launch",
-            tray_close_to_tray: "Close to Tray",
             tray_quit: "Quit",
         };
     }
@@ -44,7 +42,6 @@ pub fn shell_texts_for_locale(locale: &str) -> ShellTexts {
         tray_restart_backend: "重启后端",
         tray_launch_at_login: "开机自启",
         tray_silent_launch: "静默启动",
-        tray_close_to_tray: "关闭到托盘",
         tray_quit: "退出",
     }
 }
@@ -203,7 +200,6 @@ mod tests {
         assert_eq!(texts.tray_hide, "Hide AstrBot");
         assert_eq!(texts.tray_launch_at_login, "Launch at Login");
         assert_eq!(texts.tray_silent_launch, "Silent Launch");
-        assert_eq!(texts.tray_close_to_tray, "Close to Tray");
         assert_eq!(texts.tray_quit, "Quit");
     }
 
@@ -213,7 +209,6 @@ mod tests {
         assert_eq!(texts.tray_hide, "隐藏 AstrBot");
         assert_eq!(texts.tray_launch_at_login, "开机自启");
         assert_eq!(texts.tray_silent_launch, "静默启动");
-        assert_eq!(texts.tray_close_to_tray, "关闭到托盘");
         assert_eq!(texts.tray_quit, "退出");
     }
 

--- a/src-tauri/src/tray/actions.rs
+++ b/src-tauri/src/tray/actions.rs
@@ -3,7 +3,6 @@ pub const TRAY_MENU_RELOAD_WINDOW: &str = "tray_reload_window";
 pub const TRAY_MENU_RESTART_BACKEND: &str = "tray_restart_backend";
 pub const TRAY_MENU_LAUNCH_AT_LOGIN: &str = "tray_launch_at_login";
 pub const TRAY_MENU_SILENT_LAUNCH: &str = "tray_silent_launch";
-pub const TRAY_MENU_CLOSE_TO_TRAY: &str = "tray_close_to_tray";
 pub const TRAY_MENU_QUIT: &str = "tray_quit";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -13,7 +12,6 @@ pub enum TrayMenuAction {
     RestartBackend,
     LaunchAtLogin,
     SilentLaunch,
-    CloseToTray,
     Quit,
 }
 
@@ -24,7 +22,6 @@ pub fn action_from_menu_id(menu_id: &str) -> Option<TrayMenuAction> {
         TRAY_MENU_RESTART_BACKEND => Some(TrayMenuAction::RestartBackend),
         TRAY_MENU_LAUNCH_AT_LOGIN => Some(TrayMenuAction::LaunchAtLogin),
         TRAY_MENU_SILENT_LAUNCH => Some(TrayMenuAction::SilentLaunch),
-        TRAY_MENU_CLOSE_TO_TRAY => Some(TrayMenuAction::CloseToTray),
         TRAY_MENU_QUIT => Some(TrayMenuAction::Quit),
         _ => None,
     }
@@ -59,10 +56,6 @@ mod tests {
         assert_eq!(
             action_from_menu_id(TRAY_MENU_SILENT_LAUNCH),
             Some(TrayMenuAction::SilentLaunch)
-        );
-        assert_eq!(
-            action_from_menu_id(TRAY_MENU_CLOSE_TO_TRAY),
-            Some(TrayMenuAction::CloseToTray)
         );
     }
 

--- a/src-tauri/src/tray/labels.rs
+++ b/src-tauri/src/tray/labels.rs
@@ -105,12 +105,6 @@ pub fn update_tray_menu_labels_with_visibility<F>(
         actions::TRAY_MENU_SILENT_LAUNCH,
         &log,
     );
-    set_check_menu_text_safe(
-        &tray_state.close_to_tray_item,
-        shell_texts.tray_close_to_tray,
-        actions::TRAY_MENU_CLOSE_TO_TRAY,
-        &log,
-    );
     set_menu_text_safe(
         &tray_state.quit_item,
         shell_texts.tray_quit,

--- a/src-tauri/src/tray/menu_handler.rs
+++ b/src-tauri/src/tray/menu_handler.rs
@@ -125,21 +125,6 @@ fn handle_silent_launch_toggle(app_handle: &AppHandle) {
     );
 }
 
-fn handle_close_to_tray_toggle(app_handle: &AppHandle) {
-    let Some(tray_state) = app_handle.try_state::<TrayMenuState>() else {
-        return;
-    };
-    let current_settings = app_handle.state::<DesktopSettingsCache>().get();
-    persist_bool_setting_and_update_tray(
-        app_handle,
-        desktop_settings::DesktopSettingKey::CloseToTray,
-        !current_settings.close_to_tray,
-        current_settings.close_to_tray,
-        &tray_state.close_to_tray_item,
-        actions::TRAY_MENU_CLOSE_TO_TRAY,
-    );
-}
-
 pub fn handle_tray_menu_event(app_handle: &AppHandle, menu_id: &str) {
     match actions::action_from_menu_id(menu_id) {
         Some(actions::TrayMenuAction::ToggleWindow) => window::actions::toggle_main_window(
@@ -193,7 +178,6 @@ pub fn handle_tray_menu_event(app_handle: &AppHandle, menu_id: &str) {
         }
         Some(actions::TrayMenuAction::LaunchAtLogin) => handle_launch_at_login_toggle(app_handle),
         Some(actions::TrayMenuAction::SilentLaunch) => handle_silent_launch_toggle(app_handle),
-        Some(actions::TrayMenuAction::CloseToTray) => handle_close_to_tray_toggle(app_handle),
         Some(actions::TrayMenuAction::Quit) => {
             lifecycle::events::handle_tray_quit(app_handle);
         }

--- a/src-tauri/src/tray/setup.rs
+++ b/src-tauri/src/tray/setup.rs
@@ -74,15 +74,6 @@ pub fn setup_tray(app_handle: &AppHandle) -> Result<(), String> {
         None::<&str>,
     )
     .map_err(|error| format!("Failed to create tray silent launch menu item: {error}"))?;
-    let close_to_tray_item = CheckMenuItem::with_id(
-        app_handle,
-        actions::TRAY_MENU_CLOSE_TO_TRAY,
-        shell_texts.tray_close_to_tray,
-        true,
-        desktop_settings.close_to_tray,
-        None::<&str>,
-    )
-    .map_err(|error| format!("Failed to create tray close to tray menu item: {error}"))?;
     let quit_item = MenuItem::with_id(
         app_handle,
         actions::TRAY_MENU_QUIT,
@@ -105,7 +96,6 @@ pub fn setup_tray(app_handle: &AppHandle) -> Result<(), String> {
             &settings_separator,
             &launch_at_login_item,
             &silent_launch_item,
-            &close_to_tray_item,
             &separator,
             &quit_item,
         ],
@@ -118,7 +108,6 @@ pub fn setup_tray(app_handle: &AppHandle) -> Result<(), String> {
         restart_backend_item: restart_backend_item.clone(),
         launch_at_login_item: launch_at_login_item.clone(),
         silent_launch_item: silent_launch_item.clone(),
-        close_to_tray_item: close_to_tray_item.clone(),
         quit_item: quit_item.clone(),
     }) {
         append_desktop_log("tray menu state already exists, skipping manage");


### PR DESCRIPTION
<!-- Please explain the motivation of this PR and what problem it solves. -->
<!-- 请说明这个 PR 的动机，以及它解决了什么问题。 -->
本 PR 集中修复 Dashboard 从 Vue 迁移到 React 后出现的一系列回归问题，包括聊天流生命周期、提供商校验、公共控件样式、页面布局、加载反馈及桌面窗口交互。
修复 https://github.com/AstrBotDevs/AstrBot/issues/9433
修复 #154 
### Summary / 改动概述

<!-- Please summarize the core changes and affected files. -->
<!-- 请简要说明核心改动和涉及的文件。 -->
#### Chat streaming and session state / 聊天流与会话状态

- Preserve active chat streams when navigating between Dashboard routes.
- Move active stream controllers and message caches into a shared registry so unmounting the chat page no longer interrupts the WebSocket response.
- Restore the latest cached streaming content when returning to a running conversation.
- Keep conversation-list loading indicators synchronized with the actual stream state.
- Validate persisted provider and model selections before sending the first message in a new conversation.
- Automatically fall back to the first available provider when a previously selected provider no longer exists.
- Prevent invalid provider IDs from being included in send, regenerate, retry, and checkpoint requests.

#### Shared dropdown controls / 统一下拉控件

- Introduce shared `SelectControl` and `SelectMenu` components.
- Replace inconsistent native selects across configuration, chat, monitoring, knowledge base, extension, pagination, and welcome pages.
- Apply consistent borders, focus states, selected states, icons, spacing, and theme-aware colors.
- Render expanded menus through a portal to prevent clipping by dialogs, cards, and scroll containers.
- Automatically position menus above or below their trigger according to available viewport space.
- Refine the page-size selector on the behavior management page.

#### Layout and visual feedback / 布局与视觉反馈

- Enlarge the welcome-page model and platform onboarding dialogs with responsive viewport sizing.
- Refine chat thinking and loading indicators to match the legacy Dashboard behavior.
- Improve running indicators in both the active message area and conversation list.
- Introduce shared portaled floating-action components.
- Reuse the same floating-action implementation across:
  - Knowledge base
  - Installed AstrBot plugins
  - Plugin marketplace
  - MCP
  - Skills
- Prevent floating buttons from shifting during entrance animations or being positioned relative to scrolling content.

#### Desktop window behavior / 桌面窗口行为

- Keep the minimize button’s native behavior, minimizing the application to the taskbar.
- Make the close button consistently hide the main window to the system tray.
- Preserve explicit application exit through the tray menu.
- Remove the obsolete configurable `closeToTray` behavior and related runtime branches.

### Verification / 验证方式

<!-- Paste test logs, screenshots, or CI links that prove this change works. -->
<!-- 请粘贴测试日志、截图或 CI 链接，证明改动有效。 -->
Automated coverage was added or updated for:

- Preserving active chat streams across route navigation.
- Restoring cached streaming messages after returning to a conversation.
- Falling back from stale persisted provider selections.
- Chat loading and conversation-list indicators.
- Shared select rendering and interaction behavior.
- Portaled dropdown positioning and clipping prevention.
- Behavior-page pagination controls.
- Shared floating-action portal rendering.
- Knowledge-base and extension-page interactions.
- Desktop close, minimize, and tray-exit event handling.

Local Dashboard verification included:

- Targeted Vitest suites.
- TypeScript project build with `npx tsc -b`.
- ESLint checks.
- Stylelint checks.
- Git diff whitespace checks.

Manual verification included:

1. Start a streaming response and navigate to another Dashboard route.
2. Return to the conversation and confirm the stream continued without WebSocket interruption.
3. Start a new conversation with a stale persisted provider and confirm a valid provider is selected.
4. Open dropdowns inside dialogs, cards, pagination areas, and scroll containers.
5. Confirm dropdowns are not clipped and remain visually consistent.
6. Open the welcome-page model and platform configuration dialogs.
7. Check floating buttons on the knowledge base, plugin, marketplace, MCP, and Skills pages.
8. Minimize the desktop application and confirm it remains on the taskbar.
9. Close the main window and confirm the application remains available from the system tray.
---

### Checklist / 检查清单

- [x] This change is **not** a breaking change. / 此改动**不是**破坏性变更。
- [x] I have verified the change locally (and provided logs/screenshots above). / 我已在本地验证并在上方提供日志/截图。
- [x] If workflows are changed, I attached at least one related Actions run link. / 如果修改了工作流，我已附上至少一个相关 Actions 运行链接。
- [x] If dependencies are updated, lockfiles are updated accordingly (`src-tauri/Cargo.lock`, lockfiles under changed package dirs). / 如果引入或升级依赖，已同步更新相关 lock 文件（如 `src-tauri/Cargo.lock`、对应包目录中的 lock 文件）。
- [x] This PR does not include malicious code. / 此 PR 不包含恶意代码。

## Summary by Sourcery

Address regressions from the Dashboard React migration by stabilizing chat streaming/session state, unifying dropdown and floating-action UI, refining loading/transition visuals, and simplifying desktop window/tray behavior.

New Features:
- Introduce shared SelectMenu and SelectControl components for consistent dropdown behavior and portal-based positioning across Dashboard pages.
- Add shared FloatingActions/FloatingActionButton components to provide reusable, portaled floating action stacks for resource and extension pages.
- Add a centralized chatStreamRegistry to persist active chat streams and message caches across route navigation.

Bug Fixes:
- Ensure persisted provider and model selections are validated and replaced when the previous provider has been removed before starting a new chat session.
- Keep active chat streams alive and message content restored when navigating between Dashboard routes instead of aborting streams on unmount.
- Align chat loading indicators and session list progress spinners with lightweight, text-based feedback that matches legacy behavior.

Enhancements:
- Apply theme-aware baseline styles to native form controls and custom select menus for consistent appearance and accessibility.
- Refine pagination, filters, and configuration editors to use the shared select primitives, simplifying markup and improving layout responsiveness.
- Adjust onboarding and configuration dialogs’ layout and motion transitions to better fit the viewport and avoid lingering transform states.

Tests:
- Expand unit and integration coverage for chat streaming registry behavior, provider fallback selection, shared select controls, floating actions, and motion transition styles.
- Update existing tests to interact with the new select menu components and verify batch operations, object editors, and configuration flows remain functional.

Chores:
- Remove the obsolete closeToTray desktop setting, its tray menu wiring, and related runtime branches so closing the main window consistently hides to tray while quit remains explicit from the tray menu.